### PR TITLE
Reexport missing PayPalScriptOptions type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -68,3 +68,6 @@ export * from "./apis/shipping";
 // Export apis/subscriptions
 export * from "./apis/subscriptions/commons";
 export * from "./apis/subscriptions/subscriptions";
+
+// Export script-options
+export * from "./script-options";


### PR DESCRIPTION
### Description
The PR contains the reexport `PayPalScriptOptions` type from the `index.d.ts` file

### Why are we making these changes?
This change avoids importing the `PayPalScriptOptions` from the relative file path.