### PR TITLE
Remove unused create order type

### DIFF
--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -1,5 +1,3 @@
-import type { CreateOrderRequestBody } from "../apis/orders";
-
 type UnknownObject = Record<string, unknown>;
 
 type HostedFieldsCardTypes = {
@@ -59,12 +57,6 @@ type HostedFieldsTokenize = {
         countryCodeAlpha2?: string;
         countryCodeAlpha3?: string;
         countryName?: string;
-    };
-};
-
-export type CreateOrderActions = {
-    order: {
-        create: (options: CreateOrderRequestBody) => Promise<string>;
     };
 };
 


### PR DESCRIPTION
### Description
We have an unneeded type definition in the file `types/components/hosted-fields.d.ts`.

This PR removed that unused type from the hosted-fields type script definition