### PR TITLE
Disable package.json version bumps from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,6 @@
   "semanticCommits": true,
   "timezone": "America/Los_Angeles",
   "rebaseStalePrs": true,
-  "bumpVersion": "major",
   "labels": [
     ":christmas_tree: dependencies"
   ],


### PR DESCRIPTION
I noticed the renovate bot is currently set up to do major version bumps when updating dependencies (ex: https://github.com/paypal/paypal-js/pull/15/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2). We don't do automated releases yet so we don't need/want this. This PR removes this [bumpVersion](https://docs.renovatebot.com/configuration-options/) configuration with renovate. 