### PR TITLE
Add new param to style type def

### DIFF
--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -175,6 +175,7 @@ export interface PayPalButtonsComponentOptions {
      */
     style?: {
         color?: "gold" | "blue" | "silver" | "white" | "black";
+        disableMaxWidth?: boolean;
         height?: number;
         label?:
             | "paypal"


### PR DESCRIPTION
`disableMaxWidth` was missing. 

See https://developer.paypal.com/sdk/js/reference/#link-width

![image](https://github.com/paypal/paypal-js/assets/4338717/42419527-733b-4f8a-977e-04850a08650c)
