### PR TITLE
Add dataJsSdkLibrary to PayPalScriptDataAttributes

### DIFF
--- a/.changeset/sweet-ants-fix.md
+++ b/.changeset/sweet-ants-fix.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Add dataJsSdkLibrary to PayPalScriptDataAttributes

--- a/packages/paypal-js/types/script-options.d.ts
+++ b/packages/paypal-js/types/script-options.d.ts
@@ -24,6 +24,7 @@ interface PayPalScriptDataAttributes {
     dataClientToken?: string;
     dataCspNonce?: string;
     dataClientMetadataId?: string;
+    dataJsSdkLibrary?: string;
     // loadScript() supports an array and will convert it
     // to the correct dataMerchantId string values
     dataMerchantId?: string[] | string;


### PR DESCRIPTION
### Description

This PR will resolve the following type error in `react-paypal-js` when adding `dataJsSdkLibrary` to `loadScript()`:

![Screenshot 2024-03-20 at 11 32 56 AM](https://github.com/paypal/paypal-js/assets/20399044/eb7cccd4-ccad-4fcf-ace1-db59227c66b7)