### PR TITLE
Enhance 400 error messages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,6 @@
         "semi": ["error", "always"]
     },
     "settings": {
-        "polyfills": ["Promise"]
+        "polyfills": ["Promise", "fetch"]
     }
 }

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -186,7 +186,7 @@ describe("loadCustomScript()", () => {
         */`;
         window.fetch = jest.fn().mockResolvedValue({
             status: 400,
-            text: () => Promise.resolve(serverMessage),
+            text: jest.fn().mockResolvedValue(serverMessage),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
@@ -197,9 +197,8 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { message } = err as Record<string, string>;
 
-            expect(message).toBe(errorMessage);
+            expect(err).toBe(errorMessage);
         }
     });
 
@@ -214,7 +213,7 @@ describe("loadCustomScript()", () => {
         */`;
         window.fetch = jest.fn().mockResolvedValue({
             status: 400,
-            text: () => Promise.resolve(serverMessage),
+            text: jest.fn().mockResolvedValue(serverMessage),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
@@ -225,9 +224,8 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { message } = err as Record<string, string>;
 
-            expect(message).toBe(errorMessage);
+            expect(err).toBe(errorMessage);
         }
     });
 
@@ -242,7 +240,7 @@ describe("loadCustomScript()", () => {
         */`;
         window.fetch = jest.fn().mockResolvedValue({
             status: 400,
-            text: () => Promise.resolve(serverMessage),
+            text: jest.fn().mockResolvedValue(serverMessage),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
@@ -253,17 +251,16 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { message } = err as Record<string, string>;
 
-            expect(message).toBe(errorMessage);
+            expect(err).toBe(errorMessage);
         }
     });
 
     test("should throw an error when the script fails to load catching an unexpected behavior", async () => {
         // eslint-disable-next-line compat/compat
-        window.fetch = jest.fn().mockRejectedValue({
+        window.fetch = jest.fn().mockResolvedValue({
             status: 500,
-            text: () => Promise.resolve("throw new Error()"),
+            text: jest.fn().mockRejectedValue("throw new Error()"),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -175,8 +175,9 @@ describe("loadCustomScript()", () => {
     });
 
     test("should throw an error when the script fails to load taking the response message", async () => {
-        const errorMessage = `
-        throw new Error("SDK Validation error: 'Expected client-id to be passed'" );
+        const errorMessage = "SDK Validation error: 'Expected client-id to be passed'";
+        const serverMessage = `
+        throw new Error("${errorMessage}");
     
         /* Original Error:
     
@@ -185,7 +186,7 @@ describe("loadCustomScript()", () => {
         */`;
         window.fetch = jest.fn().mockResolvedValue({
             status: 400,
-            text: () => Promise.resolve(errorMessage)
+            text: () => Promise.resolve(serverMessage),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
@@ -196,16 +197,15 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { message } = err as Record<string, string >;
+            const { message } = err as Record<string, string>;
 
-            expect(message).toBe(
-                errorMessage
-            );
+            expect(message).toBe(errorMessage);
         }
     });
 
     test("should throw an error when the script fails to load because invalid client-id", async () => {
-        const errorMessage = `throw new Error("SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'" );
+        const errorMessage = "SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'";
+        const serverMessage = `throw new Error("${errorMessage}");
 
         /* Original Error:
         
@@ -214,7 +214,7 @@ describe("loadCustomScript()", () => {
         */`;
         window.fetch = jest.fn().mockResolvedValue({
             status: 400,
-            text: () => Promise.resolve(errorMessage)
+            text: () => Promise.resolve(serverMessage),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
@@ -235,7 +235,7 @@ describe("loadCustomScript()", () => {
         // eslint-disable-next-line compat/compat
         window.fetch = jest.fn().mockRejectedValue({
             status: 500,
-            text: () => Promise.resolve("throw new Error()")
+            text: () => Promise.resolve("throw new Error()"),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -282,29 +282,6 @@ describe("loadCustomScript()", () => {
         }
     });
 
-    test("should throw an error when the script fails to load and server response is unavailable", async () => {
-        // eslint-disable-next-line compat/compat
-        window.fetch = jest.fn().mockResolvedValue({
-            status: 503,
-            text: jest.fn().mockRejectedValue("Service unavailable"),
-        });
-
-        insertScriptElementSpy.mockImplementation(({ onError }) => {
-            process.nextTick(() => onError && onError("failed to load"));
-        });
-
-        try {
-            await loadCustomScript({ url: "https://www.example.com/index.js" });
-        } catch (err) {
-            expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { message } = err as Record<string, string>;
-
-            expect(message).toBe(
-                'The script "https://www.example.com/index.js" failed to load.'
-            );
-        }
-    });
-
     test("should use the provided promise ponyfill", () => {
         const PromisePonyfill = jest.fn(() => {
             return {

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -201,7 +201,7 @@ describe("loadCustomScript()", () => {
         }
     });
 
-    test.only("should throw an error when the script fails to load because invalid client-id", async () => {
+    test("should throw an error when the script fails to load because invalid client-id", async () => {
         const errorMessage = "SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'";
         const serverMessage = `throw new Error("${errorMessage}");
 

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -201,7 +201,7 @@ describe("loadCustomScript()", () => {
         }
     });
 
-    test("should throw an error when the script fails to load because invalid client-id", async () => {
+    test.only("should throw an error when the script fails to load because invalid client-id", async () => {
         const errorMessage = "SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'";
         const serverMessage = `throw new Error("${errorMessage}");
 

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -175,13 +175,14 @@ describe("loadCustomScript()", () => {
     });
 
     test("should throw an error when the script fails to load taking the response message", async () => {
-        const errorMessage = "SDK Validation error: 'Expected client-id to be passed'";
+        const errorMessage =
+            "Expected client-id to be passed (debug id: f124435555fb3)";
         const serverMessage = `
-        throw new Error("${errorMessage}");
+        throw new Error("SDK Validation error: 'Expected client-id to be passed'");
     
         /* Original Error:
     
-        Expected client-id to be passed (debug id: f124435555fb3)
+        ${errorMessage}
     
         */`;
         window.fetch = jest.fn().mockResolvedValue({
@@ -204,12 +205,13 @@ describe("loadCustomScript()", () => {
     });
 
     test("should throw an error when the script fails to load because invalid client-id", async () => {
-        const errorMessage = "SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'";
-        const serverMessage = `throw new Error("${errorMessage}");
+        const errorMessage =
+            "client-id not recognized for either production or sandbox: djhhjfg (debug id: ab31131130723)";
+        const serverMessage = `throw new Error("SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'");
 
         /* Original Error:
         
-        client-id not recognized for either production or sandbox: djhhjfg (debug id: ab31131130723)
+        ${errorMessage}
         
         */`;
         window.fetch = jest.fn().mockResolvedValue({
@@ -232,12 +234,13 @@ describe("loadCustomScript()", () => {
     });
 
     test("should throw an error when the script fails to load and server response is a plain string", async () => {
-        const errorMessage = "SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'";
-        const serverMessage = `return "${errorMessage}";
+        const errorMessage =
+            "This is a custom error message: djhhjfg (debug id: ab31131130723)";
+        const serverMessage = `Random text here we do not process it: 'This text is ignore'";
 
         /* Original Error:
         
-        client-id not recognized for either production or sandbox: djhhjfg (debug id: ab31131130723)
+        ${errorMessage}
         
         */`;
         window.fetch = jest.fn().mockResolvedValue({
@@ -263,7 +266,7 @@ describe("loadCustomScript()", () => {
         // eslint-disable-next-line compat/compat
         window.fetch = jest.fn().mockResolvedValue({
             status: 500,
-            text: jest.fn().mockRejectedValue("Internal Server Error"),
+            text: jest.fn().mockResolvedValue("Internal Server Error"),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
@@ -276,9 +279,7 @@ describe("loadCustomScript()", () => {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
             const { message } = err as Record<string, string>;
 
-            expect(message).toBe(
-                'The script "https://www.example.com/index.js" failed to load.'
-            );
+            expect(message).toBe("Internal Server Error");
         }
     });
 

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -166,7 +166,7 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { errorMessage: { message } } = err as Record<string, { message: string }>;
+            const { message } = err as Record<string, string>;
 
             expect(message).toBe(
                 'The script "https://www.example.com/index.js" failed to load.'
@@ -196,7 +196,7 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { errorMessage: { message } } = err as Record<string, { message: string }>;
+            const { message } = err as Record<string, string >;
 
             expect(message).toBe(
                 errorMessage
@@ -225,7 +225,7 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { errorMessage: { message } } = err as Record<string, { message: string }>;
+            const { message } = err as Record<string, string>;
 
             expect(message).toBe(errorMessage);
         }
@@ -246,7 +246,7 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { errorMessage: { message } } = err as Record<string, { message: string }>;
+            const { message } = err as Record<string, string>;
 
             expect(message).toBe(
                 'The script "https://www.example.com/index.js" failed to load.'

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -166,9 +166,8 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { message } = err as Record<string, string>;
 
-            expect(message).toBe(
+            expect(err).toBe(
                 'The script "https://www.example.com/index.js" failed to load.'
             );
         }
@@ -260,7 +259,7 @@ describe("loadCustomScript()", () => {
         // eslint-disable-next-line compat/compat
         window.fetch = jest.fn().mockResolvedValue({
             status: 500,
-            text: jest.fn().mockRejectedValue("throw new Error()"),
+            text: jest.fn().mockRejectedValue("new Error('Random Error')"),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
@@ -271,9 +270,8 @@ describe("loadCustomScript()", () => {
             await loadCustomScript({ url: "https://www.example.com/index.js" });
         } catch (err) {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
-            const { message } = err as Record<string, string>;
 
-            expect(message).toBe(
+            expect(err).toBe(
                 'The script "https://www.example.com/index.js" failed to load.'
             );
         }

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -175,16 +175,17 @@ describe("loadCustomScript()", () => {
     });
 
     test("should throw an error when the script fails to load taking the response message", async () => {
+        const errorMessage = `
+        throw new Error("SDK Validation error: 'Expected client-id to be passed'" );
+    
+        /* Original Error:
+    
+        Expected client-id to be passed (debug id: f124435555fb3)
+    
+        */`;
         window.fetch = jest.fn().mockResolvedValue({
             status: 400,
-            text: () => Promise.resolve(`
-                throw new Error("SDK Validation error: 'Expected client-id to be passed'" );
-            
-                /* Original Error:
-            
-                Expected client-id to be passed (debug id: f124435555fb3)
-            
-                */`)
+            text: () => Promise.resolve(errorMessage)
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
@@ -198,22 +199,22 @@ describe("loadCustomScript()", () => {
             const { errorMessage: { message } } = err as Record<string, { message: string }>;
 
             expect(message).toBe(
-                "SDK Validation error: 'Expected client-id to be passed'"
+                errorMessage
             );
         }
     });
 
     test("should throw an error when the script fails to load because invalid client-id", async () => {
+        const errorMessage = `throw new Error("SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'" );
+
+        /* Original Error:
+        
+        client-id not recognized for either production or sandbox: djhhjfg (debug id: ab31131130723)
+        
+        */`;
         window.fetch = jest.fn().mockResolvedValue({
             status: 400,
-            text: () => Promise.resolve(`
-                throw new Error("SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'" );
-
-                /* Original Error:
-                
-                client-id not recognized for either production or sandbox: djhhjfg (debug id: ab31131130723)
-                
-                */`)
+            text: () => Promise.resolve(errorMessage)
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
@@ -226,9 +227,7 @@ describe("loadCustomScript()", () => {
             expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
             const { errorMessage: { message } } = err as Record<string, { message: string }>;
 
-            expect(message).toBe(
-                "SDK Validation error: 'client-id not recognized for either production or sandbox: djhhjfg'"
-            );
+            expect(message).toBe(errorMessage);
         }
     });
 
@@ -236,14 +235,7 @@ describe("loadCustomScript()", () => {
         // eslint-disable-next-line compat/compat
         window.fetch = jest.fn().mockRejectedValue({
             status: 500,
-            text: () => Promise.resolve(`
-                throw new Error("SDK Validation error: 'Expected client-id to be passed'" );
-            
-                /* Original Error:
-            
-                Expected client-id to be passed (debug id: f124435555fb3)
-            
-                */`)
+            text: () => Promise.resolve("throw new Error()")
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {

--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -261,7 +261,10 @@ describe("loadCustomScript()", () => {
 
     test("should throw an error when the script fails to load and fail fetching the error message", async () => {
         // eslint-disable-next-line compat/compat
-        window.fetch = jest.fn().mockRejectedValue("Internal Server Error");
+        window.fetch = jest.fn().mockResolvedValue({
+            status: 500,
+            text: jest.fn().mockRejectedValue("Internal Server Error"),
+        });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {
             process.nextTick(() => onError && onError("failed to load"));
@@ -279,11 +282,11 @@ describe("loadCustomScript()", () => {
         }
     });
 
-    test("should throw an error when the script fails to load server response is not a text", async () => {
+    test("should throw an error when the script fails to load and server response is unavailable", async () => {
         // eslint-disable-next-line compat/compat
         window.fetch = jest.fn().mockResolvedValue({
-            status: 500,
-            text: jest.fn().mockRejectedValue("throw new Error('Random Error')"),
+            status: 503,
+            text: jest.fn().mockRejectedValue("Service unavailable"),
         });
 
         insertScriptElementSpy.mockImplementation(({ onError }) => {

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -93,10 +93,10 @@ export function loadCustomScript(
                 if (!window.fetch) {
                     return reject(defaultError);
                 }
-                // NOTE: Attempt to fetch() the error reason from the response body
+                // Fetch the error reason from the response body for validation errors
                 return fetch(url)
                     .then((response) => {
-                        // NOTE: Only catch errors from 400 status responses
+                        // Only catch 400 errors
                         if (response.status === 400) {
                             return response.text();
                         }

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -86,7 +86,9 @@ export function loadCustomScript(
             attributes,
             onSuccess: () => resolve(),
             onError: () => {
-                const defaultError = `The script "${url}" failed to load.`;
+                const defaultError = new Error(
+                    `The script "${url}" failed to load.`
+                );
 
                 if (!window.fetch) {
                     return reject(defaultError);
@@ -98,10 +100,16 @@ export function loadCustomScript(
                             ? reject(defaultError)
                             : response.text();
                     })
-                    .then((message) =>
-                        reject(parseErrorMessage(message as string))
-                    )
-                    .catch((err) => reject(err.message || defaultError));
+                    .then((message) => {
+                        const parseMessage = parseErrorMessage(
+                            message as string
+                        ) as string;
+
+                        reject(new Error(parseMessage));
+                    })
+                    .catch((err) =>
+                        reject(err instanceof Error ? err : defaultError)
+                    );
             },
         });
     });

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -93,23 +93,21 @@ export function loadCustomScript(
                 if (!window.fetch) {
                     return reject(defaultError);
                 }
-                // attempt to fetch() the error reason from the response body
+                // NOTE: Attempt to fetch() the error reason from the response body
                 return fetch(url)
-                    .then((response): void | string | Promise<string> => {
-                        return response.status === 200
-                            ? reject(defaultError)
-                            : response.text();
+                    .then((response) => {
+                        // NOTE: Only catch errors from 400 status responses
+                        if (response.status === 400) {
+                            return response.text();
+                        }
+                        throw defaultError;  
                     })
                     .then((message) => {
-                        const parseMessage = parseErrorMessage(
-                            message as string
-                        ) as string;
+                        const parseMessage = parseErrorMessage(message);
 
                         reject(new Error(parseMessage));
                     })
-                    .catch((err) =>
-                        reject(err instanceof Error ? err : defaultError)
-                    );
+                    .catch((err) =>  reject(err));
             },
         });
     });

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -2,7 +2,6 @@ import { findScript, insertScriptElement, processOptions } from "./utils";
 import type { PayPalScriptOptions } from "../types/script-options";
 import type { PayPalNamespace } from "../types/index";
 
-
 /**
  * Load the Paypal JS SDK script asynchronously.
  *
@@ -82,30 +81,24 @@ export function loadCustomScript(
             attributes,
             onSuccess: () => resolve(),
             onError: () => {
-                const defaultError = new Error(`The script "${url}" failed to load.`);
+                const defaultError = new Error(
+                    `The script "${url}" failed to load.`
+                );
 
                 if (!window.fetch) {
-                    return reject({
-                        errorMessage: defaultError
-                    });
+                    return reject(defaultError);
                 }
                 // attempt to fetch() the error reason from the response body
-                return fetch('https://www.paypal.com/sdk/js')
-                    .then(response => {
-                        response.text().then(message => {
-                            return reject({
-                                status: response.status,
-                                errorMessage: new Error(message)
-                            });
-                        });
+                return fetch("https://www.paypal.com/sdk/js")
+                    .then((response) => {
+                        response
+                            .text()
+                            .then((message) => reject(new Error(message)));
                     })
                     .catch(() => {
-                        return reject({
-                            errorMessage: defaultError
-                        });
+                        return reject(defaultError);
                     });
-
-            }
+            },
         });
     });
 }

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -101,9 +101,7 @@ export function loadCustomScript(
                     .then((message) =>
                         reject(parseErrorMessage(message as string))
                     )
-                    .catch((err) => {
-                        reject(err.message || defaultError);
-                    });
+                    .catch((err) => reject(err.message || defaultError));
             },
         });
     });

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -96,18 +96,16 @@ export function loadCustomScript(
                 // Fetch the error reason from the response body for validation errors
                 return fetch(url)
                     .then((response) => {
-                        // Only catch 400 errors
                         if (response.status === 400) {
                             return response.text();
                         }
-                        throw defaultError;  
+                        throw defaultError;
                     })
                     .then((message) => {
                         const parseMessage = parseErrorMessage(message);
-
                         reject(new Error(parseMessage));
                     })
-                    .catch((err) =>  reject(err));
+                    .catch((err) => reject(err));
             },
         });
     });

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -95,21 +95,15 @@ export function loadCustomScript(
                 }
                 // attempt to fetch() the error reason from the response body
                 return fetch(url)
-                    .then((response) => {
-                        response
-                            .text()
-                            .then((message) =>
-                                reject(
-                                    new Error(
-                                        parseErrorMessage(message) as string
-                                    )
-                                )
-                            )
-                            .catch((e) => reject(e));
+                    .then((response): void | string | Promise<string> => {
+                        return response.status === 200
+                            ? reject(defaultError)
+                            : response.text();
                     })
-                    .catch(() => {
-                        return reject(defaultError);
-                    });
+                    .then((message) =>
+                        reject(parseErrorMessage(message as string))
+                    )
+                    .catch((err) => reject(err.message || defaultError));
             },
         });
     });

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -96,16 +96,18 @@ export function loadCustomScript(
                 // Fetch the error reason from the response body for validation errors
                 return fetch(url)
                     .then((response) => {
-                        if (response.status === 400) {
-                            return response.text();
+                        if (response.status === 200) {
+                            reject(defaultError);
                         }
-                        throw defaultError;
+                        return response.text();
                     })
                     .then((message) => {
                         const parseMessage = parseErrorMessage(message);
                         reject(new Error(parseMessage));
                     })
-                    .catch((err) => reject(err));
+                    .catch((err) => {
+                        reject(err);
+                    });
             },
         });
     });

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -2,7 +2,7 @@ import {
     findScript,
     insertScriptElement,
     processOptions,
-    parseErrorMessage
+    parseErrorMessage,
 } from "./utils";
 import type { PayPalScriptOptions } from "../types/script-options";
 import type { PayPalNamespace } from "../types/index";
@@ -98,8 +98,10 @@ export function loadCustomScript(
                     .then((response) => {
                         response
                             .text()
-                            .then((message) => parseErrorMessage(message))
-                            .catch(e => reject(e));
+                            .then((message) =>
+                                reject({ message: parseErrorMessage(message) })
+                            )
+                            .catch((e) => reject(e));
                     })
                     .catch(() => {
                         return reject(defaultError);

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -99,7 +99,11 @@ export function loadCustomScript(
                         response
                             .text()
                             .then((message) =>
-                                reject({ message: parseErrorMessage(message) })
+                                reject(
+                                    new Error(
+                                        parseErrorMessage(message) as string
+                                    )
+                                )
                             )
                             .catch((e) => reject(e));
                     })

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -1,4 +1,9 @@
-import { findScript, insertScriptElement, processOptions } from "./utils";
+import {
+    findScript,
+    insertScriptElement,
+    processOptions,
+    parseErrorMessage
+} from "./utils";
 import type { PayPalScriptOptions } from "../types/script-options";
 import type { PayPalNamespace } from "../types/index";
 
@@ -89,11 +94,12 @@ export function loadCustomScript(
                     return reject(defaultError);
                 }
                 // attempt to fetch() the error reason from the response body
-                return fetch("https://www.paypal.com/sdk/js")
+                return fetch(url)
                     .then((response) => {
                         response
                             .text()
-                            .then((message) => reject(new Error(message)));
+                            .then((message) => parseErrorMessage(message))
+                            .catch(e => reject(e));
                     })
                     .catch(() => {
                         return reject(defaultError);

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -1,6 +1,7 @@
-import { findScript, insertScriptElement, processOptions } from "./utils";
+import { findScript, insertScriptElement, processOptions, obtainErrorMessageFromServer } from "./utils";
 import type { PayPalScriptOptions } from "../types/script-options";
 import type { PayPalNamespace } from "../types/index";
+
 
 /**
  * Load the Paypal JS SDK script asynchronously.
@@ -92,16 +93,21 @@ export function loadCustomScript(
                         errorMessage: defaultError
                     });
                 }
-
                 // attempt to fetch() the error reason from the response body
-                fetch(url)
+                return fetch('https://www.paypal.com/sdk/js')
                     .then(response => {
-                        new PromisePonyfill((fetchErrorResolve, fetchErrorReject) => {
-                            if (response.status === 400)
-                            response.text()
-                        })
+                        response.text().then(message => {
+                            return reject({
+                                status: response.status,
+                                errorMessage: new Error(obtainErrorMessageFromServer(message))
+                            });
+                        });
                     })
-                    .then()
+                    .catch(() => {
+                        return reject({
+                            errorMessage: defaultError
+                        });
+                    });
 
             }
         });

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -86,9 +86,7 @@ export function loadCustomScript(
             attributes,
             onSuccess: () => resolve(),
             onError: () => {
-                const defaultError = new Error(
-                    `The script "${url}" failed to load.`
-                );
+                const defaultError = `The script "${url}" failed to load.`;
 
                 if (!window.fetch) {
                     return reject(defaultError);
@@ -103,7 +101,9 @@ export function loadCustomScript(
                     .then((message) =>
                         reject(parseErrorMessage(message as string))
                     )
-                    .catch((err) => reject(err.message || defaultError));
+                    .catch((err) => {
+                        reject(err.message || defaultError);
+                    });
             },
         });
     });

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -80,8 +80,30 @@ export function loadCustomScript(
             url,
             attributes,
             onSuccess: () => resolve(),
-            onError: () =>
-                reject(new Error(`The script "${url}" failed to load.`)),
+            onError: () => {
+                // TODO: add new response object shape for error messages
+                // { errorMessage: "", statusCode: 400 }
+                // { errorMessage: "" }
+
+                const defaultError = new Error(`The script "${url}" failed to load.`);
+
+                if (!window.fetch) {
+                    return reject({
+                        errorMessage: defaultError
+                    });
+                }
+
+                // attempt to fetch() the error reason from the response body
+                fetch(url)
+                    .then(response => {
+                        new PromisePonyfill((fetchErrorResolve, fetchErrorReject) => {
+                            if (response.status === 400)
+                            response.text()
+                        })
+                    })
+                    .then()
+
+            }
         });
     });
 }

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -1,4 +1,4 @@
-import { findScript, insertScriptElement, processOptions, obtainErrorMessageFromServer } from "./utils";
+import { findScript, insertScriptElement, processOptions } from "./utils";
 import type { PayPalScriptOptions } from "../types/script-options";
 import type { PayPalNamespace } from "../types/index";
 
@@ -82,10 +82,6 @@ export function loadCustomScript(
             attributes,
             onSuccess: () => resolve(),
             onError: () => {
-                // TODO: add new response object shape for error messages
-                // { errorMessage: "", statusCode: 400 }
-                // { errorMessage: "" }
-
                 const defaultError = new Error(`The script "${url}" failed to load.`);
 
                 if (!window.fetch) {
@@ -99,7 +95,7 @@ export function loadCustomScript(
                         response.text().then(message => {
                             return reject({
                                 status: response.status,
-                                errorMessage: new Error(obtainErrorMessageFromServer(message))
+                                errorMessage: new Error(message)
                             });
                         });
                     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,13 +124,13 @@ export function objectToQueryString(params: StringMap): string {
  * Parse the error message code received from the server during the scrip load.
  * The response is always an error.
  * This function execute the received string code.
- * NOTE: Server response: throw new Error("detail message");
+ * NOTE: Server response example: throw new Error("detail message");
  * 
  * @param source the received error response from the server
  * @throw {Error} server error message
  * @returns a string or throw the exception
  */
-export function parseErrorMessage(source: string): Error | string {
+export function parseErrorMessage(source: string): string {
     return Function(`'use strict'; ${source}`)();
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,8 +121,8 @@ export function objectToQueryString(params: StringMap): string {
 }
 
 /**
- * Parse the error message code received from the server during the scrip load.
- * The response is always an error.
+ * Parse the error message code received from the server during the script load.
+ * For validation errors the response will include a `throw new Error()` statement.
  * This function execute the received string code.
  * NOTE: Server response example: throw new Error("detail message");
  * 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,6 +120,20 @@ export function objectToQueryString(params: StringMap): string {
     return queryString;
 }
 
+/**
+ * Parse the error message code received from the server during the scrip load.
+ * The response is always an error.
+ * This function execute the received string code.
+ * NOTE: Server response: throw new Error("detail message");
+ * 
+ * @param source the received error response from the server
+ * @throw {Error} server error message
+ * @returns a string or throw the exception
+ */
+export function parseErrorMessage(source: string) {
+    return Function(`'use strict'; ${source}`)();
+}
+
 function createScriptElement(
     url: string,
     attributes: StringMap = {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,7 +130,7 @@ export function objectToQueryString(params: StringMap): string {
  * @throw {Error} server error message
  * @returns a string or throw the exception
  */
-export function parseErrorMessage(source: string) {
+export function parseErrorMessage(source: string): Error {
     return Function(`'use strict'; ${source}`)();
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,6 +120,23 @@ export function objectToQueryString(params: StringMap): string {
     return queryString;
 }
 
+/**
+ * HACK:FIXME: This is not the ideal solution, the server is returning
+ * a string response and if in the future the server change the response format
+ * this code will breaks and not work anymore. 
+ * 
+ * This code tries to get a readable error message from the server response.
+ * 
+ * @param errorMessage  the server string error message to process
+ * @returns the detail error message
+ */
+export function obtainErrorMessageFromServer(errorMessage: string): string {
+    const startOfDoubleQuote = (errorMessage.indexOf('"') + 1);
+    const endOfDoubleQuote = (errorMessage.lastIndexOf('"'));
+
+    return errorMessage.substring(startOfDoubleQuote, endOfDoubleQuote);
+}
+
 function createScriptElement(
     url: string,
     attributes: StringMap = {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,23 +120,6 @@ export function objectToQueryString(params: StringMap): string {
     return queryString;
 }
 
-/**
- * HACK:FIXME: This is not the ideal solution, the server is returning
- * a string response and if in the future the server change the response format
- * this code will breaks and not work anymore. 
- * 
- * This code tries to get a readable error message from the server response.
- * 
- * @param errorMessage  the server string error message to process
- * @returns the detail error message
- */
-export function obtainErrorMessageFromServer(errorMessage: string): string {
-    const startOfDoubleQuote = (errorMessage.indexOf('"') + 1);
-    const endOfDoubleQuote = (errorMessage.lastIndexOf('"'));
-
-    return errorMessage.substring(startOfDoubleQuote, endOfDoubleQuote);
-}
-
 function createScriptElement(
     url: string,
     attributes: StringMap = {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,16 +122,18 @@ export function objectToQueryString(params: StringMap): string {
 
 /**
  * Parse the error message code received from the server during the script load.
- * For validation errors the response will include a `throw new Error()` statement.
- * This function execute the received string code.
- * NOTE: Server response example: throw new Error("detail message");
- * 
- * @param source the received error response from the server
- * @throw {Error} server error message
- * @returns a string or throw the exception
+ * This function search for the occurrence of this specific string "/* Original Error:".
+ *
+ * @param message the received error response from the server
+ * @returns the content of the message if the string string was found.
+ *          The whole message otherwise
  */
-export function parseErrorMessage(source: string): string {
-    return Function(`'use strict'; ${source}`)();
+export function parseErrorMessage(message: string): string {
+    const originalErrorText = message.split("/* Original Error:")[1];
+
+    return originalErrorText
+        ? originalErrorText.replace(/\n/g, "").replace("*/", "").trim()
+        : message;
 }
 
 function createScriptElement(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,7 +130,7 @@ export function objectToQueryString(params: StringMap): string {
  * @throw {Error} server error message
  * @returns a string or throw the exception
  */
-export function parseErrorMessage(source: string): Error {
+export function parseErrorMessage(source: string): Error | string {
     return Function(`'use strict'; ${source}`)();
 }
 


### PR DESCRIPTION
**Current problem**: 
The final client/user cannot see the real problem message problem when are getting the SDK library. We're returning all the time the same message:  `The script "${url}" failed to load.`. The `url` represents the sandbox/PayPal server from where we load the SDK.
Nevertheless, we receive the real problem message in the server response as a string and we never use that message to report him the real source of the problem.
This is a server response example:
```
throw new Error("SDK Validation error: 'Expected client-id to be passed'");
    
/* Original Error:

Expected client-id to be passed (debug id: f124435555fb3)

*/
```
 

**Proposal**:
The idea is to get the error response from the server, parse it and return it. In the `onError` callback of the `insertScriptElement` function will fetch for the exact same URL used to get the SDK library and get the server error message.

**Example**: 
Currently, if the user doesn't set the `client-id` and tries to bring the SDK the resulting request would be: `https://www.paypal.com/sdk/js?client-id=` and the error shown would be this: `The script "https://www.paypal.com/sdk/js?client-id=" failed to load.`. But we have this response from the server:
```
throw new Error("SDK Validation error: 'Please pass a value for query param: client-id'" );

/* Original Error:

Please pass a value for query param: client-id (debug id: f6684998ed030)

*/
```
And we aren't using it to indicate the real reason the SDK wasn't loaded.

**Result**:
With the changes on this PR and @gregjopa 's recommendations, we'll be able to grab the server error message and report it to the user.
Resulting in an accurate/useful returning message: `"SDK Validation error: 'Please pass a value for query param: client-id'"`. This will help finals users to understand what is the problem and why they cannot load the SDK, preventing loss of time in debugging. 

**NOTE**: Fill free to provide/propose any suggestion, idea or concern related to these changes