### PR TITLE
fix: override tsconfig target in legacy build

### DIFF
--- a/e2e-tests/bundle/bundle-size.test.js
+++ b/e2e-tests/bundle/bundle-size.test.js
@@ -2,7 +2,7 @@ import filesize from "filesize";
 import fs from "fs";
 
 const maxBundleSizeInKiloBytes = 3.7;
-const maxLegacyBundleSizeInKiloBytes = 6.8;
+const maxLegacyBundleSizeInKiloBytes = 6.89;
 
 describe("bundle size", () => {
     it(`paypal.browser.min.js should be less than ${maxBundleSizeInKiloBytes} KB`, () => {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,10 @@ const outputConfigForBrowserBundle = {
         "window.paypalLoadCustomScript = paypalLoadScript.loadCustomScript;" +
         "\nwindow.paypalLoadScript = paypalLoadScript.loadScript;",
 };
-const tsconfigOverride = { exclude: ["node_modules", "**/*.test.ts"] };
+const tsconfigOverride = {
+    exclude: ["node_modules", "**/*.test.ts"],
+    target: "es5",
+};
 
 export default [
     {
@@ -60,7 +63,7 @@ export default [
     {
         input: "src/legacy/index.ts",
         plugins: [
-            typescript({ ...tsconfigOverride, target: "es5" }),
+            typescript({ ...tsconfigOverride }),
             nodeResolve({
                 browser: true,
             }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -60,7 +60,7 @@ export default [
     {
         input: "src/legacy/index.ts",
         plugins: [
-            typescript({ ...tsconfigOverride }),
+            typescript({ ...tsconfigOverride, target: "es5" }),
             nodeResolve({
                 browser: true,
             }),


### PR DESCRIPTION
The legacy paypal-js library, which supposedly should work on IE11, does not compile to ES5.
This overrides the `target: "esnext"` in `tsconfig.json`