### PR TITLE
Add the ability to configure the async attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ loadScript({ 'client-id': 'YOUR_CLIENT_ID', 'currency': 'EUR' });
 Which will render the following `<script>` tag to the DOM:
 
 ```html
-<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&currency=EUR" defer></script>
+<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&currency=EUR" async defer></script>
 ```
 
 View the [full list of supported query parameters](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#query-parameters).
@@ -57,24 +57,24 @@ loadScript({ 'client-id': 'YOUR_CLIENT_ID', 'data-client-token': 'abc123xyz==' }
 Which will render the following `<script>` tag:
 
 ```html
-<script data-client-token="abc123xyz==" src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID" defer></script>
+<script data-client-token="abc123xyz==" src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID" async defer></script>
 ```
 
 View the [full list of supported script parameters](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#script-parameters).
 
-#### Defer
+#### Async and Defer
 
-The `defer` attribute can also be set. By default, the `<script>` tag loads with [defer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#Attributes) to ensure your web page renders as fast as possible.
+The `async` and `defer` attributes can also be set. By default, the `<script>` tag loads with [async and defer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#Attributes) to ensure your web page renders as fast as possible.
 
-The following example opts out of the default `<script defer>` behavior by setting `defer` to false:
+The following example opts out of the default `<script async defer>` behavior by setting `async` and `defer` to false:
 
 ```js
-loadScript({ 'client-id': 'YOUR_CLIENT_ID', 'defer': false });
+loadScript({ 'client-id': 'YOUR_CLIENT_ID', 'async': false, 'defer': false });
 ```
 
 Which will render the following `<script>` tag:
 
 ```html
-<!-- Note the absence of the `defer` attribute -->
+<!-- Note the absence of the `async` and `defer` attributes -->
 <script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID"></script>
 ```

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,6 +18,7 @@ export function insertScriptElement({ url, dataAttributes = {}, scriptAttributes
     document.head.insertBefore(newScript, document.head.firstElementChild);
 
     newScript.src = url;
+    newScript.async = scriptAttributes.async ?? true;
     newScript.defer = scriptAttributes.defer ?? true;
 }
 
@@ -31,7 +32,7 @@ export function processOptions(options = {}) {
     forEachObjectKey(options, key => {
         if (key.substring(0, 5) === 'data-') {
             processedOptions.dataAttributes[key] = options[key];
-        } else if (key === 'defer') {
+        } else if (key === 'defer' || key === 'async') {
             processedOptions.scriptAttributes[key] = options[key];
         } else {
             processedOptions.queryParams[key] = options[key];

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -100,6 +100,7 @@ describe('insertScriptElement()', () => {
 
         const scriptFromDOM = document.querySelector('head script');
         expect(scriptFromDOM.src).toBe(url);
+        expect(scriptFromDOM.async).toBe(true);
         expect(scriptFromDOM.defer).toBe(true);
         expect(scriptFromDOM.getAttribute('data-order-id')).toBe('12345');
     });
@@ -120,15 +121,16 @@ describe('insertScriptElement()', () => {
         expect(secondScript.src).toBe(existingScript.src);
     });
 
-    test('sets the defer property to false', () => {
+    test('sets the async and defer attributes to false', () => {
         const url = 'https://www.paypal.com/sdk/js';
         insertScriptElement({
             url,
-            scriptAttributes: { defer: false }
+            scriptAttributes: { async: false, defer: false }
         });
 
         const scriptFromDOM = document.querySelector('head script');
         expect(scriptFromDOM.src).toBe(url);
+        expect(scriptFromDOM.async).toBe(false);
         expect(scriptFromDOM.defer).toBe(false);
     });
 


### PR DESCRIPTION
This PR exposes the `async` script attribute and defaults it to true. The reason for this change is to:
- Make it super clear in the docs that we load the script asynchronously by default.
- Support the edge case where a user would want to set `async=false` to support sequential script loading.

## Details

Technically the script already loads async because that's the default behavior when adding a script to the DOM programmatically.

> Scripts that are dynamically created and added to the document are async by default, they don’t block rendering and execute as soon as they download, meaning they could come out in the wrong order. 

source: https://www.html5rocks.com/en/tutorials/speed/script-loading/

Setting async to false does change the behavior and can be used to load scripts in order programmatically:

> To request script-inserted external scripts be executed in the insertion order in browsers where the document.createElement("script").async evaluates to true (such as Firefox 4), set async="false" on the scripts you want to maintain order.

source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script

Other script loading libraries seem to set async to true by default:
- https://github.com/myspace-nu/resLoader#options (this library also offers a `blocking` option which appends the script with `document.write()`. We shouldn't do this but just wanted to mention the approach)
- https://github.com/ded/script.js/blob/05860e2fcd07259da61319a1a30b2a9ad5f19d3a/src/script.js#L79