### PR TITLE
Types for hosted fields component

### DIFF
--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -1,0 +1,31 @@
+import type { CreateOrderRequestBody } from "../apis/orders";
+
+type UnknownObject = Record<string, unknown>;
+
+export type CreateOrderActions = {
+    order: {
+        create: (options: CreateOrderRequestBody) => Promise<string>;
+    };
+};
+
+export interface PayPalHostedFieldsComponentOptions {
+    createOrder?: (
+        data: UnknownObject,
+        actions: CreateOrderActions
+    ) => Promise<string>;
+    onError?: (err: UnknownObject) => void;
+    styles?: UnknownObject;
+    fields?: UnknownObject;
+}
+
+export interface HostedFieldsHandler {
+    submit: (options?: UnknownObject) => Promise<void>;
+    getCardTypes: () => UnknownObject;
+}
+
+export interface PayPalHostedFieldsComponent {
+    isEligible: () => boolean;
+    render: (
+        options: PayPalHostedFieldsComponentOptions
+    ) => Promise<HostedFieldsHandler>;
+}

--- a/types/index.d.test.ts
+++ b/types/index.d.test.ts
@@ -174,3 +174,56 @@ loadScript({ "client-id": "test", "data-namespace": "customName" }).then(
         customObjectFromWindow.Buttons();
     }
 );
+
+// hosted-fields
+// https://developer.paypal.com/docs/business/checkout/advanced-card-payments/
+loadScript({
+    "client-id": "test",
+    components: "buttons,hosted-fields",
+    "data-client-token": "123456789",
+}).then((paypal) => {
+    if (paypal.HostedFields.isEligible() === false) return;
+
+    paypal.HostedFields.render({
+        createOrder: (data, actions) => {
+            return actions.order.create({
+                purchase_units: [
+                    {
+                        amount: {
+                            value: "1.00",
+                        },
+                    },
+                ],
+            });
+        },
+        styles: {
+            ".valid": {
+                color: "green",
+            },
+            ".invalid": {
+                color: "red",
+            },
+        },
+        fields: {
+            number: {
+                selector: "#card-number",
+                placeholder: "4111 1111 1111 1111",
+            },
+            cvv: {
+                selector: "#cvv",
+                placeholder: "123",
+            },
+            expirationDate: {
+                selector: "#expiration-date",
+                placeholder: "MM/YY",
+            },
+        },
+    }).then((cardFields) => {
+        document
+            .querySelector("#card-form")
+            .addEventListener("submit", (event) => {
+                event.preventDefault();
+                cardFields.submit({});
+            });
+    });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,6 +16,7 @@ import type {
     isFundingEligible,
     rememberFunding,
 } from "./components/funding-eligibility";
+import type { PayPalHostedFieldsComponent } from "./components/hosted-fields";
 
 export interface PayPalNamespace {
     Buttons?: (options?: PayPalButtonsComponentProps) => PayPalButtonsComponent;
@@ -23,6 +24,7 @@ export interface PayPalNamespace {
     Messages?: (
         options?: PayPalMessagesComponentProps
     ) => PayPalMessagesComponent;
+    HostedFields?: PayPalHostedFieldsComponent;
     getFundingSources?: getFundingSources;
     isFundingEligible?: isFundingEligible;
     rememberFunding?: rememberFunding;


### PR DESCRIPTION
This PR adds some basic types for the hosted fields component. It builds off of #66. 

Types for `fields`, `styles`, and `cardFields` props are currently typed as unknown objects so there's still work to do here. This PR does enable hosted-fields to work without throwing type errors.