### PR TITLE
fix(types): update order shipping options to match spec

### DIFF
--- a/types/apis/orders.d.ts
+++ b/types/apis/orders.d.ts
@@ -135,7 +135,7 @@ export type ShippingInfoOption = {
     selected: boolean;
 };
 
-export interface ShippingInfoBase {
+interface ShippingInfoBase {
     /**
      * The name of the party
      */

--- a/types/apis/orders.d.ts
+++ b/types/apis/orders.d.ts
@@ -135,18 +135,18 @@ export type ShippingInfoOption = {
     selected: boolean;
 };
 
-export type ShippingInfo = {
+export interface ShippingInfoBase {
     /**
      * The name of the party
      */
-    name: Partial<{
+    name?: Partial<{
         /**
          * When the party is a person, the party's full name
          */
         full_name: string;
     }>;
-    email_address: string;
-    phone_number: {
+    email_address?: string;
+    phone_number?: {
         /**
          * The national number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en).
          * The combined length of the country calling code (CC) and the national number must not be greater than 15 digits.
@@ -154,18 +154,20 @@ export type ShippingInfo = {
          */
         national_number: string;
     };
-    /**
-     * The method by which the payer wants to get their items from the payee e.g shipping, in-person pickup.
-     * Either type or options but not both may be present
-     */
-    type: string;
-    /**
-     * An array of shipping options that the payee or
-     * merchant offers to the payer to ship or pick up their items
-     */
+    address?: Address;
+}
+
+interface ShippingInfoWithType extends ShippingInfoBase {
+    type: "SHIPPING" | "PICKUP_IN_PERSON";
+    options?: never;
+}
+
+interface ShippingInfoWithOptions extends ShippingInfoBase {
     options: ShippingInfoOption[];
-    address: Address;
-};
+    type?: never;
+}
+
+export type ShippingInfo = ShippingInfoWithType | ShippingInfoWithOptions;
 
 export type PurchaseItem = {
     name: string;

--- a/types/tests/buttons.test.ts
+++ b/types/tests/buttons.test.ts
@@ -279,4 +279,69 @@ async function main() {
         paypal.rememberFunding?.([paypal.FUNDING.VENMO]);
         paypal.isFundingEligible?.(paypal.FUNDING.VENMO);
     }
+
+    // shipping info with options
+    // https://developer.paypal.com/docs/checkout/standard/customize/shipping-options/
+    paypal.Buttons({
+        createOrder(data, actions) {
+            return actions.order.create({
+                purchase_units: [
+                    {
+                        amount: {
+                            value: "15.00",
+                            currency_code: "USD",
+                        },
+
+                        shipping: {
+                            options: [
+                                {
+                                    id: "SHIP_123",
+                                    label: "Free Shipping",
+                                    type: "SHIPPING",
+                                    selected: true,
+                                    amount: {
+                                        value: "3.00",
+                                        currency_code: "USD",
+                                    },
+                                },
+                                {
+                                    id: "SHIP_456",
+                                    label: "Pick up in Store",
+                                    type: "PICKUP",
+                                    selected: false,
+                                    amount: {
+                                        value: "0.00",
+                                        currency_code: "USD",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            });
+        },
+    });
+
+    // shipping info with options
+    paypal.Buttons({
+        createOrder(data, actions) {
+            return actions.order.create({
+                purchase_units: [
+                    {
+                        amount: {
+                            value: "88.44",
+                            currency_code: "USD",
+                        },
+                        shipping: {
+                            name: {
+                                full_name: "Jon Doe",
+                            },
+                            email_address: "jon@test.com",
+                            type: "SHIPPING",
+                        },
+                    },
+                ],
+            });
+        },
+    });
 }


### PR DESCRIPTION
This PR is a follow up to https://github.com/paypal/paypal-js/pull/268 and includes the following changes:

- Update shipping name, address, phone_number, and email to be optional (https://developer.paypal.com/docs/api/orders/v2/#definition-shipping_detail)
- Update shipping types to enforce the rule of having either` shipping.type` or `'shipping.options` but not both. This enforces the following requirement from the rest api docs:
  > The method by which the payer wants to get their items from the payee e.g shipping, in-person pickup. Either type or options but not both may be present.