### PR TITLE
feature: add appendScript()

### DIFF
--- a/e2e-tests/credit-messaging-and-buttons/append-script-demo.html
+++ b/e2e-tests/credit-messaging-and-buttons/append-script-demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>appendScript() Demo | PayPal JS</title>
+  </head>
+  <body>
+    <h1>appendScript() Demo w/ Buttons and Messages</h1>
+
+    <div id="paypal-buttons"></div>
+    <div id="paypal-messages"></div>
+
+    <script>
+        // global functions for rendering components
+        let currentButtons;
+        function renderButtons () {
+            if (currentButtons) {
+                currentButtons.close();
+            }
+            currentButtons = window.paypal.Buttons();
+            currentButtons.render('#paypal-buttons')
+                .catch(err => {
+                    console.log('Buttons rendering error', err);
+                })
+        }
+
+        function renderMessages () {
+            paypal.Messages().render('#paypal-messages');
+        }
+    </script>
+
+
+    <script type="module">
+        import { loadScript } from '../../dist/paypal.esm.js';
+
+        const options = {
+            'client-id': 'sb',
+            'data-order-id': '12345',
+            components: 'buttons'
+        };
+
+        loadScript(options)
+          .then(paypal => {
+            renderButtons();
+          });
+    </script>
+
+
+    <script type="module">
+        import { appendScript } from '../../dist/paypal.esm.js';
+
+        // the previous set options like client-id are persisted
+        appendScript({ components: 'buttons,messages' })
+        .then(paypal => {
+            renderButtons();
+            renderMessages();
+        });
+    </script>
+
+  </body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import Promise from 'promise-polyfill';
-import { findScript, insertScriptElement, processOptions } from './utils';
+import { findScript, insertScriptElement, processOptions, forEachObjectKey } from './utils';
 
 const SDK_BASE_URL = 'https://www.paypal.com/sdk/js';
 let loadingPromise;
@@ -32,6 +32,50 @@ export function loadScript(options) {
             onError: () => {
                 isLoading = false;
                 return reject(new Error(`The script "${url}" didn't load correctly.`));
+            }
+        });
+    });
+}
+
+export function appendScript(options) {
+    return new Promise((resolve, reject) => {
+        // resolve with null when running in Node
+        if (typeof window === 'undefined') return resolve(null);
+
+        const existingScript = document.querySelector(`script[src^="${SDK_BASE_URL}"]`);
+
+        // reject when the JS SDK isn't found on the page
+        if (existingScript === null) {
+            return reject('Failed to find an existing JS SDK <script> element');
+        }
+
+        const { queryParams, dataAttributes } = processOptions(options);
+
+        let newSrc = existingScript.src;
+
+        forEachObjectKey(queryParams, queryParamKey => {
+            const keyValue = `${queryParamKey}=${queryParams[queryParamKey]}`;
+
+            if (newSrc.indexOf(queryParamKey) > -1) {
+                newSrc = newSrc.replace(new RegExp(`${queryParamKey}=[^&]*`, "g"), keyValue);
+            } else {
+                newSrc += `&${keyValue}`;
+            }
+        });
+
+        // TODO: add support for data-attributes
+
+        insertScriptElement({
+            url: newSrc,
+            dataAttributes,
+            onSuccess: () => {
+                isLoading = false;
+                if (window.paypal) return resolve(window.paypal);
+                return reject(new Error('The window.paypal global variable is not available.'));
+            },
+            onError: () => {
+                isLoading = false;
+                return reject(new Error(`The script "${newSrc}" didn't load correctly.`));
             }
         });
     });

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,6 +47,7 @@ export function processOptions(options = {}) {
 
     return {
         queryString: objectToQueryString(queryParams),
+        queryParams,
         dataAttributes
     };
 }
@@ -73,7 +74,7 @@ function createScriptElement(url, dataAttributes = {}) {
 }
 
 // uses es3 to avoid requiring polyfills for Array.prototype.forEach and Object.keys
-function forEachObjectKey(obj, callback) {
+export function forEachObjectKey(obj, callback) {
     for (let key in obj) {
         if (Object.prototype.hasOwnProperty.call(obj, key)) {
             callback(key);


### PR DESCRIPTION
This PR implements the new `appendScript()` function defined in #46. Note that this is still a work-in-progress. I wanted to create a demo to prove that this is possible. There are a few things to note:

1. All components must be re-rendered after loading the JS SDK. The demo solves this by having a reusable `renderButtons()` function.
2. The first button should be closed before rendering the button again. Otherwise you may end up seeing two on the page.
3. The first button render will throw a rendering error and can be caught with `paypal.Buttons().render(element).catch(err => {})` 