### PR TITLE
fix(types): add missing action for revising a subscription

### DIFF
--- a/types/apis/subscriptions/subscriptions.d.ts
+++ b/types/apis/subscriptions/subscriptions.d.ts
@@ -28,6 +28,19 @@ export type CreateSubscriptionRequestBody = {
     plan?: Record<string, unknown>;
 };
 
+export type ReviseSubscriptionRequestBody = {
+    application_context?: Record<string, unknown>;
+    effective_time?: string;
+    plan?: Record<string, unknown>;
+    plan_id?: string;
+    quantity?: string;
+    shipping_address?: {
+        name?: string;
+        address?: Address;
+    };
+    shipping_amount?: AmountWithCurrencyCode;
+};
+
 /**
  * Contains all the information related to a subscription flow
  */

--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -1,5 +1,8 @@
 import type { CreateOrderRequestBody, OrderResponseBody } from "../apis/orders";
-import type { CreateSubscriptionRequestBody } from "../apis/subscriptions/subscriptions";
+import type {
+    CreateSubscriptionRequestBody,
+    ReviseSubscriptionRequestBody,
+} from "../apis/subscriptions/subscriptions";
 import type { ShippingAddress, SelectedShippingOption } from "../apis/shipping";
 import type { SubscriptionDetail } from "../apis/subscriptions/subscriptions";
 import type { FUNDING_SOURCE } from "./funding-eligibility";
@@ -19,6 +22,11 @@ export type CreateSubscriptionActions = {
     subscription: {
         /** Used to create a subscription for client-side integrations. Accepts the same options as the request body of the [/v1/billing/subscription api](https://developer.paypal.com/docs/api/subscriptions/v1#subscriptions-create-request-body). */
         create: (options: CreateSubscriptionRequestBody) => Promise<string>;
+        /** Used to revise an existing subscription for client-side integrations. Accepts the same options as the request body of the [/v1/billing/subscription/{id}/revise api](https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_revise). */
+        revise: (
+            subscriptionID: string,
+            options: ReviseSubscriptionRequestBody
+        ) => Promise<string>;
     };
 };
 


### PR DESCRIPTION
Improve the types for the Subscription flow. This PR adds types for the `actions.subscription.revise()` function.

Resolves: https://github.com/paypal/react-paypal-js/issues/312