### PR TITLE
Use TypeScript and also manage type declarations for the JS SDK

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist/*
+scripts/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,11 @@
 {
-  "extends": ["eslint:recommended", "plugin:compat/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:compat/recommended"
+  ],
   "env": {
     "browser": true,
     "es2020": true,

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,8 @@ module.exports = api => {
             presets: [
                 [
                     '@babel/preset-env', { targets: { node: 'current' } }
-                ]
+                ],
+                '@babel/preset-typescript'
             ]
         };
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -901,6 +901,15 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz",
+      "integrity": "sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
@@ -1195,6 +1204,17 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.1.tgz",
+      "integrity": "sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-typescript": "^7.12.1"
+      }
+    },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
@@ -1318,6 +1338,17 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.7.tgz",
+      "integrity": "sha512-nOoIqIqBmHBSEgBXWR4Dv/XBehtIFcw9PqZw6rFYuKrzsZmOQm3PR5siLBnKZFEsDb03IegG8nSjU/iXXXYRmw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-validator-option": "^7.12.1",
+        "@babel/plugin-transform-typescript": "^7.12.1"
       }
     },
     "@babel/runtime": {
@@ -1768,6 +1799,32 @@
         "extend": "3.0.2"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
     "@npmcli/ci-detect": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-1.3.0.tgz",
@@ -1935,6 +1992,16 @@
         "magic-string": "^0.25.7"
       }
     },
+    "@rollup/plugin-typescript": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.1.0.tgz",
+      "integrity": "sha512-pyQlcGQYRsONUDwXK3ckGPHjPzmjlq4sinzr7emW8ZMb2oZjg9WLcdcP8wyHSvBjvHrLzMayyPy079RROqb4vw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
+      }
+    },
     "@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -2056,6 +2123,22 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.19",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.19.tgz",
+      "integrity": "sha512-jqHoirTG61fee6v6rwbnEuKhpSKih0tuhqeFbCmMmErhtu3BYlOZaXWjffgOstMM4S/3iQD31lI5bGLTrs97yQ==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.0.22",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.22.tgz",
@@ -2072,6 +2155,12 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
+      "dev": true
+    },
+    "@types/promise-polyfill": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.3.tgz",
+      "integrity": "sha512-f/BFgF9a+cgsMseC7rpv9+9TAE3YNjhfYrtwCo/pIeCDDfQtE6PY0b5bao2eIIEpZCBUy8Y5ToXd4ObjPSJuFw==",
       "dev": true
     },
     "@types/resolve": {
@@ -2112,6 +2201,111 @@
       "optional": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.11.0.tgz",
+      "integrity": "sha512-x4arJMXBxyD6aBXLm3W7mSDZRiABzy+2PCLJbL7OPqlp53VXhaA1HKK7R2rTee5OlRhnUgnp8lZyVIqjnyPT6g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "4.11.0",
+        "@typescript-eslint/scope-manager": "4.11.0",
+        "debug": "^4.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.0.tgz",
+      "integrity": "sha512-1VC6mSbYwl1FguKt8OgPs8xxaJgtqFpjY/UzUYDBKq4pfQ5lBvN2WVeqYkzf7evW42axUHYl2jm9tNyFsb8oLg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/scope-manager": "4.11.0",
+        "@typescript-eslint/types": "4.11.0",
+        "@typescript-eslint/typescript-estree": "4.11.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.11.0.tgz",
+      "integrity": "sha512-NBTtKCC7ZtuxEV5CrHUO4Pg2s784pvavc3cnz6V+oJvVbK4tH9135f/RBP6eUA2KHiFKAollSrgSctQGmHbqJQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "4.11.0",
+        "@typescript-eslint/types": "4.11.0",
+        "@typescript-eslint/typescript-estree": "4.11.0",
+        "debug": "^4.1.1"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.0.tgz",
+      "integrity": "sha512-6VSTm/4vC2dHM3ySDW9Kl48en+yLNfVV6LECU8jodBHQOhO8adAVizaZ1fV0QGZnLQjQ/y0aBj5/KXPp2hBTjA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.11.0",
+        "@typescript-eslint/visitor-keys": "4.11.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.11.0.tgz",
+      "integrity": "sha512-XXOdt/NPX++txOQHM1kUMgJUS43KSlXGdR/aDyEwuAEETwuPt02Nc7v+s57PzuSqMbNLclblQdv3YcWOdXhQ7g==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.0.tgz",
+      "integrity": "sha512-eA6sT5dE5RHAFhtcC+b5WDlUIGwnO9b0yrfGa1mIOIAjqwSQCpXbLiFmKTdRbQN/xH2EZkGqqLDrKUuYOZ0+Hg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.11.0",
+        "@typescript-eslint/visitor-keys": "4.11.0",
+        "debug": "^4.1.1",
+        "globby": "^11.0.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.0.tgz",
+      "integrity": "sha512-tRYKyY0i7cMk6v4UIOCjl1LhuepC/pc6adQqJk4Is3YcC6k46HvsV9Wl7vQoLbm9qADgeujiT7KdLrylvFIQ+A==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.11.0",
+        "eslint-visitor-keys": "^2.0.0"
       }
     },
     "@zeit/schemas": {
@@ -2386,6 +2580,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
     "array-unique": {
@@ -3484,6 +3684,15 @@
       "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
       "dev": true
     },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4145,6 +4354,20 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4172,6 +4395,15 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
+      }
+    },
+    "fastq": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
+      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
       }
     },
     "fb-watchman": {
@@ -4607,6 +4839,28 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globby": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        }
+      }
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -6309,6 +6563,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -7068,6 +7328,12 @@
       "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
       "dev": true
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -7619,6 +7885,12 @@
       "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -7697,6 +7969,12 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "rx": {
@@ -8933,6 +9211,29 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
+    "tslib": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+      "dev": true
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -8977,6 +9278,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
     },
     "unbzip2-stream": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Client-side loader for the PayPal JS SDK",
   "main": "dist/paypal.node.js",
   "module": "dist/paypal.esm.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && rollup --config",
     "lint": "eslint .",
@@ -15,10 +16,13 @@
     "test:bundle": "jest --env=jsdom e2e-tests/bundle/**",
     "test:e2e": "jest -c e2e-tests/jest.config.js",
     "test:e2e:start": "serve",
-    "validate": "npm run build && npm run lint && npm test -- --coverage && npm run test:bundle"
+    "typecheck": "tsc --noEmit && tsc types/*.ts --noEmit",
+    "validate": "npm run typecheck && npm run build && npm run lint && npm test -- --coverage && npm run test:bundle"
   },
   "files": [
-    "dist"
+    "dist",
+    "types",
+    "!types/**/*.test.ts"
   ],
   "keywords": [
     "paypal",
@@ -34,10 +38,16 @@
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
+    "@babel/preset-typescript": "^7.12.7",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.1",
     "@rollup/plugin-replace": "^2.3.4",
+    "@rollup/plugin-typescript": "^8.1.0",
+    "@types/jest": "^26.0.19",
+    "@types/promise-polyfill": "^6.0.3",
+    "@typescript-eslint/eslint-plugin": "^4.11.0",
+    "@typescript-eslint/parser": "^4.11.0",
     "babel-jest": "^26.6.3",
     "eslint": "^7.16.0",
     "eslint-plugin-compat": "^3.9.0",
@@ -49,7 +59,9 @@
     "rollup-plugin-filesize": "^9.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "serve": "^11.3.2",
-    "shelljs": "^0.8.4"
+    "shelljs": "^0.8.4",
+    "tslib": "^2.0.3",
+    "typescript": "^4.1.3"
   },
   "dependencies": {
     "promise-polyfill": "^8.2.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import filesize from 'rollup-plugin-filesize';
 import { terser } from 'rollup-plugin-terser';
+import typescript from '@rollup/plugin-typescript';
 import pkg from './package.json';
 
 const banner = getBannerText();
@@ -14,18 +15,17 @@ const outputConfigForBrowserBundle = {
     footer: 'paypalLoadScript = paypalLoadScript.loadScript;',
     banner
 };
+const tsconfigOverride = { exclude: ['node_modules', '**/*.test.ts'] };
 
 export default [
     {
-        input: 'src/index.js',
+        input: 'src/index.ts',
         plugins: [
-            nodeResolve({
-                browser: true
-            }),
-            commonjs(),
+            typescript({ ...tsconfigOverride }),
             babel({
                 babelHelpers: 'bundled',
-                exclude: /node_modules/
+                exclude: /node_modules/,
+                extensions: ['.ts', '.js']
             }),
             replace({
                 '__VERSION__': pkg.version
@@ -55,8 +55,9 @@ export default [
         ]
     },
     {
-        input: 'src/legacy/index.js',
+        input: 'src/legacy/index.ts',
         plugins: [
+            typescript({ ...tsconfigOverride }),
             nodeResolve({
                 browser: true
             }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { default as loadScript } from './loadScript';
+export { default as loadScript } from './load-script';
 
 // replaced with the package.json version at build time
 export const version = '__VERSION__';

--- a/src/legacy/index.js
+++ b/src/legacy/index.js
@@ -1,9 +1,0 @@
-import Promise from 'promise-polyfill';
-import loadScriptPromise from '../loadScript';
-
-export function loadScript(options) {
-    return loadScriptPromise(options, Promise);
-}
-
-// replaced with the package.json version at build time
-export const version = '__VERSION__';

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -1,0 +1,13 @@
+import Promise from 'promise-polyfill';
+import loadScriptPromise from '../load-script';
+import type { PayPalScriptOptions } from '../../types/script-options';
+import type { PayPalNamespace } from '../../types/index';
+
+type PromiseResults = Promise<PayPalNamespace | null>;
+
+export function loadScript(options: PayPalScriptOptions): PromiseResults {
+    return loadScriptPromise(options, Promise);
+}
+
+// replaced with the package.json version at build time
+export const version = '__VERSION__';

--- a/src/load-script.node.test.ts
+++ b/src/load-script.node.test.ts
@@ -2,8 +2,8 @@
  * @jest-environment node
  */
 
-import loadScript from './loadScript';
+import loadScript from './load-script';
 
 test('should resolve with null when global window object does not exist', () => {
-    return expect(loadScript({})).resolves.toBe(null);
+    return expect(loadScript({ 'client-id': 'sb' })).resolves.toBe(null);
 });

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -1,18 +1,36 @@
-import loadScript from './loadScript';
-import * as utils from './utils';
+jest.mock('./utils', () => {
+    return {
+        findScript: jest.fn(),
+        insertScriptElement: jest.fn(),
+        processOptions: jest.fn()
+    };
+});
+
+import loadScript from './load-script';
+import { findScript, insertScriptElement, processOptions } from './utils';
 
 describe('loadScript()', () => {
-    let PromiseBackup = window.Promise;
+    const PromiseBackup = window.Promise;
+    const paypalNamespace = { version: "5" };
+
+    const mockedInsertScriptElement = <jest.Mock<void>>insertScriptElement;
+    const mockedProcessOptions = <jest.Mock< { url: string, dataAttributes: Record<string, unknown>}>>processOptions;
+    const mockedFindScript = <jest.Mock<HTMLScriptElement | null>>findScript;
 
     beforeEach(() => {
         document.head.innerHTML = '';
 
-        // eslint-disable-next-line no-import-assign
-        utils.insertScriptElement = jest.fn()
-            .mockImplementation(({ onSuccess }) => {
-                window.paypal = {};
-                process.nextTick(() => onSuccess());
-            });
+        mockedFindScript.mockReturnValue(null);
+
+        mockedInsertScriptElement.mockImplementation(({ onSuccess }) => {
+            window.paypal = paypalNamespace;
+            process.nextTick(() => onSuccess());
+        });
+
+        mockedProcessOptions.mockReturnValue({
+            url: 'https://www.paypal.com/sdk/js?client-id=sb',
+            dataAttributes: {}
+        });
 
         Object.defineProperty(window, 'paypal', {
             writable: true,
@@ -23,27 +41,29 @@ describe('loadScript()', () => {
     });
 
     afterEach(() => {
-        utils.insertScriptElement.mockClear();
+        mockedFindScript.mockClear();
+        mockedInsertScriptElement.mockClear();
+        mockedProcessOptions.mockClear();
     });
 
     test('should insert <script> and resolve the promise', async () => {
         expect(window.paypal).toBe(undefined);
 
         const response = await loadScript({ 'client-id': 'sb' });
-        expect(utils.insertScriptElement).toHaveBeenCalledTimes(1);
-        expect(response).toEqual({});
+        expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
+        expect(response).toEqual(window.paypal);
     });
 
     test('should not insert <script> when an existing script with the same src is already in the DOM and window.paypal is set', async () => {
         expect(window.paypal).toBe(undefined);
 
         // simulate the script already being loaded
-        document.head.innerHTML = '<script src="https://www.paypal.com/sdk/js?client-id=sb"></script>';
-        window.paypal = {};
+        mockedFindScript.mockReturnValue(document.createElement('script'));
+        window.paypal = paypalNamespace;
 
         const response = await loadScript({ 'client-id': 'sb' });
-        expect(utils.insertScriptElement).not.toHaveBeenCalled();
-        expect(response).toEqual({});
+        expect(mockedInsertScriptElement).not.toHaveBeenCalled();
+        expect(response).toEqual(window.paypal);
     });
 
     test('should only load the <script> once when loadScript() is called twice', async () => {
@@ -54,31 +74,30 @@ describe('loadScript()', () => {
             loadScript({ 'client-id': 'sb' })
         ]);
 
-        expect(utils.insertScriptElement).toHaveBeenCalledTimes(1);
-        expect(response).toEqual([{}, {}]);
+        expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
+        expect(response).toEqual([window.paypal, window.paypal]);
     });
 
     test('should reject the promise when window.paypal is undefined after loading the <script>', async () => {
         expect.assertions(3);
 
-        // eslint-disable-next-line no-import-assign
-        utils.insertScriptElement = jest.fn()
-            .mockImplementation(({ onSuccess }) => {
-                // do not set window.paypal in the mock implementation
-                process.nextTick(() => onSuccess());
-            });
+        mockedInsertScriptElement.mockImplementation(({ onSuccess }) => {
+            // do not set window.paypal in the mock implementation
+            process.nextTick(() => onSuccess());
+        });
 
         expect(window.paypal).toBe(undefined);
 
         try {
             await loadScript({ 'client-id': 'sb' });
         } catch (err) {
-            expect(utils.insertScriptElement).toHaveBeenCalledTimes(1);
+            expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
             expect(err.message).toBe('The window.paypal global variable is not available.');
         }
     });
 
     test('should throw an error from invalid arguments', () => {
+        // @ts-expect-error ignore invalid arguments error
         expect(() => loadScript()).toThrow(
             'Invalid arguments. Expected an object to be passed into loadScript().'
         );
@@ -87,30 +106,29 @@ describe('loadScript()', () => {
     test('should throw an error when the script fails to load', async () => {
         expect.assertions(3);
 
-        // eslint-disable-next-line no-import-assign
-        utils.insertScriptElement = jest.fn()
-            .mockImplementation(({ onError }) => {
-                process.nextTick(() => onError());
-            });
+        mockedInsertScriptElement.mockImplementationOnce(({ onError }) => {
+            process.nextTick(() => onError());
+        });
 
         expect(window.paypal).toBe(undefined);
 
         try {
             await loadScript({ 'client-id': 'sb' });
         } catch (err) {
-            expect(utils.insertScriptElement).toHaveBeenCalledTimes(1);
+            expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
             expect(err.message).toBe("The script \"https://www.paypal.com/sdk/js?client-id=sb\" didn't load correctly.");
         }
     });
 
     test('should use the provided promise ponyfill', () => {
         const PromisePonyfill = jest.fn();
-
+        // @ts-expect-error ignore mock error
         loadScript({ 'client-id': 'sb' }, PromisePonyfill);
         expect(PromisePonyfill).toHaveBeenCalledTimes(1);
     });
 
     test('should throw an error when the Promise implementation is undefined', () => {
+        // @ts-expect-error ignore deleting window.Promise
         delete window.Promise;
 
         expect(window.paypal).toBe(undefined);

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -1,9 +1,18 @@
 import { findScript, insertScriptElement, processOptions } from './utils';
+import type { PayPalScriptOptions } from '../types/script-options';
+import type { PayPalNamespace } from '../types/index';
 
-let loadingPromise;
+type PromiseResults = Promise<PayPalNamespace | null>;
+let loadingPromise: PromiseResults;
 let isLoading = false;
 
-export default function loadScript(options, PromisePonyfill) {
+declare global {
+    interface Window {
+        paypal?: PayPalNamespace;
+    }
+}
+
+export default function loadScript(options: PayPalScriptOptions, PromisePonyfill?: PromiseConstructor): PromiseResults {
     if (!(options instanceof Object)) {
         throw new Error('Invalid arguments. Expected an object to be passed into loadScript().');
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,12 @@
-export function findScript(url, dataAttributes) {
-    const currentScript = document.querySelector(`script[src="${url}"]`);
-    if (!currentScript) return null;
+import type { PayPalScriptOptions } from '../types/script-options';
+
+interface StringMap {
+    [key: string]: string;
+}
+
+export function findScript(url: string, dataAttributes?: StringMap): HTMLScriptElement | null {
+    const currentScript = document.querySelector<HTMLScriptElement>(`script[src="${url}"]`);
+    if (currentScript === null) return null;
 
     const nextScript = createScriptElement(url, dataAttributes);
 
@@ -21,7 +27,14 @@ export function findScript(url, dataAttributes) {
     return isExactMatch ? currentScript : null;
 }
 
-export function insertScriptElement({ url, dataAttributes, onSuccess, onError }) {
+interface ScriptElement {
+    url: string;
+    dataAttributes?: StringMap;
+    onSuccess: () => void;
+    onError: OnErrorEventHandler;
+}
+
+export function insertScriptElement({ url, dataAttributes, onSuccess, onError }: ScriptElement): void {
     const newScript = createScriptElement(url, dataAttributes);
     newScript.onerror = onError;
     newScript.onload = onSuccess;
@@ -29,7 +42,7 @@ export function insertScriptElement({ url, dataAttributes, onSuccess, onError })
     document.head.insertBefore(newScript, document.head.firstElementChild);
 }
 
-export function processOptions(options = {}) {
+export function processOptions(options: PayPalScriptOptions): { url: string, dataAttributes: StringMap } {
     let sdkBaseURL = 'https://www.paypal.com/sdk/js';
 
     if (options.sdkBaseURL) {
@@ -37,17 +50,20 @@ export function processOptions(options = {}) {
         delete options.sdkBaseURL;
     }
 
-    const processedOptions = {
+    interface ProcessedScriptOptions {
+        queryParams: StringMap,
+        dataAttributes: StringMap
+    }
+
+    const processedOptions: ProcessedScriptOptions = {
         queryParams: {},
         dataAttributes: {}
     };
 
     forEachObjectKey(options, key => {
-        if (key.substring(0, 5) === 'data-') {
-            processedOptions.dataAttributes[key] = options[key];
-        } else {
-            processedOptions.queryParams[key] = options[key];
-        }
+        const keyType = key.substring(0, 5) === 'data-' ? 'dataAttributes' : 'queryParams';
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        processedOptions[keyType][key] = options[key]!.toString();
     });
 
     const { queryParams, dataAttributes } = processedOptions;
@@ -58,7 +74,7 @@ export function processOptions(options = {}) {
     };
 }
 
-export function objectToQueryString(params) {
+export function objectToQueryString(params: StringMap): string {
     let queryString = '';
 
     forEachObjectKey(params, key => {
@@ -68,8 +84,8 @@ export function objectToQueryString(params) {
     return queryString;
 }
 
-function createScriptElement(url, dataAttributes = {}) {
-    const newScript = document.createElement('script');
+function createScriptElement(url: string, dataAttributes: StringMap = {}): HTMLScriptElement {
+    const newScript: HTMLScriptElement = document.createElement('script');
     newScript.src = url;
 
     forEachObjectKey(dataAttributes, key => {
@@ -80,15 +96,15 @@ function createScriptElement(url, dataAttributes = {}) {
 }
 
 // uses es3 to avoid requiring polyfills for Array.prototype.forEach and Object.keys
-function forEachObjectKey(obj, callback) {
-    for (let key in obj) {
+function forEachObjectKey(obj: Record<string, unknown>, callback: (key: string) => void): void {
+    for (const key in obj) {
         if (Object.prototype.hasOwnProperty.call(obj, key)) {
             callback(key);
         }
     }
 }
 
-function objectSize(obj) {
+function objectSize(obj: Record<string, unknown>): number {
     let size = 0;
     forEachObjectKey(obj, () => size++);
     return size;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "esnext",
+    "strict": true,
+
+      // these are overridden by the Rollup plugin
+      "outDir": "./dist",
+      "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/types/apis/orders.d.ts
+++ b/types/apis/orders.d.ts
@@ -1,0 +1,111 @@
+// https://developer.paypal.com/docs/api/orders/v2
+
+type SHIPPING_PREFERENCE = "GET_FROM_FILE" | "NO_SHIPPING" | "SET_PROVIDED_ADDRESS";
+
+type Address = {
+    address_line_1: string;
+    address_line_2: string;
+    admin_area_2: string;
+    admin_area_1: string;
+    postal_code: string;
+    country_code: string;
+};
+
+type Payer = {
+    name: {
+        given_name: string;
+        surname: string;
+    };
+    email_address: string;
+    payer_id: string;
+    phone: {
+        phone_number: string;
+    };
+    birth_date: string;
+    tax_info: {
+        tax_id: string;
+        tax_id_type: string;
+    };
+    address: Address;
+}
+
+type Payee = {
+    merchant_id: string;
+    email_address: string;
+}
+
+interface Amount {
+    currency_code?: string;
+    value: string;
+}
+
+interface AmountWithBreakdown extends Amount {
+    breakdown?: {
+        item_total: Amount;
+        shipping: Amount;
+        handling: Amount;
+        tax_total: Amount;
+        insurance: Amount;
+        shipping_discount: Amount;
+        discount: Amount;
+    }
+}
+
+type PlatformFee = {
+    amount: Amount;
+    payee: Payee;
+}
+
+type PaymentInstruction = {
+    platform_fees: PlatformFee[];
+    disbursement_mode: "INSTANT" | "DELAYED";
+}
+
+type ShippingInfo = {
+    name: {
+        full_name: string;
+    };
+    address: Address;
+}
+
+type PurchaseItem = {
+    name: string;
+    quantity: string;
+    unit_amount: Amount;
+    tax?: Amount;
+    description?: string;
+    sku: string;
+    category: "DIGITAL_GOODS" | "PHYSICAL_GOODS";
+}
+
+type PurchaseUnit = {
+    amount: AmountWithBreakdown;
+    reference_id?: string;
+    description?: string;
+    custom_id?: string;
+    invoice_id?: string;
+    soft_descriptor?: string;
+    payee?: Payee;
+    payment_instruction?: PaymentInstruction;
+    shipping?: ShippingInfo;
+    items?: PurchaseItem[];
+}
+
+type OrderApplicationContext = {
+    brand_name: string;
+    locale: string;
+    landing_page: "LOGIN" | "BILLING" | "NO_PREFERENCE";
+    shipping_preference: SHIPPING_PREFERENCE;
+    user_action: "CONTINUE" | "PAY_NOW";
+    payment_method: Record<string, unknown>;
+    return_url: string;
+    cancel_url: string;
+    stored_payment_source: Record<string, unknown>;
+}
+
+export type CreateOrderRequestBody = {
+    intent?: "CAPTURE" | "AUTHORIZE";
+    purchase_units: PurchaseUnit[];
+    payer?: Payer;
+    application_context?: OrderApplicationContext;
+}

--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -1,0 +1,54 @@
+import type { CreateOrderRequestBody } from '../apis/orders';
+
+type CreateOrderData = Record<string, unknown>;
+
+type CreateOrderActions = {
+    order: {
+        create: (options: CreateOrderRequestBody) => Promise<string>;
+    }
+};
+
+type OnApproveOrderData = Record<string, unknown>;
+
+type OnApproveOrderActions = {
+    order: {
+        capture: (options: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    }
+};
+
+type OnCancelledOrderData = {
+    orderID: string;
+};
+
+type OnCancelledOrderActions = {
+    redirect: () => void;
+};
+
+export interface PayPalButtonsComponentProps {
+    createOrder?: (data: CreateOrderData, actions: CreateOrderActions) => Promise<string>;
+    createSubscription?: (data: Record<string, unknown>, actions: Record<string, unknown>) => void;
+
+    fundingSource?: string;
+
+    onApprove?: (data: OnApproveOrderData, actions: OnApproveOrderActions) => Promise<void>;
+    onCancel?: (data: OnCancelledOrderData, actions: OnCancelledOrderActions) => void;
+    onClick?: () => void;
+    onError?: () => void;
+    onInit?: () => void;
+    onShippingChange?: () => void;
+
+    style?: {
+        color?: "gold" | "blue" | "silver" | "white" | "black";
+        height?: number;
+        label?: "paypal" | "checkout" | "buynow" | "pay" | "installment";
+        layout?: "vertical" | "horizontal";
+        shape?: "rect" | "pill";
+        tagline?: boolean;
+    };
+}
+
+export interface PayPalButtonsComponent {
+    close: () => Promise<void>;
+    isEligible: () => boolean;
+    render: (container: HTMLElement | string) => Promise<void>;
+}

--- a/types/index.d.test.ts
+++ b/types/index.d.test.ts
@@ -1,0 +1,40 @@
+import { loadScript } from '../src/index';
+import type { PayPalNamespace } from '.';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const loadScriptBasicPromise: Promise<PayPalNamespace | null> = loadScript({ 'client-id': 'sb' });
+
+loadScript({
+    'client-id': 'sb',
+    'currency': 'USD',
+    'data-order-id': '12345',
+    'disable-funding': 'card'
+});
+
+loadScript({ 'client-id': 'sb' })
+    .then((paypal) => {
+        if (!(paypal && paypal.Buttons)) return;
+
+        paypal.Buttons().render('#container');
+        paypal.Buttons().render(document.createElement('div'));
+
+        paypal.Buttons({
+            fundingSource: 'PAYPAL',
+            createOrder: (data, actions) => {
+                return actions.order.create({
+                    intent: 'AUTHORIZE',
+                    purchase_units: [
+                        {
+                            amount: {
+                                value: '1.20',
+                                currency_code: 'USD'
+                            }
+                        }
+                    ]
+                });
+            }
+        });
+    })
+    .catch(err => {
+        console.error(err);
+    });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,22 @@
+import type { PayPalScriptOptions } from './script-options';
+import type { PayPalButtonsComponentProps, PayPalButtonsComponent } from './components/buttons';
+
+export interface PayPalNamespace {
+    Buttons?: (options?: PayPalButtonsComponentProps) => PayPalButtonsComponent;
+    version: string;
+}
+
+declare module '@paypal/paypal-js' {
+    export function loadScript(
+        options: PayPalScriptOptions,
+        PromisePonyfill? : PromiseConstructor
+    ): Promise<PayPalNamespace | null>;
+
+    export const version: string;
+}
+
+declare global {
+    interface Window {
+        paypal?: PayPalNamespace;
+    }
+}

--- a/types/script-options.d.ts
+++ b/types/script-options.d.ts
@@ -1,0 +1,28 @@
+interface PayPalScriptQueryParameters {
+    'client-id': string;
+    'merchant-id'?: string;
+    currency?: string;
+    intent?: string;
+    commit?: boolean;
+    vault?: boolean | string;
+    components?: string;
+    'disable-funding'?: string;
+    'disable-card'?: string;
+    'integration-date'?: string;
+    debug?: boolean | string;
+    'buyer-country'?: string;
+    locale?: string;
+}
+
+interface PayPalScriptDataAttributes {
+    'data-partner-attribution-id'?: string;
+    'data-csp-nonce'?: string;
+    'data-order-id'?: string;
+    'data-page-type'?: string;
+    'data-client-token'?: string;
+}
+
+export interface PayPalScriptOptions extends PayPalScriptQueryParameters, PayPalScriptDataAttributes {
+    [key: string]: string | boolean | undefined;
+    sdkBaseURL?: string;
+}


### PR DESCRIPTION
This PR does two things:
- Upgrades the library to use TypeScript
- Exports type declarations for both paypal-js and the `window.paypal` namespace

### How to Test the new Types

This branch is currently published to npm using the beta tag. Install it using the following command:

`npm install @paypal/paypal-js@beta`

Here are some screenshots of my editor to show the new helpful auto-suggestions TypeScript devs will get:

Types for `loadScript()`:
<img width="926" alt="Screen Shot 2020-12-29 at 3 25 41 PM" src="https://user-images.githubusercontent.com/534034/103315095-3d9ff480-49ea-11eb-8d0e-dfddf13d4b7f.png">

Types for `window.paypal`:
<img width="816" alt="Screen Shot 2020-12-29 at 3 26 09 PM" src="https://user-images.githubusercontent.com/534034/103315149-632cfe00-49ea-11eb-9661-6a6067d1d919.png">


Types for `window.paypal` reference returned from loadScript Promise:
<img width="903" alt="Screen Shot 2020-12-29 at 3 25 26 PM" src="https://user-images.githubusercontent.com/534034/103315154-67591b80-49ea-11eb-9153-ee7b51c4dca8.png">

### Why convert to TypeScript

There is a high demand for TypeScript types for the JS SDK. For example, the checkout.js library is typed on DefinitelyTyped and gets about 13K downloads a week (https://www.npmjs.com/package/@types/paypal-checkout-components). Let's host the JS SDK types in this repo and be the source of truth for those types. It's also an incentive for more folks to use this library.

### Additional Notes

#### TypeScript Definition files

When designing a library with TypeScript, you have two options:
1. Use `declarations: true` in your tsconfig.json to dynamically generate them from your source code.
2. Manually define them using definition files.

My goal was to use option 1 with auto-generating the types for `loadScript()` and also the `window.paypal` namespace that isn't managed in this code base. I ran into problems with this approach with the TypeScript complier being smart about only including declarations for functionality that is actually exports. This problem led me to use option 2 instead (I think this is why [stripe-js](https://github.com/stripe/stripe-js/blob/master/package.json#L8) also uses option 2). There is some redundancy between what's in the /types/ folder and the /src/ folder but I think it's worth it. The benefit to this design is we can add TypeScript definitions for all our components (`window.paypal.Buttons`, `window.paypal.Messages`, etc...) and manage them in this single repo.


There is a lot more work to do for adding type declarations for `window.paypal`. Right now only the `Buttons` component is fully defined. The goal of this PR is to lay the foundation for our TypeScript strategy for the PayPal JS SDK. Future PRs can add types for things like `window.paypal.Marks`, `window.paypal.Messages`, braintree integration support, etc.