### PR TITLE
Increase test coverage

### DIFF
--- a/src/load-script.test.ts
+++ b/src/load-script.test.ts
@@ -174,6 +174,28 @@ describe("loadCustomScript()", () => {
         }
     });
 
+    test("should throw the default error when the script fails to load but getting the error has a success response", async () => {
+        expect.assertions(2);
+        window.fetch = jest.fn().mockResolvedValue({
+            status: 200
+        });
+
+        insertScriptElementSpy.mockImplementation(({ onError }) => {
+            process.nextTick(() => onError && onError("failed to load"));
+        });
+
+        try {
+            await loadCustomScript({ url: "https://www.example.com/index.js" });
+        } catch (err) {
+            expect(insertScriptElementSpy).toHaveBeenCalledTimes(1);
+            const { message } = err as Record<string, string>;
+
+            expect(message).toBe(
+                'The script "https://www.example.com/index.js" failed to load.'
+            );
+        }
+    });
+
     test("should throw an error when the script fails to load taking the response message", async () => {
         const errorMessage =
             "Expected client-id to be passed (debug id: f124435555fb3)";


### PR DESCRIPTION
### Description
This PR cover missing lines in the test cases on the file load-script.test.ts. We missing a specific case when the script fails to load but trying to get the server error response the script is loaded.

### Why are we making these changes?
The main reason for this change is to avoid uncovered lines in the new functionality related to getting the server error messages.

### Screenshots
Previous test cases show this: 
![Screen Shot 2021-11-17 at 5 14 59 PM](https://user-images.githubusercontent.com/26287838/142291333-837f719b-5b37-4dc1-8781-df83e2d32e0e.png)

After the change we have this result: 
![Screen Shot 2021-11-17 at 5 15 10 PM](https://user-images.githubusercontent.com/26287838/142291364-85b066bf-2bf3-4d69-ad50-5d75f1cab06c.png)
