### PR TITLE
docs: separate out catch for render() errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ try {
 
 if (paypal) {
     try {
-        paypal.Buttons().render("#your-container-element");
+        await paypal.Buttons().render("#your-container-element");
     } catch (error) {
         console.error("failed to render the PayPal Buttons", error);
     }

--- a/README.md
+++ b/README.md
@@ -61,12 +61,20 @@ Import the `loadScript` function for asynchronously loading the Paypal JS SDK.
 ```js
 import { loadScript } from "@paypal/paypal-js";
 
-try {
-    const paypal = await loadScript({ "client-id": "test" });
+let paypal;
 
-    paypal.Buttons().render("#your-container-element");
+try {
+    paypal = await loadScript({ "client-id": "test" });
 } catch (error) {
     console.error("failed to load the PayPal JS SDK script", error);
+}
+
+if (paypal) {
+    try {
+        paypal.Buttons().render("#your-container-element");
+    } catch (error) {
+        console.error("failed to render the PayPal Buttons", error);
+    }
 }
 ```
 
@@ -77,10 +85,15 @@ import { loadScript } from "@paypal/paypal-js";
 
 loadScript({ "client-id": "test" })
     .then((paypal) => {
-        paypal.Buttons().render("#your-container-element");
+        paypal
+            .Buttons()
+            .render("#your-container-element")
+            .catch((error) => {
+                console.error("failed to render the PayPal Buttons", error);
+            });
     })
-    .catch((err) => {
-        console.error("failed to load the PayPal JS SDK script", err);
+    .catch((error) => {
+        console.error("failed to load the PayPal JS SDK script", error);
     });
 ```
 


### PR DESCRIPTION
I was dreaming about JS error handling and realized we should recommend a separate error handler for `render()` calls since that also returns a promise. 

Here's the reference to the zoid types for `render()` and `renderTo()` which we use in the sdk: https://github.com/krakenjs/zoid/blob/master/src/component/component.js#L138-L139. The render returns a Promise because it needs to get acknowledgement from the iframe window within a certain time period.