### PR TITLE
chore: export card fields types from index

### DIFF
--- a/.changeset/catfish-papaya.md
+++ b/.changeset/catfish-papaya.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Exported the card field types. They were previously defined but not exported.

--- a/packages/paypal-js/types/index.d.ts
+++ b/packages/paypal-js/types/index.d.ts
@@ -67,6 +67,7 @@ export * from "./components/funding-eligibility";
 export * from "./components/hosted-fields";
 export * from "./components/marks";
 export * from "./components/messages";
+export * from "./components/card-fields"
 
 // Export apis
 export * from "./apis/orders";


### PR DESCRIPTION
Export card fields types from index