### PR TITLE
feat: add type definitions for two new callbacks

### DIFF
--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -108,6 +108,81 @@ export type OnShippingChangeActions = {
     };
 };
 
+type CurrencyCodeAndValue = {
+    currencyCode: string;
+    value: string;
+};
+
+type ShippingOption = {
+    amount: CurrencyCodeAndValue;
+    id?: string;
+    label: string;
+    selected: boolean;
+    type: "SHIPPING" | "PICKUP";
+};
+
+export type OnShippingOptionsChangeData = {
+    orderID?: string;
+    paymentID?: string;
+    paymentToken?: string;
+    selectedShippingOption?: ShippingOption;
+};
+
+type BuildOrderPatchPayloadOptions = {
+    discount?: string;
+    handling?: string;
+    insurance?: string;
+    itemTotal?: string;
+    option?: ShippingOption;
+    shippingOptions?: ShippingOption[];
+    shippingDiscount?: string;
+    taxTotal?: string;
+};
+
+export type OnShippingOptionsChangeActions = {
+    buildOrderPatchPayload: ({
+        discount,
+        handling,
+        insurance,
+        itemTotal,
+        shippingOptions,
+        shippingDiscount,
+        taxTotal,
+    }: BuildOrderPatchPayloadOptions) => UpdateOrderRequestBody;
+    reject: () => Promise<void>;
+};
+
+export type OnShippingAddressChangeData = {
+    amount: CurrencyCodeAndValue;
+    orderID?: string;
+    paymentID?: string;
+    paymentToken?: string;
+    shippingAddress: {
+        city: string;
+        state: string;
+        /** The [two-character ISO 3166-1 code](/docs/integration/direct/rest/country-codes/) that identifies the country or region. */
+        countryCode: string;
+        /**
+         * The postal code, which is the zip code or equivalent.
+         * Typically required for countries with a postal code or an equivalent.
+         */
+        postalCode: string;
+    };
+};
+
+export type OnShippingAddressChangeActions = {
+    buildOrderPatchPayload: ({
+        discount,
+        handling,
+        insurance,
+        itemTotal,
+        shippingOptions,
+        shippingDiscount,
+        taxTotal,
+    }: BuildOrderPatchPayloadOptions) => UpdateOrderRequestBody;
+    reject: () => Promise<void>;
+};
+
 export interface PayPalButtonsComponentOptions {
     /**
      * Called on button click. Often used for [Braintree vault integrations](https://developers.braintreepayments.com/guides/paypal/vault/javascript/v3).
@@ -165,10 +240,25 @@ export interface PayPalButtonsComponentOptions {
     onInit?: (data: Record<string, unknown>, actions: OnInitActions) => void;
     /**
      * Called when the buyer changes their shipping address on PayPal.
+     * @deprecated Use `onShippingAddressChange` or `onShippingOptionsChange` instead.
      */
     onShippingChange?: (
         data: OnShippingChangeData,
         actions: OnShippingChangeActions,
+    ) => Promise<void>;
+    /**
+     * Called when the buyer selects a new shipping option on PayPal.
+     */
+    onShippingOptionsChange?: (
+        data: OnShippingOptionsChangeData,
+        actions: OnShippingOptionsChangeActions,
+    ) => Promise<void>;
+    /**
+     * Called when the buyer their shipping address on PayPal.
+     */
+    onShippingAddressChange?: (
+        data: OnShippingAddressChangeData,
+        actions: OnShippingAddressChangeActions,
     ) => Promise<void>;
     /**
      * [Styling options](https://developer.paypal.com/docs/business/checkout/reference/style-guide/#customize-the-payment-buttons) for customizing the button appearance.

--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -113,7 +113,7 @@ type CurrencyCodeAndValue = {
     value: string;
 };
 
-type ShippingOption = {
+type CheckoutShippingOption = {
     amount: CurrencyCodeAndValue;
     id?: string;
     label: string;
@@ -125,7 +125,7 @@ type OnShippingOptionsChangeData = {
     orderID?: string;
     paymentID?: string;
     paymentToken?: string;
-    selectedShippingOption?: ShippingOption;
+    selectedShippingOption?: CheckoutShippingOption;
 };
 
 type BuildOrderPatchPayloadArgs = {
@@ -133,19 +133,19 @@ type BuildOrderPatchPayloadArgs = {
     handling?: string;
     insurance?: string;
     itemTotal?: string;
-    option?: ShippingOption;
+    option?: CheckoutShippingOption;
     shippingDiscount?: string;
     taxTotal?: string;
 };
 
 type OnShippingOptionsChangeBuildOrderPatchPayloadArgs =
     BuildOrderPatchPayloadArgs & {
-        shippingOption?: ShippingOption;
+        shippingOption?: CheckoutShippingOption;
     };
 
 type OnShippingAddressChangeBuildOrderPatchPayloadArgs =
     BuildOrderPatchPayloadArgs & {
-        shippingOptions?: ShippingOption[];
+        shippingOptions?: CheckoutShippingOption[];
     };
 
 type OnShippingOptionsChangeActions = {

--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -254,7 +254,7 @@ export interface PayPalButtonsComponentOptions {
         actions: OnShippingOptionsChangeActions,
     ) => Promise<void>;
     /**
-     * Called when the buyer their shipping address on PayPal.
+     * Called when the buyer updates their shipping address on PayPal.
      */
     onShippingAddressChange?: (
         data: OnShippingAddressChangeData,

--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -121,38 +121,47 @@ type ShippingOption = {
     type: "SHIPPING" | "PICKUP";
 };
 
-export type OnShippingOptionsChangeData = {
+type OnShippingOptionsChangeData = {
     orderID?: string;
     paymentID?: string;
     paymentToken?: string;
     selectedShippingOption?: ShippingOption;
 };
 
-type BuildOrderPatchPayloadOptions = {
+type BuildOrderPatchPayloadArgs = {
     discount?: string;
     handling?: string;
     insurance?: string;
     itemTotal?: string;
     option?: ShippingOption;
-    shippingOptions?: ShippingOption[];
     shippingDiscount?: string;
     taxTotal?: string;
 };
 
-export type OnShippingOptionsChangeActions = {
+type OnShippingOptionsChangeBuildOrderPatchPayloadArgs =
+    BuildOrderPatchPayloadArgs & {
+        shippingOption?: ShippingOption;
+    };
+
+type OnShippingAddressChangeBuildOrderPatchPayloadArgs =
+    BuildOrderPatchPayloadArgs & {
+        shippingOptions?: ShippingOption[];
+    };
+
+type OnShippingOptionsChangeActions = {
     buildOrderPatchPayload: ({
         discount,
         handling,
         insurance,
         itemTotal,
-        shippingOptions,
+        shippingOption,
         shippingDiscount,
         taxTotal,
-    }: BuildOrderPatchPayloadOptions) => UpdateOrderRequestBody;
+    }: OnShippingOptionsChangeBuildOrderPatchPayloadArgs) => UpdateOrderRequestBody;
     reject: () => Promise<void>;
 };
 
-export type OnShippingAddressChangeData = {
+type OnShippingAddressChangeData = {
     amount: CurrencyCodeAndValue;
     orderID?: string;
     paymentID?: string;
@@ -170,7 +179,7 @@ export type OnShippingAddressChangeData = {
     };
 };
 
-export type OnShippingAddressChangeActions = {
+type OnShippingAddressChangeActions = {
     buildOrderPatchPayload: ({
         discount,
         handling,
@@ -179,7 +188,7 @@ export type OnShippingAddressChangeActions = {
         shippingOptions,
         shippingDiscount,
         taxTotal,
-    }: BuildOrderPatchPayloadOptions) => UpdateOrderRequestBody;
+    }: OnShippingAddressChangeBuildOrderPatchPayloadArgs) => UpdateOrderRequestBody;
     reject: () => Promise<void>;
 };
 


### PR DESCRIPTION
This PR adds type definitions for two new callbacks that were implemented in https://github.com/paypal/paypal-smart-payment-buttons/pull/679

Also see the react-paypal-js changes, which consume these changes here: https://github.com/paypal/react-paypal-js/pull/388