### PR TITLE
Add enable-funding to script options

### DIFF
--- a/types/script-options.d.ts
+++ b/types/script-options.d.ts
@@ -7,6 +7,7 @@ interface PayPalScriptQueryParameters {
     vault?: boolean | string;
     components?: string;
     'disable-funding'?: string;
+    'enable-funding'?: string;
     'disable-card'?: string;
     'integration-date'?: string;
     debug?: boolean | string;


### PR DESCRIPTION
This PR adds `enable-funding` to the valid script options types