### PR TITLE
Update script loading technique

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following example adds `client-id` and `currency` as query string parameters
 loadScript({ 'client-id': 'YOUR_CLIENT_ID', 'currency': 'EUR' });
 ```
 
-Which will dynamically insert the following `<script>` tag:
+Which will load the following `<script>` asynchronously:
 
 ```html
 <script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&currency=EUR"></script>
@@ -54,26 +54,10 @@ All options prefixed with `data-` are considered attributes. The following examp
 loadScript({ 'client-id': 'YOUR_CLIENT_ID', 'data-client-token': 'abc123xyz==' });
 ```
 
-Which will dynamically insert the following `<script>` tag:
+Which will load the following `<script>` asynchronously:
 
 ```html
 <script data-client-token="abc123xyz==" src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID"></script>
 ```
 
 View the [full list of supported script parameters](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#script-parameters).
-
-#### Async and Defer attributes
-
-You can optionally set the `async` and `defer` attributes. By default, these are not set since it already loads async thanks to the dynamic script insertion default behavior.
-
-The following example sets `async` and `defer` to true:
-
-```js
-loadScript({ 'client-id': 'YOUR_CLIENT_ID', 'defer': true, 'async': true });
-```
-
-Which will dynamically insert the following `<script>` tag:
-
-```html
-<script async defer src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID"></script>
-```

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ export function loadScript(options) {
         // resolve with null when running in Node
         if (typeof window === 'undefined') return resolve(null);
 
-        const { queryString, dataAttributes, scriptAttributes } = processOptions(options);
+        const { queryString, dataAttributes } = processOptions(options);
         const url = `${SDK_BASE_URL}?${queryString}`;
 
         // resolve with the existing global paypal object when a script with the same src already exists
@@ -24,7 +24,6 @@ export function loadScript(options) {
         insertScriptElement({
             url,
             dataAttributes,
-            scriptAttributes,
             callback: () => {
                 isLoading = false;
                 if (window.paypal) return resolve(window.paypal);

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@ export function findScript(url) {
     return document.querySelector(`script[src="${url}"]`);
 }
 
-export function insertScriptElement({ url, dataAttributes = {}, scriptAttributes = {}, callback }) {
+export function insertScriptElement({ url, dataAttributes = {}, callback }) {
     const newScript = document.createElement('script');
     newScript.onerror = loadError;
     newScript.onload = callback;
@@ -15,14 +15,6 @@ export function insertScriptElement({ url, dataAttributes = {}, scriptAttributes
         newScript.setAttribute(key, dataAttributes[key]);
     });
 
-    if (typeof scriptAttributes.async !== 'undefined') {
-        newScript.async = scriptAttributes.async;
-    }
-
-    if (typeof scriptAttributes.defer !== 'undefined') {
-        newScript.defer = scriptAttributes.defer;
-    }
-
     newScript.src = url;
     document.head.insertBefore(newScript, document.head.firstElementChild);
 }
@@ -30,26 +22,22 @@ export function insertScriptElement({ url, dataAttributes = {}, scriptAttributes
 export function processOptions(options = {}) {
     const processedOptions = {
         queryParams: {},
-        dataAttributes: {},
-        scriptAttributes: {}
+        dataAttributes: {}
     };
 
     forEachObjectKey(options, key => {
         if (key.substring(0, 5) === 'data-') {
             processedOptions.dataAttributes[key] = options[key];
-        } else if (key === 'defer') {
-            processedOptions.scriptAttributes[key] = options[key];
         } else {
             processedOptions.queryParams[key] = options[key];
         }
     });
 
-    const { queryParams, dataAttributes, scriptAttributes } = processedOptions;
+    const { queryParams, dataAttributes } = processedOptions;
 
     return {
         queryString: objectToQueryString(queryParams),
-        dataAttributes,
-        scriptAttributes
+        dataAttributes
     };
 }
 
@@ -66,7 +54,7 @@ export function objectToQueryString(params) {
 // uses es3 to avoid requiring polyfills for Array.prototype.forEach and Object.keys
 function forEachObjectKey(obj, callback) {
     for (let key in obj) {
-        if (obj.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
             callback(key);
         }
     }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -14,27 +14,24 @@ describe('objectToQueryString()', () => {
 });
 
 describe('processOptions()', () => {
-    test('returns dataAttributes, scriptAttributes, and queryString', () => {
+    test('returns dataAttributes and queryString', () => {
         const options = {
             'client-id': 'sb',
             currency: 'USD',
-            defer: true,
             'data-order-id': '12345',
             'some-random-key': 'some-random-value'
         };
 
-        const { queryString, dataAttributes, scriptAttributes } = processOptions(options);
+        const { queryString, dataAttributes } = processOptions(options);
 
         expect(queryString).toBe('client-id=sb&currency=USD&some-random-key=some-random-value');
         expect(dataAttributes).toEqual({ 'data-order-id': '12345' });
-        expect(scriptAttributes).toEqual({ defer: true });
     });
-    test('when no options are passed in it returns empty dataAttributes, scriptAttributes, and queryString', () => {
+    test('when no options are passed in it returns empty dataAttributes and queryString', () => {
         const { queryString, dataAttributes, scriptAttributes } = processOptions();
 
         expect(queryString).toBe('');
         expect(dataAttributes).toEqual({});
-        expect(scriptAttributes).toEqual({});
     });
 });
 
@@ -117,19 +114,6 @@ describe('insertScriptElement()', () => {
 
         expect(firstScript.src).toBe(newScriptSrc);
         expect(secondScript.src).toBe(existingScript.src);
-    });
-
-    test('sets the async and defer attributes', () => {
-        const url = 'https://www.paypal.com/sdk/js';
-        insertScriptElement({
-            url,
-            scriptAttributes: { defer: false, async: true }
-        });
-
-        const scriptFromDOM = document.querySelector('head script');
-        expect(scriptFromDOM.src).toBe(url);
-        expect(scriptFromDOM.defer).toBe(false);
-        expect(scriptFromDOM.async).toBe(true);
     });
 
     test("onload() event", () => {


### PR DESCRIPTION
~This PR makes both `async` and `defer` configurable. By default, it does not set these values but the caller can explicitly set them like so:~

**Update**

@mnicpt and I paired and decided to remove both the `async` and `defer` options all together to avoid confusion.

## Details

By default, dynamically inserted scripts are load async. Ex:

```js
const newScript = document.createElement('script');
newScript.src = url;
document.head.insertBefore(newScript, document.head.firstElementChild);
```

We learned, through various demos, that the `defer` behavior only seems to apply to inline scripts. It doesn't delay script execution time til DOMContentLoaded when dynamically inserting the scripts. Based on today's findings we are not going to set these values by default. 

Closes #24