### PR TITLE
Update cache logic to check data attributes

### DIFF
--- a/e2e-tests/bundle/bundle-size.test.js
+++ b/e2e-tests/bundle/bundle-size.test.js
@@ -1,12 +1,14 @@
 import filesize from 'filesize';
 import fs from 'fs';
 
+const maxBundleSizeInKiloBytes = 6;
+
 describe('bundle size', () => {
-    it('paypal.browser.min.js should be less than 5 KB', () => {
+    it(`paypal.browser.min.js should be less than ${maxBundleSizeInKiloBytes} KB`, () => {
         const { size: sizeInBytes } = fs.statSync('dist/paypal.browser.min.js');
         const [sizeInKiloBytes, label] = filesize(sizeInBytes, {output: "array"});
         console.log(`paypal.browser.min.js: ${sizeInKiloBytes} ${label}`);
 
-        expect(sizeInKiloBytes).toBeLessThan(18);
+        expect(sizeInKiloBytes).toBeLessThan(maxBundleSizeInKiloBytes);
     });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ export function loadScript(options) {
         const url = `${SDK_BASE_URL}?${queryString}`;
 
         // resolve with the existing global paypal object when a script with the same src already exists
-        if (findScript(url) && window.paypal) return resolve(window.paypal);
+        if (findScript(url, dataAttributes) && window.paypal) return resolve(window.paypal);
 
         isLoading = true;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,15 +3,16 @@ export function findScript(url, dataAttributes) {
     if (!currentScript) return null;
 
     const nextScript = createScriptElement(url, dataAttributes);
+
+    // check if the new script has the same number of data attributes
+    if (objectSize(currentScript.dataset) !== objectSize(nextScript.dataset)) {
+        return null;
+    }
+
     let isExactMatch = true;
 
+    // check if the data attribute values are the same
     forEachObjectKey(currentScript.dataset, key => {
-        if (currentScript.dataset[key] !== nextScript.dataset[key]) {
-            isExactMatch = false;
-        }
-    });
-
-    forEachObjectKey(nextScript.dataset, key => {
         if (currentScript.dataset[key] !== nextScript.dataset[key]) {
             isExactMatch = false;
         }
@@ -60,15 +61,6 @@ export function objectToQueryString(params) {
     return queryString;
 }
 
-// uses es3 to avoid requiring polyfills for Array.prototype.forEach and Object.keys
-function forEachObjectKey(obj, callback) {
-    for (let key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-            callback(key);
-        }
-    }
-}
-
 function createScriptElement(url, dataAttributes = {}) {
     const newScript = document.createElement('script');
     newScript.src = url;
@@ -78,4 +70,19 @@ function createScriptElement(url, dataAttributes = {}) {
     });
 
     return newScript;
+}
+
+// uses es3 to avoid requiring polyfills for Array.prototype.forEach and Object.keys
+function forEachObjectKey(obj, callback) {
+    for (let key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            callback(key);
+        }
+    }
+}
+
+function objectSize(obj) {
+    let size = 0;
+    forEachObjectKey(obj, () => size++);
+    return size;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,17 +1,30 @@
-export function findScript(url) {
-    return document.querySelector(`script[src="${url}"]`);
+export function findScript(url, dataAttributes) {
+    const currentScript = document.querySelector(`script[src="${url}"]`);
+    if (!currentScript) return null;
+
+    const nextScript = createScriptElement(url, dataAttributes);
+    let isExactMatch = true;
+
+    forEachObjectKey(currentScript.dataset, key => {
+        if (currentScript.dataset[key] !== nextScript.dataset[key]) {
+            isExactMatch = false;
+        }
+    });
+
+    forEachObjectKey(nextScript.dataset, key => {
+        if (currentScript.dataset[key] !== nextScript.dataset[key]) {
+            isExactMatch = false;
+        }
+    });
+
+    return isExactMatch ? currentScript : null;
 }
 
-export function insertScriptElement({ url, dataAttributes = {}, onSuccess, onError }) {
-    const newScript = document.createElement('script');
+export function insertScriptElement({ url, dataAttributes, onSuccess, onError }) {
+    const newScript = createScriptElement(url, dataAttributes);
     newScript.onerror = onError;
     newScript.onload = onSuccess;
 
-    forEachObjectKey(dataAttributes, key => {
-        newScript.setAttribute(key, dataAttributes[key]);
-    });
-
-    newScript.src = url;
     document.head.insertBefore(newScript, document.head.firstElementChild);
 }
 
@@ -54,4 +67,15 @@ function forEachObjectKey(obj, callback) {
             callback(key);
         }
     }
+}
+
+function createScriptElement(url, dataAttributes = {}) {
+    const newScript = document.createElement('script');
+    newScript.src = url;
+
+    forEachObjectKey(dataAttributes, key => {
+        newScript.setAttribute(key, dataAttributes[key]);
+    });
+
+    return newScript;
 }


### PR DESCRIPTION
This PR updates the cache logic for the reload use case. This change ensures that both query params and data attributes are validated for the reload use case. 
- If the query params or data attributes change, it will reload the script. 
- If both are the same, it will avoid reloading the script and will return the existing `window.paypal` reference.