### PR TITLE
Add cdn config file

### DIFF
--- a/.nodeops
+++ b/.nodeops
@@ -1,0 +1,8 @@
+{
+  "PROJECT_TYPE": "front-tier",
+  "web": {
+    "projectName": "@paypal/paypal-js",
+    "staticDirectory": "dist",
+    "staticNamespace": "paypal-js"
+  }
+}


### PR DESCRIPTION
This PR configures paypal-js to use cdnx. It uses the new "paypal-js" namespace so the prod url will eventually be: 
https://www.paypalobjects.com/paypal-js/paypal.browser.min.js.

Please let us know if you'd like to see a different namespace used. 