### PR TITLE
Add support for data-namespace option

### DIFF
--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -3,10 +3,10 @@ import type { PayPalScriptOptions } from "../types/script-options";
 import type { PayPalNamespace } from "../types/index";
 
 type PromiseResults = Promise<PayPalNamespace | null>;
-let loadingPromise: PromiseResults;
 
 declare global {
     interface Window {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         [key: string]: any;
         paypal?: PayPalNamespace;
     }
@@ -33,7 +33,7 @@ export default function loadScript(
         PromisePonyfill = Promise;
     }
 
-    return (loadingPromise = new PromisePonyfill((resolve, reject) => {
+    return new PromisePonyfill((resolve, reject) => {
         // resolve with null when running in Node
         if (typeof window === "undefined") return resolve(null);
 
@@ -62,5 +62,5 @@ export default function loadScript(
                 );
             },
         });
-    }));
+    });
 }

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -4,10 +4,10 @@ import type { PayPalNamespace } from "../types/index";
 
 type PromiseResults = Promise<PayPalNamespace | null>;
 let loadingPromise: PromiseResults;
-let isLoading = false;
 
 declare global {
     interface Window {
+        [key: string]: any;
         paypal?: PayPalNamespace;
     }
 }
@@ -33,9 +33,6 @@ export default function loadScript(
         PromisePonyfill = Promise;
     }
 
-    // resolve with the existing promise when the script is loading
-    if (isLoading) return loadingPromise;
-
     return (loadingPromise = new PromisePonyfill((resolve, reject) => {
         // resolve with null when running in Node
         if (typeof window === "undefined") return resolve(null);
@@ -46,22 +43,20 @@ export default function loadScript(
         if (findScript(url, dataAttributes) && window.paypal)
             return resolve(window.paypal);
 
-        isLoading = true;
-
         insertScriptElement({
             url,
             dataAttributes,
             onSuccess: () => {
-                isLoading = false;
-                if (window.paypal) return resolve(window.paypal);
+                const namespace = dataAttributes.dataNamespace || "paypal";
+
+                if (window[namespace]) return resolve(window[namespace]);
                 return reject(
                     new Error(
-                        "The window.paypal global variable is not available."
+                        `The window.${namespace} global variable is not available.`
                     )
                 );
             },
             onError: () => {
-                isLoading = false;
                 return reject(
                     new Error(`The script "${url}" didn't load correctly.`)
                 );

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -38,17 +38,17 @@ export default function loadScript(
         if (typeof window === "undefined") return resolve(null);
 
         const { url, dataAttributes } = processOptions(options);
+        const namespace = dataAttributes["data-namespace"] || "paypal";
 
-        // resolve with the existing global paypal object when a script with the same src already exists
-        if (findScript(url, dataAttributes) && window.paypal)
-            return resolve(window.paypal);
+        // resolve with the existing global paypal namespace when a script with the same params already exists
+        if (findScript(url, dataAttributes) && window[namespace]) {
+            return resolve(window[namespace]);
+        }
 
         insertScriptElement({
             url,
             dataAttributes,
             onSuccess: () => {
-                const namespace = dataAttributes.dataNamespace || "paypal";
-
                 if (window[namespace]) return resolve(window[namespace]);
                 return reject(
                     new Error(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export function findScript(
     return isExactMatch ? currentScript : null;
 }
 
-interface ScriptElement {
+export interface ScriptElement {
     url: string;
     dataAttributes?: StringMap;
     onSuccess: () => void;

--- a/types/index.d.test.ts
+++ b/types/index.d.test.ts
@@ -154,3 +154,13 @@ loadScript({ "client-id": "test" })
     .catch((err) => {
         console.error(err);
     });
+
+loadScript({ "client-id": "test", "data-namespace": "customName" }).then(
+    (customObject) => {
+        customObject.Buttons();
+
+        // example showing how to use the types with a custom namespace off window
+        const customObjectFromWindow = window.customName as PayPalNamespace;
+        customObjectFromWindow.Buttons();
+    }
+);

--- a/types/script-options.d.ts
+++ b/types/script-options.d.ts
@@ -22,6 +22,7 @@ interface PayPalScriptDataAttributes {
     "data-page-type"?: string;
     "data-client-token"?: string;
     "data-merchant-id"?: string;
+    "data-namespace"?: string;
 }
 
 export interface PayPalScriptOptions


### PR DESCRIPTION
This PR adds support for using custom namespaces. Ex:


```js
    // we default to `window.paypal` when no data-namespace is defined.
    loadScript({ "client-id": "test", "data-namespace": "customName" })
        .then((customObject) => {
            customObject.Buttons();
        })
```