### PR TITLE
OrderApplicationContext fields should be optional

### DIFF
--- a/types/apis/orders.d.ts
+++ b/types/apis/orders.d.ts
@@ -96,15 +96,15 @@ type PurchaseUnit = {
 };
 
 type OrderApplicationContext = {
-    brand_name: string;
-    locale: string;
-    landing_page: "LOGIN" | "BILLING" | "NO_PREFERENCE";
-    shipping_preference: SHIPPING_PREFERENCE;
-    user_action: "CONTINUE" | "PAY_NOW";
-    payment_method: Record<string, unknown>;
-    return_url: string;
-    cancel_url: string;
-    stored_payment_source: Record<string, unknown>;
+    brand_name?: string;
+    locale?: string;
+    landing_page?: "LOGIN" | "BILLING" | "NO_PREFERENCE";
+    shipping_preference?: SHIPPING_PREFERENCE;
+    user_action?: "CONTINUE" | "PAY_NOW";
+    payment_method?: Record<string, unknown>;
+    return_url?: string;
+    cancel_url?: string;
+    stored_payment_source?: Record<string, unknown>;
 };
 
 type LinkDescription = {


### PR DESCRIPTION
Hi,

I believe that all OrderApplicationContext fields should be optional. This object is optional and its fields should be also not required (https://developer.paypal.com/docs/api/orders/v2/#definition-order_application_context)

If it's not then we can't create a PayPal order with for example just this option configured: shipping_preference: 'NO_SHIPPING',

```
const createOrder = (data: UnknownObject, actions: CreateOrderActions) => {
    return actions.order
      .create({
        intent: 'CAPTURE',
        application_context: {                                         // here will be error that's additional fields needs to be given
          shipping_preference: 'NO_SHIPPING',
        },
        purchase_units: [
          {
            description: purchaseDescription,
            amount: {
              value: price,
              currency_code: currencyCode,
            },
          },
        ],
      })
      .then((orderID: string) => {
         ...
      });
  };
```

