### PR TITLE
Add codeowners file for auto-assigning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Owner for everything in the repo
+*       @paypal/checkout-sdk


### PR DESCRIPTION
Add a codeowners file so @paypal/checkout-sdk gets added as a PR Reviewer by default.

https://github.blog/2017-07-06-introducing-code-owners/