### PR TITLE
Use babel plugin for both esm and cjs

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,9 @@ import pkg from './package.json';
 export default {
     input: 'src/main.js',
     plugins: [
+        getBabelOutputPlugin({
+            presets: ['@babel/preset-env']
+        }),
         replace({
             '__VERSION__': pkg.version
         })
@@ -12,12 +15,7 @@ export default {
     output: [
         {
             file: pkg.module,
-            format: 'esm',
-            plugins: [
-                getBabelOutputPlugin({
-                    presets: ['@babel/preset-env']
-                })
-            ]
+            format: 'esm'
         },
         {
             file: pkg.main,


### PR DESCRIPTION
This PR updates rollup to apply the babel plugin to all builds (both esm and cjs). Previously the cjs build was not being run through babel so new features like `??` were not transpiled. I ran into this issue when using paypal-js with [react-paypal-js](https://github.com/paypal/react-paypal-js/blob/main/src/ScriptContext.js#L2).