### PR TITLE
fix: adjust current type props

### DIFF
--- a/.changeset/eminent-choufer.md
+++ b/.changeset/eminent-choufer.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Adjust card-field types.

--- a/packages/paypal-js/types/components/card-fields.d.ts
+++ b/packages/paypal-js/types/components/card-fields.d.ts
@@ -104,13 +104,13 @@ export interface PayPalCardFieldsStateObject {
 }
 
 export interface PayPalCardFieldsIndividualFieldOptions {
-    placeholder: string;
+    placeholder?: string;
     inputEvents?: PayPalCardFieldsInputEvents;
     style?: Record<string, PayPalCardFieldsStyleOptions>;
 }
 
 export interface PayPalCardFieldsIndividualField {
-    render: (container: string) => void;
+    render: (container: string | HTMLElement) => Promise<void>;
     addClass: (className: string) => Promise<void>;
     clear: () => void;
     focus: () => void;
@@ -120,12 +120,14 @@ export interface PayPalCardFieldsIndividualField {
     removeClass: (className: string) => Promise<void>;
     setAttribute: (name: string, value: string) => Promise<void>;
     setMessage: (message: string) => void;
+    close: ()=> Promise<void>;
 }
 
 export interface PayPalCardFieldsComponentOptions {
     createOrder: () => Promise<string>;
     onApprove: (err: Record<string, unknown>) => void;
     onError: (err: Record<string, unknown>) => void;
+    createVaultSetupToken?: () => Promise<string>;
     inputEvents?: PayPalCardFieldsInputEvents;
     style?: Record<string, PayPalCardFieldsStyleOptions>;
 }


### PR DESCRIPTION
Some of the types in cardfields are not accurate. more work needs to be done to include the correct types and props for each cardfield. This PR aims to correct some of the types that are already there.