### PR TITLE
Add option for passing merchant-id values as an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,13 @@ Import the `loadScript` function for asynchronously loading the Paypal JS SDK.
 ```js
 import { loadScript } from "@paypal/paypal-js";
 
-loadScript({ "client-id": "test" }).then((paypal) => {
-    paypal.Buttons().render("#your-container-element");
-});
+loadScript({ "client-id": "test" })
+    .then((paypal) => {
+        paypal.Buttons().render("#your-container-element");
+    })
+    .catch(err) => {
+        console.error("failed to load the PayPal JS SDK script", err);
+    });
 ```
 
 ### Passing Arguments
@@ -105,6 +109,26 @@ Which will load the following `<script>` asynchronously:
 ```
 
 View the [full list of supported script parameters](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-configuration/#script-parameters).
+
+#### Merchant ID Array
+
+The `merchant-id` option accepts an array to simplify the implementation for Multi-Seller Payments. With this approach the caller doesn't have to worry about managing the two different merchant id values (`data-merchant-id` and `merchant-id`). Here's an example of passing an array to `merchant-id`:
+
+```js
+loadScript({
+    "client-id": "YOUR_CLIENT_ID",
+    "merchant-id": ["123", "456", "789"],
+});
+```
+
+Which will load the following `<script>` and will use `merchant-id=*` to properly configure the edge cache:
+
+```html
+<script
+    data-merchant-id="123,456,789"
+    src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&merchant-id=*"
+></script>
+```
 
 #### sdkBaseURL
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ View the [full list of supported script parameters](https://developer.paypal.com
 
 #### Merchant ID Array
 
-The `merchant-id` option accepts an array to simplify the implementation for Multi-Seller Payments. With this approach the caller doesn't have to worry about managing the two different merchant id values (`data-merchant-id` and `merchant-id`). Here's an example of passing an array to `merchant-id`:
+The `merchant-id` option accepts an array to simplify the implementation for Multi-Seller Payments. With this approach the caller doesn't have to worry about managing the two different merchant id values (`data-merchant-id` and `merchant-id`).
+
+**Here's an example with multiple `merchant-id` values:**
 
 ```js
 loadScript({
@@ -121,13 +123,28 @@ loadScript({
 });
 ```
 
-Which will load the following `<script>` and will use `merchant-id=*` to properly configure the edge cache:
+Which will load the following `<script>` and use `merchant-id=*` to properly configure the edge cache:
 
 ```html
 <script
     data-merchant-id="123,456,789"
     src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&merchant-id=*"
 ></script>
+```
+
+**Here's an example with one `merchant-id` value:**
+
+```js
+loadScript({
+    "client-id": "YOUR_CLIENT_ID",
+    "merchant-id": ["123"],
+});
+```
+
+When there's only one, the merchant-id is passed in using the query string.
+
+```html
+<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&merchant-id=123"></script>
 ```
 
 #### sdkBaseURL

--- a/babel.config.js
+++ b/babel.config.js
@@ -17,6 +17,7 @@ module.exports = (api) => {
                 {
                     useBuiltIns: false,
                     modules: false,
+                    exclude: ["@babel/plugin-transform-typeof-symbol"],
                 },
             ],
         ],

--- a/e2e-tests/bundle/bundle-size.test.js
+++ b/e2e-tests/bundle/bundle-size.test.js
@@ -1,8 +1,8 @@
 import filesize from "filesize";
 import fs from "fs";
 
-const maxBundleSizeInKiloBytes = 3;
-const maxLegacyBundleSizeInKiloBytes = 6.25;
+const maxBundleSizeInKiloBytes = 3.25;
+const maxLegacyBundleSizeInKiloBytes = 6.5;
 
 describe("bundle size", () => {
     it(`paypal.browser.min.js should be less than ${maxBundleSizeInKiloBytes} KB`, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { default as loadScript } from "./load-script";
+export * from "./load-script";
 
 // replaced with the package.json version at build time
 export const version = "__VERSION__";

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -1,12 +1,12 @@
 import Promise from "promise-polyfill";
-import loadScriptPromise from "../load-script";
+import { loadScript as originalLoadScript } from "../load-script";
 import type { PayPalScriptOptions } from "../../types/script-options";
 import type { PayPalNamespace } from "../../types/index";
 
 type PromiseResults = Promise<PayPalNamespace | null>;
 
 export function loadScript(options: PayPalScriptOptions): PromiseResults {
-    return loadScriptPromise(options, Promise);
+    return originalLoadScript(options, Promise);
 }
 
 // replaced with the package.json version at build time

--- a/src/load-script.node.test.ts
+++ b/src/load-script.node.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import loadScript from "./load-script";
+import { loadScript } from "./load-script";
 
 test("should resolve with null when global window object does not exist", () => {
     return expect(loadScript({ "client-id": "test" })).resolves.toBe(null);

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -2,35 +2,21 @@ import { findScript, insertScriptElement, processOptions } from "./utils";
 import type { PayPalScriptOptions } from "../types/script-options";
 import type { PayPalNamespace } from "../types/index";
 
-type PromiseResults = Promise<PayPalNamespace | null>;
-
-declare global {
-    interface Window {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        [key: string]: any;
-        paypal?: PayPalNamespace;
-    }
-}
-
-export default function loadScript(
+/**
+ * Load the Paypal JS SDK script asynchronously.
+ *
+ * @param {Object} options - used to configure query parameters and data attributes for the JS SDK.
+ * @param {PromiseConstructor} [PromisePonyfill=window.Promise] - optional Promise Constructor ponyfill.
+ * @return {Promise<Object>} paypalObject - reference to the global window PayPal object.
+ */
+export function loadScript(
     options: PayPalScriptOptions,
     PromisePonyfill?: PromiseConstructor
-): PromiseResults {
-    if (!(options instanceof Object)) {
-        throw new Error(
-            "Invalid arguments. Expected an object to be passed into loadScript()."
-        );
-    }
+): Promise<PayPalNamespace | null> {
+    validateArguments(options, PromisePonyfill);
 
     if (typeof PromisePonyfill === "undefined") {
-        // default to using window.Promise as the Promise implementation
-        if (typeof Promise === "undefined") {
-            throw new Error(
-                "Failed to load the PayPal JS SDK script because Promise is undefined. To resolve the issue, use a Promise polyfill."
-            );
-        }
-
-        PromisePonyfill = Promise;
+        PromisePonyfill = getDefaultPromiseImplementation();
     }
 
     return new PromisePonyfill((resolve, reject) => {
@@ -39,17 +25,20 @@ export default function loadScript(
 
         const { url, dataAttributes } = processOptions(options);
         const namespace = dataAttributes["data-namespace"] || "paypal";
+        const existingWindowNamespace = getPayPalWindowNamespace(namespace);
 
         // resolve with the existing global paypal namespace when a script with the same params already exists
-        if (findScript(url, dataAttributes) && window[namespace]) {
-            return resolve(window[namespace]);
+        if (findScript(url, dataAttributes) && existingWindowNamespace) {
+            return resolve(existingWindowNamespace);
         }
 
         insertScriptElement({
             url,
             dataAttributes,
             onSuccess: () => {
-                if (window[namespace]) return resolve(window[namespace]);
+                const newWindowNamespace = getPayPalWindowNamespace(namespace);
+
+                if (newWindowNamespace) return resolve(newWindowNamespace);
                 return reject(
                     new Error(
                         `The window.${namespace} global variable is not available.`
@@ -63,4 +52,37 @@ export default function loadScript(
             },
         });
     });
+}
+
+function validateArguments(
+    options: PayPalScriptOptions,
+    PromisePonyfill?: PromiseConstructor
+) {
+    if (typeof options !== "object" || options === null) {
+        throw new Error("Invalid arguments. Expected options to be an object.");
+    }
+
+    if (typeof PromisePonyfill === "undefined") {
+        return;
+    }
+
+    if (typeof PromisePonyfill !== "function") {
+        throw new Error(
+            "Invalid arguments. Expected PromisePolyfill to be a function."
+        );
+    }
+}
+
+function getDefaultPromiseImplementation() {
+    if (typeof Promise === "undefined") {
+        throw new Error(
+            "Promise is undefined. To resolve the issue, use a Promise polyfill."
+        );
+    }
+    return Promise;
+}
+
+function getPayPalWindowNamespace(namespace: string): PayPalNamespace {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (window as any)[namespace];
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -52,6 +52,52 @@ describe("processOptions()", () => {
         expect(url).toBe("https://www.paypal.com/sdk/js?client-id=test");
         expect(dataAttributes).toEqual({});
     });
+
+    test("supports passing an array of merchant ids", () => {
+        const { url, dataAttributes } = processOptions({
+            "client-id": "test",
+            "merchant-id": ["123", "456", "789"],
+        });
+
+        expect(url).toBe(
+            "https://www.paypal.com/sdk/js?client-id=test&merchant-id=*"
+        );
+        expect(dataAttributes).toEqual({ "data-merchant-id": "123,456,789" });
+    });
+
+    test("supports passing a single merchant id", () => {
+        const { url, dataAttributes } = processOptions({
+            "client-id": "test",
+            "merchant-id": "123",
+        });
+
+        expect(url).toBe(
+            "https://www.paypal.com/sdk/js?client-id=test&merchant-id=123"
+        );
+        expect(dataAttributes).toEqual({});
+
+        const { url: url2, dataAttributes: dataAttributes2 } = processOptions({
+            "client-id": "test",
+            "merchant-id": ["123"],
+        });
+
+        expect(url2).toBe(
+            "https://www.paypal.com/sdk/js?client-id=test&merchant-id=123"
+        );
+        expect(dataAttributes2).toEqual({});
+    });
+
+    test("falls back to data-merchant-id when merchant-id is not set", () => {
+        const { url, dataAttributes } = processOptions({
+            "client-id": "test",
+            "data-merchant-id": "123,456,789",
+        });
+
+        expect(url).toBe(
+            "https://www.paypal.com/sdk/js?client-id=test&merchant-id=*"
+        );
+        expect(dataAttributes).toEqual({ "data-merchant-id": "123,456,789" });
+    });
 });
 
 describe("findScript()", () => {

--- a/types/index.d.test.ts
+++ b/types/index.d.test.ts
@@ -20,6 +20,9 @@ loadScript({ "client-id": "test" })
         paypal.Buttons().render("#container");
         paypal.Buttons().render(document.createElement("div"));
 
+        // window.paypal also works
+        window.paypal.Buttons().render("#container");
+
         // minimal createOrder and onApprove payload
         paypal.Buttons({
             createOrder: (data, actions) => {
@@ -160,7 +163,9 @@ loadScript({ "client-id": "test", "data-namespace": "customName" }).then(
         customObject.Buttons();
 
         // example showing how to use the types with a custom namespace off window
-        const customObjectFromWindow = window.customName as PayPalNamespace;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const customObjectFromWindow = (window as any)
+            .customName as PayPalNamespace;
         customObjectFromWindow.Buttons();
     }
 );

--- a/types/script-options.d.ts
+++ b/types/script-options.d.ts
@@ -1,6 +1,6 @@
 interface PayPalScriptQueryParameters {
     "client-id": string;
-    "merchant-id"?: string;
+    "merchant-id"?: string[] | string;
     currency?: string;
     intent?: string;
     commit?: boolean;
@@ -28,6 +28,7 @@ interface PayPalScriptDataAttributes {
 export interface PayPalScriptOptions
     extends PayPalScriptQueryParameters,
         PayPalScriptDataAttributes {
-    [key: string]: string | boolean | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
     sdkBaseURL?: string;
 }

--- a/types/script-options.d.ts
+++ b/types/script-options.d.ts
@@ -1,5 +1,7 @@
 interface PayPalScriptQueryParameters {
     "client-id": string;
+    // loadScript() supports an array and will convert it
+    // to the correct merchant-id and data-merchant-id string values
     "merchant-id"?: string[] | string;
     currency?: string;
     intent?: string;


### PR DESCRIPTION
This PR makes it easier to pass merchant-id values. Now you can pass an array of merchant ids and `loadScript` takes care of setting merchant-id and data-merchant-id to the correct values.

Usage
```js
// multipl merchant-id values
loadScript({ "client-id": "test", "merchant-id": ["123", "456", "789"] });
// <script src="https://www.paypal.com/sdk/js?client-id=test&merchant-id=*" data-merchant-id="123,456,789"></script>

// single merchant-id value
loadScript({ "client-id": "test", "merchant-id": ["123"] });
// <script src="https://www.paypal.com/sdk/js?client-id=test&merchant-id=123"></script>
```