### PR TITLE
fix: add type definitions for createVaultSetupToken

### DIFF
--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -214,7 +214,7 @@ export interface PayPalButtonsComponentOptions {
         actions: CreateSubscriptionActions,
     ) => Promise<string>;
     /**
-     * Save payment methods to charge payers after a set amount of time. For example, you can offer a free trial and charge payers after the trial expires. Payers don't need to be present when charged. No checkout required.a
+     * Save payment methods to charge payers after a set amount of time. For example, you can offer a free trial and charge payers after the trial expires. Payers don't need to be present when charged. No checkout required.
      * https://developer.paypal.com/docs/checkout/save-payment-methods/purchase-later/js-sdk/paypal/#link-clientsidecodesample
      */
     createVaultSetupToken?: () => Promise<string>;

--- a/types/components/buttons.d.ts
+++ b/types/components/buttons.d.ts
@@ -214,6 +214,11 @@ export interface PayPalButtonsComponentOptions {
         actions: CreateSubscriptionActions,
     ) => Promise<string>;
     /**
+     * Save payment methods to charge payers after a set amount of time. For example, you can offer a free trial and charge payers after the trial expires. Payers don't need to be present when charged. No checkout required.a
+     * https://developer.paypal.com/docs/checkout/save-payment-methods/purchase-later/js-sdk/paypal/#link-clientsidecodesample
+     */
+    createVaultSetupToken?: () => Promise<string>;
+    /**
      * Used for defining a standalone button.
      * Learn more about [configuring the funding source for standalone buttons](https://developer.paypal.com/docs/business/checkout/configure-payments/standalone-buttons/#4-funding-sources).
      */


### PR DESCRIPTION
Adding support for the `createVaultSetupToken` callback to our type definitions. Documented [here](https://developer.paypal.com/docs/checkout/save-payment-methods/purchase-later/js-sdk/paypal/#link-clientsidecodesample)