### PR TITLE
fix(types): add missing style props

### DIFF
--- a/types/components/messages.d.ts
+++ b/types/components/messages.d.ts
@@ -4,6 +4,15 @@ export interface PayPalMessagesComponentOptions {
     style?: {
         layout?: "text" | "flex" | "custom";
         color?: string;
+        logo?: {
+            type?: 'primary' | 'alternative' | 'inline' | 'none';
+            position?: 'left' | 'right' | 'top';
+        };
+        text: {
+            color?: 'black' | 'white' | 'monochrome' | 'grayscale';
+            size?: 	10 | 11 | 12 | 13 | 14 | 15 | 16;
+            align?: 'left' | 'center' | 'right'
+        }
     };
 }
 


### PR DESCRIPTION
### Describe Bug
See #165 

### Current problem
The props of style in interface `PayPalMessagesComponentOptions` is missing.

### Solution
Update type [message.d.ts](https://github.com/paypal/paypal-js/blob/main/types/components/messages.d.ts) by following the properties from [Customize Pay Later messages](https://developer.paypal.com/docs/checkout/pay-later/us/integrate/customize-messages/) .

**What kind of change does this PR introduce?**
type declaration fix

**Does this PR introduce a breaking change?**
No
