### PR TITLE
Introduce env parameter to support sandbox and paypal 

### DIFF
--- a/.changeset/good-falcons-turn.md
+++ b/.changeset/good-falcons-turn.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": minor
+---
+
+Support env param in loadScript options object

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 /test-results/
 /playwright-report/
 /playwright/.cache/
+.idea

--- a/packages/paypal-js/src/load-script.test.ts
+++ b/packages/paypal-js/src/load-script.test.ts
@@ -37,7 +37,38 @@ describe("loadScript()", () => {
         expect(window.paypal).toBe(undefined);
 
         const response = await loadScript({ clientId: "test" });
+        expect(mockedInsertScriptElement.mock.calls[0][0].url).toEqual(
+            "https://www.paypal.com/sdk/js?client-id=test"
+        );
         expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
+        expect(response).toEqual(window.paypal);
+    });
+
+    test("should insert <script> using environment option as sandbox", async () => {
+        expect(window.paypal).toBe(undefined);
+
+        const response = await loadScript({
+            clientId: "test",
+            environment: "sandbox",
+        });
+        expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
+        expect(mockedInsertScriptElement.mock.calls[0][0].url).toEqual(
+            "https://www.sandbox.paypal.com/sdk/js?client-id=test"
+        );
+        expect(response).toEqual(window.paypal);
+    });
+
+    test("should insert <script> using environment option as production", async () => {
+        expect(window.paypal).toBe(undefined);
+
+        const response = await loadScript({
+            clientId: "test",
+            environment: "production",
+        });
+        expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
+        expect(mockedInsertScriptElement.mock.calls[0][0].url).toEqual(
+            "https://www.paypal.com/sdk/js?client-id=test"
+        );
         expect(response).toEqual(window.paypal);
     });
 
@@ -89,6 +120,19 @@ describe("loadScript()", () => {
                 "The window.paypal global variable is not available."
             );
         }
