### PR TITLE
feat(types): type out funding sources

### DIFF
--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -2,6 +2,11 @@ import type { CreateOrderRequestBody, OrderResponseBody } from "../apis/orders";
 import type { CreateSubscriptionRequestBody } from "../apis/subscriptions/subscriptions";
 import type { ShippingAddress, SelectedShippingOption } from "../apis/shipping";
 import type { SubscriptionDetail } from "../apis/subscriptions/subscriptions";
+import type { FUNDING_SOURCE } from "./funding-eligibility";
+
+export type CreateOrderData = {
+    paymentSource: FUNDING_SOURCE;
+};
 
 export type CreateOrderActions = {
     order: {
@@ -100,7 +105,7 @@ export interface PayPalButtonsComponentOptions {
      * Called on button click to set up a one-time payment. [createOrder docs](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#createorder).
      */
     createOrder?: (
-        data: Record<string, unknown>,
+        data: CreateOrderData,
         actions: CreateOrderActions
     ) => Promise<string>;
     /**
@@ -114,7 +119,7 @@ export interface PayPalButtonsComponentOptions {
      * Used for defining a standalone button.
      * Learn more about [configuring the funding source for standalone buttons](https://developer.paypal.com/docs/business/checkout/configure-payments/standalone-buttons/#4-funding-sources).
      */
-    fundingSource?: string;
+    fundingSource?: FUNDING_SOURCE;
     /**
      * Called when finalizing the transaction. Often used to inform the buyer that the transaction is complete. [onApprove docs](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#onapprove).
      */

--- a/types/components/funding-eligibility.d.ts
+++ b/types/components/funding-eligibility.d.ts
@@ -1,3 +1,31 @@
-export type getFundingSources = () => string[];
-export type isFundingEligible = (fundingSource: string) => boolean;
-export type rememberFunding = (fundingSource: string[]) => void;
+export type FUNDING_SOURCE =
+    | "paypal"
+    | "venmo"
+    | "applepay"
+    | "itau"
+    | "credit"
+    | "paylater"
+    | "card"
+    | "ideal"
+    | "sepa"
+    | "bancontact"
+    | "giropay"
+    | "sofort"
+    | "eps"
+    | "mybank"
+    | "p24"
+    | "verkkopankki"
+    | "payu"
+    | "blik"
+    | "trustly"
+    | "zimpler"
+    | "maxima"
+    | "oxxo"
+    | "boletobancario"
+    | "wechatpay"
+    | "mercadopago"
+    | "multibanco";
+
+export type getFundingSources = () => FUNDING_SOURCE[];
+export type isFundingEligible = (fundingSource: FUNDING_SOURCE) => boolean;
+export type rememberFunding = (fundingSource: FUNDING_SOURCE[]) => void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,6 +12,7 @@ import type {
     PayPalMessagesComponent,
 } from "./components/messages";
 import type {
+    FUNDING_SOURCE,
     getFundingSources,
     isFundingEligible,
     rememberFunding,
@@ -30,7 +31,7 @@ export interface PayPalNamespace {
     getFundingSources?: getFundingSources;
     isFundingEligible?: isFundingEligible;
     rememberFunding?: rememberFunding;
-    FUNDING?: Record<string, string>;
+    FUNDING?: Record<string, FUNDING_SOURCE>;
     version: string;
 }
 


### PR DESCRIPTION
This PR adds types for all the possible funding source values. These values were copied over from the sdk-constants repo: https://github.com/paypal/paypal-sdk-constants/blob/main/src/funding.js#L3.

Also, the `createOrder(data, actions)` callback now has `data.paymentSource` for letting the merchant know which button was clicked. I added types for that.