### PR TITLE
Improve error messaging when the script fails to load

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,11 +27,31 @@ export function loadScript(options) {
             onSuccess: () => {
                 isLoading = false;
                 if (window.paypal) return resolve(window.paypal);
-                return reject(new Error('The window.paypal global variable is not available.'));
+                const errorMessage = 'The window.paypal global variable is not available.';
+                console.error(errorMessage);
+                return reject(new Error(errorMessage));
             },
             onError: () => {
                 isLoading = false;
-                return reject(new Error(`The script "${url}" didn't load correctly.`));
+                let errorMessage = `The script "${url}" didn't load correctly.`;
+
+                if (!window.fetch) {
+                    console.error(errorMessage);
+                    return reject(errorMessage);
+                }
+
+                let responseStatusCode;
+
+                window.fetch(url)
+                    .then(response => {
+                        responseStatusCode = response.status;
+                        return response.text();
+                    })
+                    .then(body => {
+                        errorMessage += `\n\nStatus Code: ${responseStatusCode}\nResponse body: ${body}`;
+                        console.error(errorMessage);
+                        return reject(new Error(errorMessage));
+                    });
             }
         });
     });


### PR DESCRIPTION
@mnicpt and I were hacking on the error use case this morning. This PR improves the error messages you see in the Dev Tools Console when paypal-js fails to load the script. 

For example, if a bad query param is passed in the developer will see the following error in the console:
<img width="1478" alt="Screen Shot 2020-09-14 at 1 58 41 PM" src="https://user-images.githubusercontent.com/534034/93126934-aa3cf080-f692-11ea-890d-daad988884b5.png">


### Additional Details

The JS SDK does return useful error messages. The problem is you have to check the Network Tab in Dev Tools to see that response. The error doesn't show up in the console because `<script src="....">` only executes when a 200 status code is returned. This `fetch` when there's an error approach allows us to get at the response status code and response body so we can log it to the console. This way the developer is more likely to see the error.