### PR TITLE
chore: update code coverage to only include src folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "test:e2e:debug": "PWDEBUG=1 playwright test --project=\"chromium\"",
         "test:e2e:start": "node e2e-tests/http-server.js",
         "typecheck": "tsc --noEmit",
-        "validate": "npm run check-node-version && npm run format:check && npm run typecheck && npm run build && npm run lint && npm test -- --coverage --watch=false && npm run test:bundle -- --watch=false",
+        "validate": "npm run check-node-version && npm run format:check && npm run typecheck && npm run build && npm run lint && npm test -- --watch=false --coverage.enabled --coverage.include=src && npm run test:bundle -- --watch=false",
         "openapi": "npm run openapi-orders && npm run openapi-subscriptions",
         "openapi-orders": "openapi-typescript node_modules/@paypal/paypal-rest-api-specifications/openapi/checkout_orders_v2.json -o types/apis/openapi/checkout_orders_v2.d.ts",
         "openapi-subscriptions": "openapi-typescript node_modules/@paypal/paypal-rest-api-specifications/openapi/billing_subscriptions_v1.json -o types/apis/openapi/billing_subscriptions_v1.d.ts"


### PR DESCRIPTION
This PR updates the code coverage report to only include the files in the src folder. Previously the `e2e-tests` and `scripts` folders were getting included by accident.