### PR TITLE
Export all modules types from the main file index.d.ts

### DIFF
--- a/types/apis/subscriptions/subscriptions.d.ts
+++ b/types/apis/subscriptions/subscriptions.d.ts
@@ -16,18 +16,16 @@ import type {
 } from "./commons";
 import type { ShippingOptionType } from "../shipping";
 
-type UnknownObject = Record<string, unknown>;
-
 export type CreateSubscriptionRequestBody = {
     plan_id: string;
     start_time?: string;
     quantity?: string;
     shipping_amount?: AmountWithCurrencyCode;
-    subscriber?: UnknownObject;
+    subscriber?: Record<string, unknown>;
     auto_renewal?: boolean;
-    application_context?: UnknownObject;
+    application_context?: Record<string, unknown>;
     custom_id?: string;
-    plan?: UnknownObject;
+    plan?: Record<string, unknown>;
 };
 
 /**

--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -3,8 +3,6 @@ import type { CreateSubscriptionRequestBody } from "../apis/subscriptions/subscr
 import type { ShippingAddress, SelectedShippingOption } from "../apis/shipping";
 import type { SubscriptionDetail } from "../apis/subscriptions/subscriptions";
 
-type UnknownObject = Record<string, unknown>;
-
 export type CreateOrderActions = {
     order: {
         /** Used to create an order for client-side integrations. Accepts the same options as the request body of the [/v2/checkout/orders api](https://developer.paypal.com/docs/api/orders/v2/#orders-create-request-body). */
@@ -83,14 +81,14 @@ export interface PayPalButtonsComponentOptions {
      * Called on button click to set up a one-time payment. [createOrder docs](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#createorder).
      */
     createOrder?: (
-        data: UnknownObject,
+        data: Record<string, unknown>,
         actions: CreateOrderActions
     ) => Promise<string>;
     /**
      * Called on button click to set up a recurring payment. [createSubscription docs](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#createsubscription).
      */
     createSubscription?: (
-        data: UnknownObject,
+        data: Record<string, unknown>,
         actions: CreateSubscriptionActions
     ) => Promise<string>;
     /**
@@ -109,23 +107,26 @@ export interface PayPalButtonsComponentOptions {
      * Called when the buyer cancels the transaction.
      * Often used to show the buyer a [cancellation page](https://developer.paypal.com/docs/business/checkout/add-capabilities/buyer-experience/#3-show-cancellation-page).
      */
-    onCancel?: (data: UnknownObject, actions: OnCancelledActions) => void;
+    onCancel?: (
+        data: Record<string, unknown>,
+        actions: OnCancelledActions
+    ) => void;
     /**
      * Called when the button is clicked. Often used for [validation](https://developer.paypal.com/docs/checkout/integration-features/validation/).
      */
     onClick?: (
-        data: UnknownObject,
+        data: Record<string, unknown>,
         actions: OnClickActions
     ) => Promise<void> | void;
     /**
      * Catch all for errors preventing buyer checkout.
      * Often used to show the buyer an [error page](https://developer.paypal.com/docs/checkout/integration-features/handle-errors/).
      */
-    onError?: (err: UnknownObject) => void;
+    onError?: (err: Record<string, unknown>) => void;
     /**
      * Called when the buttons are initialized. The component is initialized after the iframe has successfully loaded.
      */
-    onInit?: (data: UnknownObject, actions: OnInitActions) => void;
+    onInit?: (data: Record<string, unknown>, actions: OnInitActions) => void;
     /**
      * Called when the buyer changes their shipping address on PayPal.
      */

--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -1,5 +1,3 @@
-type UnknownObject = Record<string, unknown>;
-
 type HostedFieldsCardTypes = {
     [key in
         | "amex"
@@ -62,9 +60,9 @@ type HostedFieldsTokenize = {
 
 export interface PayPalHostedFieldsComponentOptions {
     createOrder: () => Promise<string>;
-    onError?: (err: UnknownObject) => void;
-    styles?: UnknownObject;
-    fields?: UnknownObject;
+    onError?: (err: Record<string, unknown>) => void;
+    styles?: Record<string, unknown>;
+    fields?: Record<string, unknown>;
 }
 
 export interface HostedFieldsSubmitResponse {
@@ -140,7 +138,9 @@ export interface HostedFieldsHandler {
     /**
      * Submit the form if is valid
      */
-    submit: (options?: UnknownObject) => Promise<HostedFieldsSubmitResponse>;
+    submit: (
+        options?: Record<string, unknown>
+    ) => Promise<HostedFieldsSubmitResponse>;
     /**
      * Clean all the fields from the DOM
      */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,23 +34,37 @@ export interface PayPalNamespace {
     version: string;
 }
 
-declare module "@paypal/paypal-js" {
-    export function loadScript(
-        options: PayPalScriptOptions,
-        PromisePonyfill?: PromiseConstructor
-    ): Promise<PayPalNamespace | null>;
+export function loadScript(
+    options: PayPalScriptOptions,
+    PromisePonyfill?: PromiseConstructor
+): Promise<PayPalNamespace | null>;
 
-    export function loadCustomScript(options: {
-        url: string;
-        attributes?: Record<string, string>;
-        PromisePonyfill?: PromiseConstructor;
-    }): Promise<void>;
+export function loadCustomScript(options: {
+    url: string;
+    attributes?: Record<string, string>;
+    PromisePonyfill?: PromiseConstructor;
+}): Promise<void>;
 
-    export const version: string;
-}
+export const version: string;
 
 declare global {
     interface Window {
-        paypal?: PayPalNamespace;
+        paypal?: PayPalNamespace | null;
     }
 }
+
+// Export components
+export * from "./components/buttons";
+export * from "./components/funding-eligibility";
+export * from "./components/hosted-fields";
+export * from "./components/marks";
+export * from "./components/messages";
+
+// Export apis
+export * from "./apis/commons";
+export * from "./apis/orders";
+export * from "./apis/shipping";
+
+// Export apis/subscriptions
+export * from "./apis/subscriptions/commons";
+export * from "./apis/subscriptions/subscriptions";


### PR DESCRIPTION
### Description
The PR contains all re-exported module types to avoid importing types from different directories inside the library.
Final users can `import type { * } from "@paypal/paypal-js"` directly. 

### Why are we making these changes?
The main reason is to make the developers live a little easier using our libraries.
Maybe it can be useful as well start documenting all the types to avoid confusion or research on the web to understand the defined types for the library.

### Dependent Changes
This PR depends on the changes/enhancements made on [Enhance the missing subscription type on OnApproveAction callback](https://github.com/paypal/paypal-js/pull/140)
