### PR TITLE
Update orders.d.ts

### DIFF
--- a/types/apis/orders.d.ts
+++ b/types/apis/orders.d.ts
@@ -158,12 +158,12 @@ export type ShippingInfo = {
      * The method by which the payer wants to get their items from the payee e.g shipping, in-person pickup.
      * Either type or options but not both may be present
      */
-    type: string;
+    type?: string;
     /**
      * An array of shipping options that the payee or
      * merchant offers to the payer to ship or pick up their items
      */
-    options: ShippingInfoOption[];
+    options?: ShippingInfoOption[];
     address: Address;
 };
 


### PR DESCRIPTION
As you are stating in your comment " * Either type or options but not both may be present".
Currently Paypal doesn't allow type and options to be used at the same time, but types it paypal-js are enforcing developers to use both.
I want to use paypal-js types over defining empty type declaration in my local types folder. so i'm suggesting this fix to paypal-js types.