### PR TITLE
Add displayOnly config option

### DIFF
--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -192,6 +192,8 @@ type OnShippingAddressChangeActions = {
     reject: () => Promise<void>;
 };
 
+export type DisplayOnlyOptions = "vaultable";
+
 export interface PayPalButtonsComponentOptions {
     /**
      * Called on button click. Often used for [Braintree vault integrations](https://developers.braintreepayments.com/guides/paypal/vault/javascript/v3).
@@ -288,6 +290,11 @@ export interface PayPalButtonsComponentOptions {
         shape?: "rect" | "pill";
         tagline?: boolean;
     };
+
+    /**
+     * Used for displaying only vaultable buttons.
+     */
+    displayOnly?: DisplayOnlyOptions[];
 }
 
 export interface PayPalButtonsComponent {

--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -290,7 +290,6 @@ export interface PayPalButtonsComponentOptions {
         shape?: "rect" | "pill";
         tagline?: boolean;
     };
-
     /**
      * Used for displaying only vaultable buttons.
      */


### PR DESCRIPTION
Adding the new `displayOnly` config option which will allow merchants to show only vaultable buttons.

```
paypal.Buttons({
    displayOnly: ["vaultable"]
})
```