### PR TITLE
chore(types): enhance hosted fields types

### DIFF
--- a/types/components/hosted-fields.d.ts
+++ b/types/components/hosted-fields.d.ts
@@ -58,8 +58,38 @@ type HostedFieldsTokenize = {
     };
 };
 
+export type InstallmentsConfiguration = {
+    currencyCode: string;
+    amount: string;
+    financingCountryCode?: string;
+    billingCountryCode?: string;
+};
+
+export type AvailableInstallments = {
+    configuration_owner_account: string;
+    financing_options: Array<Record<string, unknown>>;
+};
+
+export interface Installments {
+    /**
+     * Defines the installments configuration
+     */
+    onInstallmentsRequested: () =>
+        | Promise<InstallmentsConfiguration>
+        | InstallmentsConfiguration;
+    /**
+     * Handle and use installments options
+     */
+    onInstallmentsAvailable: (installments: AvailableInstallments) => void;
+    /**
+     * Handle fetching installments errors
+     */
+    onInstallmentsError?: (error: Record<string, unknown>) => void;
+}
+
 export interface PayPalHostedFieldsComponentOptions {
     createOrder: () => Promise<string>;
+    installments?: Installments;
     onError?: (err: Record<string, unknown>) => void;
     styles?: Record<string, unknown>;
     fields?: Record<string, unknown>;


### PR DESCRIPTION
### Description
The PR contains missing types from `PayPalHostedFieldsComponentOptions`  to enhance the `installments` missing option type for hosted fields.

### Why are we making these changes?
To enhance the hosted fields types and make visible the `installments` option in the render function to developers integrating our SPB in their merchant clients. 