### PR TITLE
fix: ignore data-uid-auto attribute in findScript

### DIFF
--- a/e2e-tests/load-cached-script/index.html
+++ b/e2e-tests/load-cached-script/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>Load Cached Script | PayPal JS</title>
+    </head>
+    <body>
+        <h1>Load Cached Script</h1>
+
+        <script type="module">
+            import { loadScript } from "../../dist/paypal.esm.js";
+
+            const options = {
+                "client-id": "test",
+                "data-order-id": "12345",
+            };
+
+            // initial load and render
+            loadScript(options).then((paypal) => {
+                window.currentPayPalButton = paypal.Buttons();
+
+                window.currentPayPalButton
+                    .render("#paypal-buttons")
+                    .catch((err) => {
+                        // ignore any render errors when reloading
+                    });
+            });
+
+            document
+                .querySelector("#btn-reload")
+                .addEventListener("click", (event) => {
+                    // this should not reload the script since the options have not changed
+                    const colors = ["gold", "blue", "black"];
+                    loadScript(options).then((paypal) => {
+                        if (
+                            window.currentPayPalButton &&
+                            window.currentPayPalButton.close
+                        ) {
+                            window.currentPayPalButton.close().then((err) => {
+                                // ignore errors when closing
+                            });
+                        }
+
+                        const color =
+                            colors[Math.floor(Math.random() * colors.length)];
+
+                        window.currentPayPalButton = paypal.Buttons({
+                            style: { color },
+                        });
+
+                        window.currentPayPalButton
+                            .render("#paypal-buttons")
+                            .catch((err) => {
+                                // ignore any render errors when reloading
+                            });
+                    });
+                });
+        </script>
+
+        <button id="btn-reload" type="button">Reload Script</button>
+        <br />
+
+        <div id="paypal-buttons"></div>
+    </body>
+</html>

--- a/e2e-tests/load-cached-script/index.test.js
+++ b/e2e-tests/load-cached-script/index.test.js
@@ -1,0 +1,55 @@
+import { baseURL } from "../test-helper";
+
+describe("Load cached script", () => {
+    beforeEach(async () => {
+        await Promise.all([
+            page.goto(`${baseURL}/e2e-tests/load-cached-script/index.html`, {
+                waitUntil: "networkidle2",
+            }),
+            page.waitForResponse((response) =>
+                response.url().startsWith("https://www.paypal.com/sdk/js")
+            ),
+            page.waitForResponse((response) =>
+                response
+                    .url()
+                    .startsWith("https://www.sandbox.paypal.com/smart/buttons")
+            ),
+        ]);
+    });
+
+    it("should return the expected page <title>", async () => {
+        const pageTitle = await page.title();
+        expect(pageTitle).toBe("Load Cached Script | PayPal JS");
+    });
+
+    it("should not reload the script when the loadScript options have not changed", async () => {
+        const scriptElement = await page.$(
+            'script[src^="https://www.paypal.com/sdk/js"]'
+        );
+        const scriptUID = await page.evaluate(
+            (el) => el.getAttribute("data-uid-auto"),
+            scriptElement
+        );
+
+        const reloadButton = await page.evaluateHandle(() =>
+            document.querySelector("#btn-reload")
+        );
+        await reloadButton.click();
+
+        await page.waitForResponse((response) =>
+            response
+                .url()
+                .startsWith("https://www.sandbox.paypal.com/smart/buttons")
+        );
+
+        const latestScriptElement = await page.$(
+            'script[src^="https://www.paypal.com/sdk/js"]'
+        );
+        const latestScriptUID = await page.evaluate(
+            (el) => el.getAttribute("data-uid-auto"),
+            latestScriptElement
+        );
+
+        expect(latestScriptUID).toBe(scriptUID);
+    });
+});

--- a/e2e-tests/reload-script/index.html
+++ b/e2e-tests/reload-script/index.html
@@ -9,26 +9,28 @@
 
         <script type="module">
             import { loadScript } from "../../dist/paypal.esm.js";
-            window.paypalLoadScript = function (currency) {
-                const options = {
-                    "client-id": "test",
-                    "data-order-id": "12345",
-                    currency,
-                };
 
-                loadScript(options).then((paypal) => {
-                    paypal.Buttons().render("#paypal-buttons");
-                });
+            const options = {
+                "client-id": "test",
+                "data-order-id": "12345",
+                currency: document.querySelector("#currency").value,
             };
 
-            const currentCurrency = document.querySelector("#currency").value;
-            paypalLoadScript(currentCurrency);
+            // initial load and render
+            loadScript(options).then((paypal) => {
+                paypal.Buttons().render("#paypal-buttons");
+            });
 
             document
                 .querySelector("#currency")
                 .addEventListener("change", (event) => {
-                    const newCurrency = event.target.value;
-                    paypalLoadScript(newCurrency);
+                    // reload and render with new currency
+                    loadScript({
+                        ...options,
+                        currency: event.target.value,
+                    }).then((paypal) => {
+                        paypal.Buttons().render("#paypal-buttons");
+                    });
                 });
         </script>
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -107,7 +107,7 @@ describe("findScript()", () => {
 
     test("finds the existing script in the DOM", () => {
         const url = "https://www.paypal.com/sdk/js?client-id=test";
-        document.head.innerHTML = `<script src="${url}" data-order-id="123" data-page-type="checkout"></script>`;
+        document.head.innerHTML = `<script src="${url}" data-order-id="123" data-page-type="checkout" data-uid-auto="81376a99ff_mdm6mji6mzg"></script>`;
 
         const result = findScript(url, {
             "data-page-type": "checkout",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,9 +13,13 @@ export function findScript(
 
     const nextScript = createScriptElement(url, attributes);
 
+    // ignore the data-uid-auto attribute that gets auto-assigned to every script tag
+    const currentScriptDataset = Object.assign({}, currentScript.dataset);
+    delete currentScriptDataset.uidAuto;
+
     // check if the new script has the same number of data attributes
     if (
-        Object.keys(currentScript.dataset).length !==
+        Object.keys(currentScriptDataset).length !==
         Object.keys(nextScript.dataset).length
     ) {
         return null;
@@ -24,8 +28,8 @@ export function findScript(
     let isExactMatch = true;
 
     // check if the data attribute values are the same
-    Object.keys(currentScript.dataset).forEach((key) => {
-        if (currentScript.dataset[key] !== nextScript.dataset[key]) {
+    Object.keys(currentScriptDataset).forEach((key) => {
+        if (currentScriptDataset[key] !== nextScript.dataset[key]) {
             isExactMatch = false;
         }
     });


### PR DESCRIPTION
The `loadScript()` function is designed to prevent unnecessary fetching of the JS SDK script if it's already been loaded with the exact params and data attributes. This logic was also picking up the data-uid-auto attribute which would prevent the matching logic from returning true. This PR fixes the issue by removing this attribute. It also adds tests to cover this use case.