### PR TITLE
Document CDN Usage

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: 🐞 Bug report
-about: Report a bug with the paypal-js sdk loader. Before you create a new issue, please search for similar issues.
+about: Report a bug with paypal-js. Before you create a new issue, please search for similar issues.
   It's possible somebody has encountered this bug already.
 title: "[Bug] Bug report"
 labels: 'bug'

--- a/.nodeops
+++ b/.nodeops
@@ -1,8 +1,0 @@
-{
-  "PROJECT_TYPE": "front-tier",
-  "web": {
-    "projectName": "@paypal/paypal-js",
-    "staticDirectory": "dist",
-    "staticNamespace": "paypal-js"
-  }
-}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PayPal JS
 
-An async loader for the PayPal JS SDK.
+An async loader for the [PayPal JS SDK](https://developer.paypal.com/docs/checkout/).
 
 <a href="https://www.npmjs.com/package/@paypal/paypal-js"><img src="https://img.shields.io/npm/v/@paypal/paypal-js?style=flat-square" alt="npm version"></a>
 <a href="https://github.com/paypal/paypal-js/blob/main/LICENSE.txt"><img src="https://img.shields.io/npm/l/@paypal/paypal-js?style=flat-square" alt="github license"></a>
@@ -67,3 +67,27 @@ Which will load the following `<script>` asynchronously:
 ```
 
 View the [full list of supported script parameters](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#script-parameters).
+
+### Using a CDN
+
+The paypal-js script is also available on the [UNPKG CDN](https://unpkg.com/). The paypal.browser.js build assigns the `loadScript` function to the window object as `window.paypalLoadScript`. Here's an example:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <script src="https://unpkg.com/@paypal/paypal-js/dist/paypal.browser.min.js"></script>
+    </head>
+    <body>
+        <div id="paypal-buttons"></div>
+        <script>
+            window.paypalLoadScript({ 'client-id': 'sb' })
+                .then(paypal => {
+                    paypal.Buttons().render('#paypal-buttons');
+                });
+        </script>
+    </body>
+</html>
+```
+
+Note that the above CDN location points to the latest release of paypal-js. It is advised that when you deploy your site, you import the specific version you have developed and tested with (ex: https://unpkg.com/@paypal/paypal-js@1.0.0/dist/paypal.browser.min.js).


### PR DESCRIPTION
This PR replaces CDNX with [UNPKG](https://unpkg.com/) as our CDN solution.

### Why UNPKG instead of CDNX?

- UNPKG is a CDN for the public npm registry. With this design, we get CDN functionality for free since we already publish paypal-js to the public registry. We don't have to write any bash code to publish to the CDN like we would need to with cdnx.
- We get versioned urls!
- It seems stable and safe to recommend. Microsoft is using it as their recommended CDN for their new component library: https://www.fast.design/docs/components/getting-started#from-cdn


