### PR TITLE
improve buttons params documentation

### DIFF
--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -58,14 +58,14 @@ export interface PayPalButtonsComponentOptions {
      */
     createBillingAgreement?: () => Promise<string>;
     /**
-     * Called on button click. Supports creating an order with the [/v2/checkout/orders api](https://developer.paypal.com/docs/api/orders/v2/#orders_create).
+     * Called on button click to set up a one-time payment. [createOrder docs](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#createorder).
      */
     createOrder?: (
         data: UnknownObject,
         actions: CreateOrderActions
     ) => Promise<string>;
     /**
-     * Called on button click. Supports creating a subscription with the [/v1/billing/subscription api](https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_create).
+     * Called on button click to set up a recurring payment. [createSubscription docs](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#createsubscription).
      */
     createSubscription?: (
         data: UnknownObject,
@@ -77,7 +77,7 @@ export interface PayPalButtonsComponentOptions {
      */
     fundingSource?: string;
     /**
-     * Called when finalizing the transaction. Supports capturing an order with the [v2/checkout/orders/:order_id/capture api](https://developer.paypal.com/docs/api/orders/v2/#orders_capture).
+     * Called when finalizing the transaction. Often used to inform the buyer that the transaction is complete. [onApprove docs](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#onapprove).
      */
     onApprove?: (
         data: OnApproveData,


### PR DESCRIPTION
# Description 

- The current links on `createOrder` , `createSubscription` and `onApprove` methods reference on [React PayPal JS StoryBook documentation](https://paypal.github.io/react-paypal-js/?path=/docs/example-paypalbuttons--default) points to the [API Reference page](https://developer.paypal.com/docs/api/orders/v2/), however, such resource does not provide enough information about how to use the mentioned methods, but how they work internally. That's why this PR updates such links to point at the [JavaScript SDK references](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference) which has more complete information about how to use them properly and how to handle their params.

