### PR TITLE
fix(types): remove deprecated disableCard param

### DIFF
--- a/types/script-options.d.ts
+++ b/types/script-options.d.ts
@@ -5,7 +5,6 @@ interface PayPalScriptQueryParameters {
     components?: string;
     currency?: string;
     debug?: boolean | string;
-    disableCard?: string;
     disableFunding?: string;
     enableFunding?: string;
     integrationDate?: string;


### PR DESCRIPTION
The `disableFunding` param is the recommended way to prevent specific funding instruments from showing in the smart buttons stack. To disable the card, `disableFunding: "card"` should be used instead of the legacy `disableCard` option.