### PR TITLE
Support return type on hostedFields submit method

### DIFF
--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -17,10 +17,10 @@ export interface PayPalHostedFieldsComponentOptions {
 
 export interface HostedFieldsPaymentMethodValidated {
     orderId: string;
-    liabilityShift: unknown;
-    liabilityShifted: unknown;
-    authenticationReason: unknown;
-    authenticationStatus: unknown;
+    liabilityShift: string;
+    liabilityShifted: boolean;
+    authenticationReason: string;
+    authenticationStatus: string;
     card: {
         brand: string;
         card_type: string;

--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -15,7 +15,7 @@ export interface PayPalHostedFieldsComponentOptions {
     fields?: UnknownObject;
 }
 
-export interface HostedFieldsPaymentMethodValidated {
+export interface HostedFieldsPaymentMethodResponse {
     orderId: string;
     liabilityShift: string;
     liabilityShifted: boolean;
@@ -30,7 +30,7 @@ export interface HostedFieldsPaymentMethodValidated {
 }
 
 export interface HostedFieldsHandler {
-    submit: (options?: UnknownObject) => Promise<HostedFieldsPaymentMethodValidated>;
+    submit: (options?: UnknownObject) => Promise<HostedFieldsPaymentMethodResponse>;
     getCardTypes: () => UnknownObject;
 }
 

--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -17,10 +17,10 @@ export interface PayPalHostedFieldsComponentOptions {
 
 export interface HostedFieldsSubmitResponse {
     orderId: string;
-    liabilityShift: string;
-    liabilityShifted: boolean;
-    authenticationReason: string;
-    authenticationStatus: string;
+    liabilityShift?: string;
+    liabilityShifted?: boolean;
+    authenticationReason?: string;
+    authenticationStatus?: string;
     card: {
         brand: string;
         card_type: string;

--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -15,7 +15,7 @@ export interface PayPalHostedFieldsComponentOptions {
     fields?: UnknownObject;
 }
 
-export interface HostedFieldsPaymentMethodResponse {
+export interface HostedFieldsSubmitResponse {
     orderId: string;
     liabilityShift: string;
     liabilityShifted: boolean;
@@ -30,7 +30,7 @@ export interface HostedFieldsPaymentMethodResponse {
 }
 
 export interface HostedFieldsHandler {
-    submit: (options?: UnknownObject) => Promise<HostedFieldsPaymentMethodResponse>;
+    submit: (options?: UnknownObject) => Promise<HostedFieldsSubmitResponse>;
     getCardTypes: () => UnknownObject;
 }
 

--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -15,8 +15,22 @@ export interface PayPalHostedFieldsComponentOptions {
     fields?: UnknownObject;
 }
 
+export interface HostedFieldsPaymentMethodValidated {
+    orderId: string;
+    liabilityShift: unknown;
+    liabilityShifted: unknown;
+    authenticationReason: unknown;
+    authenticationStatus: unknown;
+    card: {
+        brand: string;
+        card_type: string;
+        last_digits: string;
+        type: string;
+    }
+}
+
 export interface HostedFieldsHandler {
-    submit: (options?: UnknownObject) => Promise<void>;
+    submit: (options?: UnknownObject) => Promise<HostedFieldsPaymentMethodValidated>;
     getCardTypes: () => UnknownObject;
 }
 


### PR DESCRIPTION
The hosted-fields.d.ts declare a HostedFieldsHandler.submit function returning a Promise<void>.

In this PR we fix the return type, because the submit return an object containing valuable information to use after the payment was validated.