### PR TITLE
Ensure that loading errors reset loading state

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,10 +24,14 @@ export function loadScript(options) {
         insertScriptElement({
             url,
             dataAttributes,
-            callback: () => {
+            onSuccess: () => {
                 isLoading = false;
                 if (window.paypal) return resolve(window.paypal);
                 return reject(new Error('The window.paypal global variable is not available.'));
+            },
+            onError: () => {
+                isLoading = false;
+                return reject(new Error(`The script "${url}" didn't load correctly.`));
             }
         });
     });

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -7,9 +7,9 @@ describe('loadScript()', () => {
 
         // eslint-disable-next-line no-import-assign
         utils.insertScriptElement = jest.fn()
-            .mockImplementation(({ callback }) => {
+            .mockImplementation(({ onSuccess }) => {
                 window.paypal = {};
-                process.nextTick(() => callback());
+                process.nextTick(() => onSuccess());
             });
 
         Object.defineProperty(window, 'paypal', {
@@ -66,9 +66,9 @@ describe('loadScript()', () => {
 
         // eslint-disable-next-line no-import-assign
         utils.insertScriptElement = jest.fn()
-            .mockImplementation(({ callback }) => {
+            .mockImplementation(({ onSuccess }) => {
                 // do not set window.paypal in the mock implementation
-                process.nextTick(() => callback());
+                process.nextTick(() => onSuccess());
             });
 
         expect(window.paypal).toBe(undefined);
@@ -77,6 +77,24 @@ describe('loadScript()', () => {
             .catch(err => {
                 expect(utils.insertScriptElement).toHaveBeenCalledTimes(1);
                 expect(err.message).toBe('The window.paypal global variable is not available.');
+            });
+    });
+
+    test('should throw an error when the script fails to load', () => {
+        expect.assertions(3);
+
+        // eslint-disable-next-line no-import-assign
+        utils.insertScriptElement = jest.fn()
+            .mockImplementation(({ onError }) => {
+                process.nextTick(() => onError());
+            });
+
+        expect(window.paypal).toBe(undefined);
+
+        return loadScript({ 'client-id': 'sb' })
+            .catch(err => {
+                expect(utils.insertScriptElement).toHaveBeenCalledTimes(1);
+                expect(err.message).toBe("The script \"https://www.paypal.com/sdk/js?client-id=sb\" didn't load correctly.");
             });
     });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,15 +1,11 @@
-function loadError() {
-    throw new Error(`The script "${this.src}" didn't load correctly.`);
-}
-
 export function findScript(url) {
     return document.querySelector(`script[src="${url}"]`);
 }
 
-export function insertScriptElement({ url, dataAttributes = {}, callback }) {
+export function insertScriptElement({ url, dataAttributes = {}, onSuccess, onError }) {
     const newScript = document.createElement('script');
-    newScript.onerror = loadError;
-    newScript.onload = callback;
+    newScript.onerror = onError;
+    newScript.onload = onSuccess;
 
     forEachObjectKey(dataAttributes, key => {
         newScript.setAttribute(key, dataAttributes[key]);

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -72,7 +72,7 @@ describe('insertScriptElement()', () => {
             set(src) {
                 this.currentSrc = src;
                 if (src === loadFailureSrcKey) {
-                    setTimeout(() => this.onerror(new Error('error message')));
+                    setTimeout(() => this.onerror());
                 } else if (this.onload) {
                     setTimeout(() => this.onload());
                 }
@@ -123,7 +123,7 @@ describe('insertScriptElement()', () => {
         const url = 'https://www.paypal.com/sdk/js';
         insertScriptElement({
             url,
-            callback: onloadMock
+            onSuccess: onloadMock
         });
 
         jest.runAllTimers();
@@ -132,13 +132,12 @@ describe('insertScriptElement()', () => {
 
     test("onerror() event", () => {
         expect.assertions(1);
-
+        const onErrorMock = jest.fn();
         const url = loadFailureSrcKey;
-        insertScriptElement({ url });
-        try {
-            jest.runAllTimers();
-        } catch(e) {
-            expect(e.message).toBe(`The script "${url}" didn't load correctly.`);
-        }
+
+        insertScriptElement({ url, onError: onErrorMock });
+
+        jest.runAllTimers();
+        expect(onErrorMock).toBeCalled();
     });
 });


### PR DESCRIPTION
This PR fixes a bug with the error handling with `loadScript()`. It makes sure to clear the `loadingState` variable when an error happens to prevent `loadScript()` from getting into a bad state.