### PR TITLE
Add comment banner to bundles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,11 +6,13 @@ import filesize from 'rollup-plugin-filesize';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
 
+const banner = getBannerText();
 const outputConfigForBrowserBundle = {
     format: 'iife',
     name: 'paypalLoadScript',
     // update the default export to be the loadScript() function
-    footer: 'paypalLoadScript = paypalLoadScript.loadScript;'
+    footer: 'paypalLoadScript = paypalLoadScript.loadScript;',
+    banner
 };
 
 export default {
@@ -32,11 +34,13 @@ export default {
     output: [
         {
             file: pkg.module,
-            format: 'esm'
+            format: 'esm',
+            banner
         },
         {
             file: pkg.main,
-            format: 'cjs'
+            format: 'cjs',
+            banner
         },
         {
             file: 'dist/paypal.browser.js',
@@ -49,3 +53,25 @@ export default {
         }
     ]
 };
+
+function getBannerText() {
+    const banner = `
+/*!
+ * paypal-js v${pkg.version} (${new Date().toISOString()})
+ * Copyright 2020-present, PayPal, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */`.trim();
+
+    return banner;
+}


### PR DESCRIPTION
This PR adds a comment banner to the top of the bundles for displaying the version number, timestamp, and license. All the PayPal open source repos use Apache 2.0 so I went with that.

Here's what the generated comment looks like with an example `dist/paypal.browser.min.js` file:
```js
/*!
 * paypal-js v0.1.0 (2020-08-11T19:14:49.697Z)
 * Copyright 2020-present, PayPal, Inc. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 * http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
var paypalLoadScript=function(t){"use strict"; and so on...
```
[Comment block source on apache.org](https://www.apache.org/licenses/LICENSE-2.0#apply)

## Additional Notes

I reviewed how other companies are doing these comment banners:
- [Facebook JS SDK](https://connect.facebook.net/en_US/sdk.js) - MIT license banner
- [Google Analytics](https://www.google-analytics.com/analytics.js) - short two line comment mentioning apache 2.0
- [jQuery](https://code.jquery.com/jquery-3.5.1.min.js) - one line comment linking to license hosted on jquery.com

I also reviewed the approaches taken with the PayPal JS SDK and Checkout.js both currently include a single line comment mentioning the file name of the license:
```js
/*! For license information please see output.js.LICENSE.txt */
``` 
I didn't use this approach because it's fragile and is [broken for checkout.js](https://www.paypalobjects.com/api/checkout.js.LICENSE.txt). I'm also not able to see the output.js.LICENSE.txt file anywhere for the JS SDK.

In the end the Apache 2.0 comment block seems like the easiest solution. 