### PR TITLE
Added HostedFields to interface PayPalNamespace

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,6 +15,7 @@ import type { getFundingSources } from "./components/funding-eligibility";
 
 export interface PayPalNamespace {
     Buttons?: (options?: PayPalButtonsComponentProps) => PayPalButtonsComponent;
+    HostedFields?: (options?: PayPalButtonsComponentProps) => PayPalButtonsComponent;
     Marks?: (options?: PayPalMarksComponentProps) => PayPalMarksComponent;
     Messages?: (
         options?: PayPalMessagesComponentProps


### PR DESCRIPTION
HostedFields will be required for <PayPalHostedFields>

Issue: https://github.com/paypal/react-paypal-js/issues/49

This addition also depends on two types, that will need to be created.