### PR TITLE
Fix problem in HostedFields.createOrder argument types

### DIFF
--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -9,10 +9,7 @@ export type CreateOrderActions = {
 };
 
 export interface PayPalHostedFieldsComponentOptions {
-    createOrder?: (
-        data: UnknownObject,
-        actions: CreateOrderActions
-    ) => Promise<string>;
+    createOrder: () => Promise<string>;
     onError?: (err: UnknownObject) => void;
     styles?: UnknownObject;
     fields?: UnknownObject;

--- a/types/index.d.test.ts
+++ b/types/index.d.test.ts
@@ -221,12 +221,8 @@ loadScript({
 
     paypal.HostedFields.render({
         createOrder: () => {
-            // Call your server paypa order
-            return fetch('/your-server/paypal/order', {
-                method: 'post'
-              }).then(function(res) {
-                  return res.json();
-              }).then(orderData => orderData.id); 
+            // Call your server to create the order
+            return Promise.resolve("7632736476738");
         },
         styles: {
             ".valid": {

--- a/types/index.d.test.ts
+++ b/types/index.d.test.ts
@@ -220,16 +220,13 @@ loadScript({
     if (paypal.HostedFields.isEligible() === false) return;
 
     paypal.HostedFields.render({
-        createOrder: (data, actions) => {
-            return actions.order.create({
-                purchase_units: [
-                    {
-                        amount: {
-                            value: "1.00",
-                        },
-                    },
-                ],
-            });
+        createOrder: () => {
+            // Call your server paypa order
+            return fetch('/your-server/paypal/order', {
+                method: 'post'
+              }).then(function(res) {
+                  return res.json();
+              }).then(orderData => orderData.id); 
         },
         styles: {
             ".valid": {


### PR DESCRIPTION
The HostedFields.createOrder function is required and doesn't received any arguments from the callback. 
The user needs to handle the order creation process manually.

In this PR we fix those issues.