### PR TITLE
fix(types): query params as an array or string

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ By default, the JS SDK only loads the buttons component. The `components` query 
 ```js
 loadScript({
     clientId: "YOUR_CLIENT_ID",
-    components: "buttons,marks,messages",
+    components: ["buttons", "marks", "messages"],
 });
 ```
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -55,6 +55,20 @@ describe("processOptions()", () => {
         expect(dataAttributes).toEqual({});
     });
 
+    test("support passing arrays for query string params", () => {
+        const { url, dataAttributes } = processOptions({
+            clientId: "test",
+            components: ["buttons", "marks", "messages"],
+            enableFunding: ["venmo", "paylater"],
+            disableFunding: ["card"],
+        });
+
+        expect(url).toBe(
+            "https://www.paypal.com/sdk/js?client-id=test&components=buttons,marks,messages&enable-funding=venmo,paylater&disable-funding=card",
+        );
+        expect(dataAttributes).toEqual({});
+    });
+
     test("supports passing an array of merchant ids", () => {
         const { url, dataAttributes } = processOptions({
             clientId: "test",

--- a/types/script-options.d.ts
+++ b/types/script-options.d.ts
@@ -2,14 +2,14 @@ interface PayPalScriptQueryParameters {
     buyerCountry?: string;
     clientId: string;
     commit?: boolean;
-    components?: string;
+    components?: string[] | string;
     currency?: string;
     debug?: boolean | string;
     // loadScript() supports an array and will convert it
     // to the correct disable-funding and enable-funding string values
-    disableFunding?: string;
+    disableFunding?: string[] | string;
     enableFunding?: string[] | string;
-    integrationDate?: string[] | string;
+    integrationDate?: string;
     intent?: string;
     locale?: string;
     // loadScript() supports an array for merchantId, even though


### PR DESCRIPTION
Follow up to #419. Applies the same array or string type logic to `components` and also fixes the types for `disableFunding` and `integrationDate`.

cc: @CBoensel 