### PR TITLE
fix(types): add types for payment_source with order creation

### DIFF
--- a/types/apis/orders.d.ts
+++ b/types/apis/orders.d.ts
@@ -215,6 +215,18 @@ export type OrderApplicationContext = {
     stored_payment_source?: Record<string, unknown>;
 };
 
+export type OrderPaymentSource = {
+    // support any key until all the payment_source options are typed
+    [key: string]: unknown;
+    paypal?: {
+        experience_context?: {
+            user_action?: "CONTINUE" | "PAY_NOW";
+            return_url?: string;
+            cancel_url?: string;
+        };
+    };
+};
+
 export type LinkDescription = {
     href: string;
     rel: string;
@@ -233,6 +245,7 @@ export type CreateOrderRequestBody = {
     purchase_units: PurchaseUnit[];
     payer?: Payer;
     application_context?: OrderApplicationContext;
+    payment_source?: OrderPaymentSource;
 };
 
 export type UpdateOrderOperation =

--- a/types/tests/server.test.ts
+++ b/types/tests/server.test.ts
@@ -155,6 +155,27 @@ createOrder({
     ],
 });
 
+// paypal payment_source
+createOrder({
+    intent: "CAPTURE",
+    purchase_units: [
+        {
+            amount: {
+                value: "88.44",
+            },
+        },
+    ],
+    payment_source: {
+        paypal: {
+            experience_context: {
+                user_action: "CONTINUE",
+                return_url: "https://www.example.com/capture-checkout",
+                cancel_url: "https://www.example.com/cancel-checkout",
+            },
+        },
+    },
+});
+
 updateOrder({
     orderID: "42P22220TW111111R",
     requestBody: [


### PR DESCRIPTION
The [payment_source](https://developer.paypal.com/docs/api/orders/v2/#orders_create!path=payment_source&t=request) option is for defining configuration for specific funding sources when creating an order. This PR adds types for this new option. Right now, it only types the `paypal` option. Other options will be added in future PRs.

Example usage: https://github.com/gregjopa/paypal-button-full-page-redirect-example/blob/main/src/controllers/order-controller.ts#L76