+    });
+
+    test("should fail to insert <script> using invalid environment option", async () => {
+        expect(window.paypal).toBe(undefined);
+        expect(() =>
+            loadScript({
+                clientId: "test",
+                // @ts-expect-error intentionally sending invalid value
+                environment: "invalid",
+            })
+        ).toThrowError(
+            'The `environment` option must be either "production" or "sandbox"'
+        );
     });
 
     test("should throw an error from invalid arguments", () => {

--- a/packages/paypal-js/src/load-script.ts
+++ b/packages/paypal-js/src/load-script.ts
@@ -106,7 +106,11 @@ function validateArguments(options: unknown, PromisePonyfill?: unknown) {
     }
     const { environment } = options as PayPalScriptOptions;
 
-    if (environment && !["production", "sandbox"].includes(environment)) {
+    if (
+        environment &&
+        environment !== "production" &&
+        environment !== "sandbox"
+    ) {
         throw new Error(
             'The `environment` option must be either "production" or "sandbox".'
         );

--- a/packages/paypal-js/src/load-script.ts
+++ b/packages/paypal-js/src/load-script.ts
@@ -104,6 +104,13 @@ function validateArguments(options: unknown, PromisePonyfill?: unknown) {
     if (typeof options !== "object" || options === null) {
         throw new Error("Expected an options object.");
     }
+    const { environment } = options as PayPalScriptOptions;
+
+    if (environment && !["production", "sandbox"].includes(environment)) {
+        throw new Error(
+            'The `environment` option must be either "production" or "sandbox".'
+        );
+    }
 
     if (
         typeof PromisePonyfill !== "undefined" &&

--- a/packages/paypal-js/src/utils.ts
+++ b/packages/paypal-js/src/utils.ts
@@ -66,15 +66,15 @@ export function processOptions(options: PayPalScriptOptions): {
     url: string;
     attributes: StringMap;
 } {
-    const { env } = options;
+    const { environment } = options;
     // Keeping production as default to keep maintain backward compatibility.
     // In the future this logic needs to be changed to use sandbox domain as default instead of production.
     let sdkBaseUrl =
-        env === "sandbox"
+        environment === "sandbox"
             ? "https://www.sandbox.paypal.com/sdk/js"
             : "https://www.paypal.com/sdk/js";
     // env is not an allowed key for sdk/js url.
-    delete options.env;
+    delete options.environment;
 
     if (options.sdkBaseUrl) {
         sdkBaseUrl = options.sdkBaseUrl;

--- a/packages/paypal-js/src/utils.ts
+++ b/packages/paypal-js/src/utils.ts
@@ -66,7 +66,15 @@ export function processOptions(options: PayPalScriptOptions): {
     url: string;
     attributes: StringMap;
 } {
-    let sdkBaseUrl = "https://www.paypal.com/sdk/js";
+    const { env } = options;
+    // Keeping production as default to keep maintain backward compatibility.
+    // In the future this logic needs to be changed to use sandbox domain as default instead of production.
+    let sdkBaseUrl =
+        env === "sandbox"
+            ? "https://www.sandbox.paypal.com/sdk/js"
+            : "https://www.paypal.com/sdk/js";
+    // env is not an allowed key for sdk/js url.
+    delete options.env;
 
     if (options.sdkBaseUrl) {
         sdkBaseUrl = options.sdkBaseUrl;

--- a/packages/paypal-js/types/components/card-fields.d.ts
+++ b/packages/paypal-js/types/components/card-fields.d.ts
@@ -114,7 +114,7 @@ export interface PayPalCardFieldsIndividualFieldOptions {
 }
 
 export interface PayPalCardFieldsIndividualField {
-    render: (container: string | HTMLElement) => Promise<void>;
+    render: (container: string | HTMLElement) => Promise<void>;
     addClass: (className: string) => Promise<void>;
     clear: () => void;
     focus: () => void;
@@ -124,7 +124,7 @@ export interface PayPalCardFieldsIndividualField {
     removeClass: (className: string) => Promise<void>;
     setAttribute: (name: string, value: string) => Promise<void>;
     setMessage: (message: string) => void;
-    close: ()=> Promise<void>;
+    close: () => Promise<void>;
 }
 
 export interface PayPalCardFieldsComponentOptions {

--- a/packages/paypal-js/types/index.d.ts
+++ b/packages/paypal-js/types/index.d.ts
@@ -25,15 +25,15 @@ import type {
 
 export interface PayPalNamespace {
     Buttons?: (
-        options?: PayPalButtonsComponentOptions,
+        options?: PayPalButtonsComponentOptions
     ) => PayPalButtonsComponent;
     Marks?: (options?: PayPalMarksComponentOptions) => PayPalMarksComponent;
     Messages?: (
-        options?: PayPalMessagesComponentOptions,
+        options?: PayPalMessagesComponentOptions
     ) => PayPalMessagesComponent;
     HostedFields?: PayPalHostedFieldsComponent;
     CardFields?: (
-        options?: PayPalCardFieldsComponentOptions,
+        options?: PayPalCardFieldsComponentOptions
     ) => PayPalCardFieldsComponent;
     getFundingSources?: getFundingSources;
     isFundingEligible?: isFundingEligible;
@@ -44,7 +44,7 @@ export interface PayPalNamespace {
 
 export function loadScript(
     options: PayPalScriptOptions,
-    PromisePonyfill?: PromiseConstructor,
+    PromisePonyfill?: PromiseConstructor
 ): Promise<PayPalNamespace | null>;
 
 export function loadCustomScript(options: {
@@ -67,7 +67,7 @@ export * from "./components/funding-eligibility";
 export * from "./components/hosted-fields";
 export * from "./components/marks";
 export * from "./components/messages";
-export * from "./components/card-fields"
+export * from "./components/card-fields";
 
 // Export apis
 export * from "./apis/orders";

--- a/packages/paypal-js/types/script-options.d.ts
+++ b/packages/paypal-js/types/script-options.d.ts
@@ -21,7 +21,7 @@ interface PayPalScriptQueryParameters {
 }
 
 interface PayPalScriptDataAttributes {
-    env?: 'sandbox' | 'production',
+    env?: "sandbox" | "production";
     dataClientToken?: string;
     dataCspNonce?: string;
     dataClientMetadataId?: string;

--- a/packages/paypal-js/types/script-options.d.ts
+++ b/packages/paypal-js/types/script-options.d.ts
@@ -44,7 +44,6 @@ export interface PayPalScriptOptions
     extends PayPalScriptQueryParameters,
         PayPalScriptDataAttributes,
         ScriptAttributes {
-    sdkBaseUrl?: string;
     environment?: "production" | "sandbox";
     sdkBaseUrl?: string;
 }

--- a/packages/paypal-js/types/script-options.d.ts
+++ b/packages/paypal-js/types/script-options.d.ts
@@ -21,7 +21,6 @@ interface PayPalScriptQueryParameters {
 }
 
 interface PayPalScriptDataAttributes {
-    env?: "sandbox" | "production";
     dataClientToken?: string;
     dataCspNonce?: string;
     dataClientMetadataId?: string;
@@ -46,4 +45,5 @@ export interface PayPalScriptOptions
         PayPalScriptDataAttributes,
         ScriptAttributes {
     sdkBaseUrl?: string;
+    environment?: "production" | "sandbox";
 }

--- a/packages/paypal-js/types/script-options.d.ts
+++ b/packages/paypal-js/types/script-options.d.ts
@@ -21,6 +21,7 @@ interface PayPalScriptQueryParameters {
 }
 
 interface PayPalScriptDataAttributes {
+    env?: 'sandbox' | 'production',
     dataClientToken?: string;
     dataCspNonce?: string;
     dataClientMetadataId?: string;

--- a/packages/paypal-js/types/script-options.d.ts
+++ b/packages/paypal-js/types/script-options.d.ts
@@ -46,4 +46,5 @@ export interface PayPalScriptOptions
         ScriptAttributes {
     sdkBaseUrl?: string;
     environment?: "production" | "sandbox";
+    sdkBaseUrl?: string;
 }


### PR DESCRIPTION
* Introduce a new option in the `loadScript` method to allow passing `env = sandbox or production`.
*  If `env=sandbox` is passed as an option, then the sdk script will be loaded from `www.sandbox.paypal.com/sdk/js`