### PR TITLE
Add github templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,30 @@
+---
+name: 🐞 Bug report
+about: Report a bug with the paypal-js sdk loader. Before you create a new issue, please search for similar issues.
+  It's possible somebody has encountered this bug already.
+title: "[Bug] Bug report"
+labels: 'bug'
+assignees: ''
+
+---
+
+### 🐞 Describe the Bug
+A clear and concise description of what the bug is.
+
+### 🔬 Minimal Reproduction
+Describe steps to reproduce. If possible, please, share a link with a minimal reproduction.
+
+### 😕 Actual Behavior
+A clear and concise description of what is happening. Please include console logs during the time of the issue, especially error messages.
+
+### 🤔 Expected Behavior
+A clear and concise description of what you expected to happen.
+
+### 🌍 Environment
+
+- Node.js/npm: -
+- OS: -
+- Browser: -
+
+### ➕ Additional Context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,20 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea to us!
+title: "[Feature] Feature request"
+labels: 'feature'
+assignees: ''
+
+---
+
+### 🚀 Feature Proposal
+
+A clear and concise description of what the feature is.
+
+### Motivation
+
+Please outline the motivation for the proposal.
+
+### Example
+
+Please provide an example for how this feature would be used.


### PR DESCRIPTION
This PR adds templates for Bugs and Feature Requests.

Once this is merged, these templates will appear when creating a GitHub issue for the project. For example, here's how the templates look with paypal-checkout-components: https://github.com/paypal/paypal-checkout-components/issues/new/choose