### PR TITLE
fix(types): update patch request body for order actions

### DIFF
--- a/types/apis/orders.d.ts
+++ b/types/apis/orders.d.ts
@@ -235,6 +235,31 @@ export type CreateOrderRequestBody = {
     application_context?: OrderApplicationContext;
 };
 
+export type UpdateOrderOperation =
+    | {
+          op: "add" | "replace" | "copy" | "test";
+          /**
+           * The JSON Pointer to the target document location at which to complete the operation.
+           */
+          path: string;
+          value: Record<string, unknown>;
+      }
+    | {
+          op: "move";
+          path: string;
+          value: Record<string, unknown>;
+          /**
+           * The JSON Pointer to the target document location from which to move the value.
+           */
+          from: string;
+      }
+    | {
+          op: "remove";
+          path: string;
+      };
+
+export type UpdateOrderRequestBody = UpdateOrderOperation[];
+
 export type OrderResponseBodyMinimal = {
     /**
      * The ID of the order

--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -1,4 +1,8 @@
-import type { CreateOrderRequestBody, OrderResponseBody } from "../apis/orders";
+import type {
+    CreateOrderRequestBody,
+    OrderResponseBody,
+    UpdateOrderRequestBody,
+} from "../apis/orders";
 import type {
     CreateSubscriptionRequestBody,
     ReviseSubscriptionRequestBody,
@@ -100,7 +104,7 @@ export type OnShippingChangeActions = {
     resolve: () => Promise<void>;
     reject: () => Promise<void>;
     order: {
-        patch: () => Promise<void>;
+        patch: (options: UpdateOrderRequestBody) => Promise<void>;
     };
 };
 


### PR DESCRIPTION
Updates the "patch" function for button callbacks to be consistent with the documented behavior for v2 of the PayPal orders API.

Reference:

- https://developer.paypal.com/docs/api/orders/v2/#orders_patch
- https://developer.paypal.com/docs/checkout/advanced/customize/update-order-details/#link-updateorderdetails