### PR TITLE
Remove deprecated order type

### DIFF
--- a/types/apis/orders.d.ts
+++ b/types/apis/orders.d.ts
@@ -149,6 +149,3 @@ export type OrderResponseBody = {
         | "PAYER_ACTION_REQUIRED";
     links: LinkDescription[];
 };
-
-// deprecated - remove `CaptureOrderResponseBody` in next major release
-export type CaptureOrderResponseBody = OrderResponseBody;


### PR DESCRIPTION
### Description
Get rid of the deprecated type`CaptureOrderResponseBody` in orders.d.ts

### Why are we making these changes?
We don;t need anymore the type `CaptureOrderResponseBody` on the repo.