### PR TITLE
chore(types): add test for patching order

### DIFF
--- a/types/apis/orders.d.ts
+++ b/types/apis/orders.d.ts
@@ -245,15 +245,6 @@ export type UpdateOrderOperation =
           value: Record<string, unknown>;
       }
     | {
-          op: "move";
-          path: string;
-          value: Record<string, unknown>;
-          /**
-           * The JSON Pointer to the target document location from which to move the value.
-           */
-          from: string;
-      }
-    | {
           op: "remove";
           path: string;
       };

--- a/types/tests/server.test.ts
+++ b/types/tests/server.test.ts
@@ -168,3 +168,13 @@ updateOrder({
         },
     ],
 });
+
+updateOrder({
+    orderID: "42P22220TW111111R",
+    requestBody: [
+        {
+            op: "remove",
+            path: "/purchase_units/@reference_id=='default'/invoice_id",
+        },
+    ],
+});

--- a/types/tests/server.test.ts
+++ b/types/tests/server.test.ts
@@ -1,6 +1,7 @@
 import type {
     CreateOrderRequestBody,
     OrderResponseBodyMinimal,
+    UpdateOrderRequestBody,
 } from "../index";
 
 function createOrder(
@@ -8,6 +9,14 @@ function createOrder(
     createOrderRequestBody: CreateOrderRequestBody
 ): Promise<OrderResponseBodyMinimal> {
     return Promise.resolve({ id: "123456", status: "CREATED", links: [] });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function updateOrder(options: {
+    orderID: string;
+    requestBody: UpdateOrderRequestBody;
+}): Promise<void> {
+    return Promise.resolve();
 }
 
 // capture
@@ -142,6 +151,20 @@ createOrder({
                     category: "DONATION",
                 },
             ],
+        },
+    ],
+});
+
+updateOrder({
+    orderID: "42P22220TW111111R",
+    requestBody: [
+        {
+            op: "replace",
+            path: "/purchase_units/@reference_id=='default'/amount",
+            value: {
+                value: "10.25",
+                currency: "USD",
+            },
         },
     ],
 });


### PR DESCRIPTION
This PR adds a test to validate the new types added in #360 for the [Update Order patch operation](https://developer.paypal.com/docs/api/orders/v2/#orders_patch).

It also removes the "move" operation from the patch api call types. Based on [this list](https://developer.paypal.com/docs/api/orders/v2/#orders_patch), no attributes actually support the "move" operation. 