### PR TITLE
Bring your own Promise Polyfill

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended", "plugin:compat/recommended"],
   "env": {
     "browser": true,
     "es2020": true,
@@ -17,5 +17,10 @@
   "rules": {
     "indent": ["error", 4],
     "semi": ["error", "always"]
+  },
+  "settings": {
+    "polyfills": [
+      "Promise"
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PayPal JS
+# paypal-js
 
 > A client-side loader for the [PayPal JS SDK](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/)
 
@@ -82,6 +82,29 @@ Which will load the following `<script>` asynchronously:
 
 View the [full list of supported script parameters](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-configuration/#script-parameters).
 
+### Legacy Browser Support
+
+This library relies on [JavaScript Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). To support legacy browsers like IE 11, you must provide your own Promise polyfill. With a Promise polyfill this library will [support the same browsers as the JS SDK](https://developer.paypal.com/docs/business/checkout/reference/browser-support/#supported-browsers-by-platform).
+
+The `loadScript()` function takes in a second parameter for providing a Promise ponyfill. It defaults to the global `Promise` object if it exists. There are two options for polyfilling the Promise object:
+
+1. Use a global polyfill strategy that monkey patches the `window.Promise` API implementation.
+2. Use a [ponyfill strategy](https://github.com/sindresorhus/ponyfill) that passes a Promise library into `loadScript()` without affecting other code:
+
+```js
+import { loadScript } from '@paypal/paypal-js';
+import PromisePonyfill from 'promise-polyfill';
+
+loadScript(options, PromisePonyfill)
+    .then(paypalObject => {})
+```
+
+We also provide a legacy build that includes the [promise-polyfill](https://github.com/taylorhakes/promise-polyfill) library. You can reference it from the CDN here:
+
+```html
+<script src="https://unpkg.com/@paypal/paypal-js/dist/paypal.legacy.browser.min.js"></script>
+```
+
 ### Using a CDN
 
 The paypal-js script is also available on the [unpkg CDN](https://unpkg.com/). The paypal.browser.js build assigns the `loadScript` function to the window object as `window.paypalLoadScript`. Here's an example:
@@ -105,10 +128,6 @@ The paypal-js script is also available on the [unpkg CDN](https://unpkg.com/). T
 ```
 
 Note that the above CDN location points to the latest release of paypal-js. It is advised that when you deploy your site, you import the specific version you have developed and tested with (ex: https://unpkg.com/@paypal/paypal-js@1.0.0/dist/paypal.browser.min.js).
-
-### Browser Support
-
-This library supports all popular browsers, including IE 11. It provides the same browser support as the JS SDK. Here's the [full list of supported browsers](https://developer.paypal.com/docs/business/checkout/reference/browser-support/#supported-browsers-by-platform).
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > A client-side loader for the [PayPal JS SDK](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/)
 
 <a href="https://www.npmjs.com/package/@paypal/paypal-js"><img src="https://img.shields.io/npm/v/@paypal/paypal-js" alt="npm version"></a>
+<a href="https://www.npmjs.com/package/@paypal/paypal-js"><img src="https://img.shields.io/bundlephobia/minzip/@paypal/paypal-js" alt="Bundle size minified and gzipped"></a>
 <a href="https://www.npmjs.com/package/@paypal/paypal-js"><img src="https://img.shields.io/npm/dm/@paypal/paypal-js" alt="npm downloads"></a>
 <a href="https://github.com/paypal/paypal-js/actions?query=workflow%3ACI"><img src="https://github.com/paypal/paypal-js/workflows/CI/badge.svg" alt="CI Status"></a>
 <a href="https://github.com/paypal/paypal-js/blob/main/LICENSE.txt"><img src="https://img.shields.io/npm/l/@paypal/paypal-js" alt="GitHub license"></a>

--- a/babel.config.js
+++ b/babel.config.js
@@ -17,11 +17,7 @@ module.exports = api => {
             [
                 '@babel/preset-env',
                 {
-                    useBuiltIns: 'usage',
-                    corejs: {
-                        version: '3.6',
-                        proposals: true
-                    },
+                    useBuiltIns: false,
                     modules: false
                 }
             ]

--- a/e2e-tests/bundle/bundle-size.test.js
+++ b/e2e-tests/bundle/bundle-size.test.js
@@ -1,14 +1,21 @@
 import filesize from 'filesize';
 import fs from 'fs';
 
-const maxBundleSizeInKiloBytes = 6;
+const maxBundleSizeInKiloBytes = 3;
+const maxLegacyBundleSizeInKiloBytes = 6;
 
 describe('bundle size', () => {
     it(`paypal.browser.min.js should be less than ${maxBundleSizeInKiloBytes} KB`, () => {
         const { size: sizeInBytes } = fs.statSync('dist/paypal.browser.min.js');
-        const [sizeInKiloBytes, label] = filesize(sizeInBytes, {output: "array"});
-        console.log(`paypal.browser.min.js: ${sizeInKiloBytes} ${label}`);
+        const [sizeInKiloBytes] = filesize(sizeInBytes, {output: "array"});
 
         expect(sizeInKiloBytes).toBeLessThan(maxBundleSizeInKiloBytes);
+    });
+
+    it(`paypal.legacy.browser.min.js should be less than ${maxLegacyBundleSizeInKiloBytes} KB`, () => {
+        const { size: sizeInBytes } = fs.statSync('dist/paypal.legacy.browser.min.js');
+        const [sizeInKiloBytes] = filesize(sizeInBytes, {output: "array"});
+
+        expect(sizeInKiloBytes).toBeLessThan(maxLegacyBundleSizeInKiloBytes);
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2215,6 +2215,12 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "ast-metadata-inferer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.4.0.tgz",
+      "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -2633,6 +2639,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-db": {
+      "version": "1.0.30001159",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001159.tgz",
+      "integrity": "sha512-fh0J2qYeW36hS5RUT7FnHcvgUxATY5LtzSXURWPuLNAolWaXR+qSu+asX5xcFvC4fwQKzfHWtWuPGJc0VJYrfw==",
       "dev": true
     },
     "caniuse-lite": {
@@ -3472,6 +3484,30 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-compat": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.8.0.tgz",
+      "integrity": "sha512-5CuWUSZXZkXLCQJBriEpndn/YWrvggDSHTpRJq++kR8GVcsWbTdp8Eh+nBA7JlrNi7ZJ/+kniOVXmn3bpnxuRA==",
+      "dev": true,
+      "requires": {
+        "ast-metadata-inferer": "^0.4.0",
+        "browserslist": "^4.12.2",
+        "caniuse-db": "^1.0.30001090",
+        "core-js": "^3.6.5",
+        "find-up": "^4.1.0",
+        "lodash.memoize": "4.1.2",
+        "mdn-browser-compat-data": "^1.0.28",
+        "semver": "7.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
       }
@@ -5882,6 +5918,12 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -5989,6 +6031,15 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "mdn-browser-compat-data": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.1.2.tgz",
+      "integrity": "sha512-uBNX2P4iu3PZcXP20rL+n7fxN9PWZLj0y43QMe/1aXzqP3H6HbVOeePS0cBZCtMwcfr2Tugf1OHj+/wLam+dUg==",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.2"
       }
     },
     "merge-deep": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@rollup/plugin-node-resolve": "^10.0.0",
     "@rollup/plugin-replace": "^2.3.4",
     "babel-jest": "^26.6.3",
-    "core-js": "^3.7.0",
     "eslint": "^7.13.0",
     "eslint-plugin-compat": "^3.8.0",
     "filesize": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-jest": "^26.6.3",
     "core-js": "^3.7.0",
     "eslint": "^7.13.0",
+    "eslint-plugin-compat": "^3.8.0",
     "filesize": "^6.1.0",
     "http-server": "^0.12.3",
     "jest": "^26.6.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,44 +15,74 @@ const outputConfigForBrowserBundle = {
     banner
 };
 
-export default {
-    input: 'src/main.js',
-    plugins: [
-        nodeResolve({
-            browser: true
-        }),
-        commonjs(),
-        babel({
-            babelHelpers: 'bundled',
-            exclude: /node_modules/
-        }),
-        replace({
-            '__VERSION__': pkg.version
-        }),
-        filesize()
-    ],
-    output: [
-        {
-            file: pkg.module,
-            format: 'esm',
-            banner
-        },
-        {
-            file: pkg.main,
-            format: 'cjs',
-            banner
-        },
-        {
-            file: 'dist/paypal.browser.js',
-            ...outputConfigForBrowserBundle
-        },
-        {
-            file: 'dist/paypal.browser.min.js',
-            ...outputConfigForBrowserBundle,
-            plugins: [terser()]
-        }
-    ]
-};
+export default [
+    {
+        input: 'src/index.js',
+        plugins: [
+            nodeResolve({
+                browser: true
+            }),
+            commonjs(),
+            babel({
+                babelHelpers: 'bundled',
+                exclude: /node_modules/
+            }),
+            replace({
+                '__VERSION__': pkg.version
+            }),
+            filesize()
+        ],
+        output: [
+            {
+                file: pkg.module,
+                format: 'esm',
+                banner
+            },
+            {
+                file: pkg.main,
+                format: 'cjs',
+                banner
+            },
+            {
+                file: 'dist/paypal.browser.js',
+                ...outputConfigForBrowserBundle
+            },
+            {
+                file: 'dist/paypal.browser.min.js',
+                ...outputConfigForBrowserBundle,
+                plugins: [terser()]
+            }
+        ]
+    },
+    {
+        input: 'src/legacy/index.js',
+        plugins: [
+            nodeResolve({
+                browser: true
+            }),
+            commonjs(),
+            babel({
+                babelHelpers: 'bundled',
+                exclude: /node_modules/
+            }),
+            replace({
+                '__VERSION__': pkg.version
+            }),
+            filesize()
+        ],
+        output: [
+            {
+                file: 'dist/paypal.legacy.browser.js',
+                ...outputConfigForBrowserBundle
+            },
+            {
+                file: 'dist/paypal.legacy.browser.min.js',
+                ...outputConfigForBrowserBundle,
+                plugins: [terser()]
+            }
+        ]
+    }
+];
 
 function getBannerText() {
     const banner = `

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+export { default as loadScript } from './loadScript';
+
+// replaced with the package.json version at build time
+export const version = '__VERSION__';

--- a/src/legacy/index.js
+++ b/src/legacy/index.js
@@ -1,0 +1,9 @@
+import Promise from 'promise-polyfill';
+import loadScriptPromise from '../loadScript';
+
+export function loadScript(options) {
+    return loadScriptPromise(options, Promise);
+}
+
+// replaced with the package.json version at build time
+export const version = '__VERSION__';

--- a/src/loadScript.js
+++ b/src/loadScript.js
@@ -1,20 +1,29 @@
-import Promise from 'promise-polyfill';
 import { findScript, insertScriptElement, processOptions } from './utils';
 
 const SDK_BASE_URL = 'https://www.paypal.com/sdk/js';
 let loadingPromise;
 let isLoading = false;
 
-export function loadScript(options) {
+export default function loadScript(options, PromisePonyfill) {
     // resolve with the existing promise when the script is loading
     if (isLoading) return loadingPromise;
 
-    return loadingPromise = new Promise((resolve, reject) => {
+    if (typeof PromisePonyfill === 'undefined') {
+        // default to using window.Promise as the Promise implementation
+        if (typeof Promise === 'undefined') {
+            throw new Error('Failed to load the PayPal JS SDK script because Promise is undefined. To resolve the issue, use a Promise polyfill.');
+        }
+
+        PromisePonyfill = Promise;
+    }
+
+    return loadingPromise = new PromisePonyfill((resolve, reject) => {
         // resolve with null when running in Node
         if (typeof window === 'undefined') return resolve(null);
 
         const { queryString, dataAttributes } = processOptions(options);
-        const url = `${SDK_BASE_URL}?${queryString}`;
+        const sdkBaseURL = options.sdkBaseURL || SDK_BASE_URL;
+        const url = `${sdkBaseURL}?${queryString}`;
 
         // resolve with the existing global paypal object when a script with the same src already exists
         if (findScript(url, dataAttributes) && window.paypal) return resolve(window.paypal);
@@ -36,6 +45,3 @@ export function loadScript(options) {
         });
     });
 }
-
-// replaced with the package.json version at build time
-export const version = '__VERSION__';

--- a/src/loadScript.node.test.js
+++ b/src/loadScript.node.test.js
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { loadScript } from './main';
+import loadScript from './loadScript';
 
 test('should resolve with null when global window object does not exist', () => {
     expect.assertions(1);


### PR DESCRIPTION
## The Problem

Currently paypal-js includes a promise-polyfill. This polyfill doubles the size of the library. More than 95% of users have browsers that support Promises (source: https://caniuse.com/promises) These users shouldn't have to pay a performance penalty when this polyfill when it's not needed. 

## Solution

Don't ship with a Promise Polyfill. Instead let's provide a way for users to bring their own Promise implementation to support legacy browsers like IE 11. This change makes the paypal-js over 50% smaller.

### Before
<img width="398" alt="Screen Shot 2020-11-23 at 1 07 46 PM" src="https://user-images.githubusercontent.com/534034/100004767-9a761280-2d8d-11eb-986c-05fb606cd941.png">

### After
<img width="400" alt="Screen Shot 2020-11-23 at 1 06 56 PM" src="https://user-images.githubusercontent.com/534034/100004777-9c3fd600-2d8d-11eb-9fea-8460c2d56f62.png">

See the readme changes for more details.
