### PR TITLE
Update publish script

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,4 +1,5 @@
 const { exec } = require('shelljs');
+const readline = require("readline");
 
 // validate git and npm
 require('./validate');
@@ -19,5 +20,15 @@ exec(`npm version ${newVersionArg}`);
 // push up new version commit and tag
 exec('git push --follow-tags');
 
-// publish to public npm
-exec('npm publish');
+// use the readline module to simulate npm prompt
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+});
+
+// prompt for otp and publish to public npm
+rl.question("Enter OTP for public npm: ", (otp) => {
+    exec(`npm publish --otp=${otp}`);
+
+    rl.close();
+});


### PR DESCRIPTION
## What
Updates the`publish.js` script to use a callback to pass in the OTP flag with `npm publish`.

## Why
Attempting to run `npm publish` with the `exec` command from `shelljs` with 2FA enabled exits before allowing the user to enter an OTP.