### PR TITLE
fix(ie11): remove usage on Object.assign

### DIFF
--- a/e2e-tests/bundle/bundle-size.test.js
+++ b/e2e-tests/bundle/bundle-size.test.js
@@ -1,8 +1,8 @@
 import filesize from "filesize";
 import fs from "fs";
 
-const maxBundleSizeInKiloBytes = 3.7;
-const maxLegacyBundleSizeInKiloBytes = 7.1;
+const maxBundleSizeInKiloBytes = 4;
+const maxLegacyBundleSizeInKiloBytes = 7.5;
 
 describe("bundle size", () => {
     it(`paypal-js.min.js should be less than ${maxBundleSizeInKiloBytes} KB`, () => {


### PR DESCRIPTION
When testing in IE 11 I noticed that `Object.assign()` errors out and we don't polyfill it. I refactored the code to avoid using Object.assign()`.