### PR TITLE
Throw error for missing client ID 👾

### DIFF
--- a/.changeset/beige-tables-pull.md
+++ b/.changeset/beige-tables-pull.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Improved error handling for missing clientId

--- a/packages/paypal-js/src/load-script.test.ts
+++ b/packages/paypal-js/src/load-script.test.ts
@@ -142,6 +142,14 @@ describe("loadScript()", () => {
         expect(() => loadScript({}, {})).toThrow(
             "Expected PromisePonyfill to be a function."
         );
+
+        const missingClientIdOptions = { components: "buttons" };
+        // @ts-expect-error ignore invalid arguments error
+        expect(() => loadScript(missingClientIdOptions)).toThrow(
+            `Expected clientId in options object: ${JSON.stringify(
+                missingClientIdOptions
+            )}`
+        );
     });
 });
 

--- a/packages/paypal-js/src/load-script.ts
+++ b/packages/paypal-js/src/load-script.ts
@@ -14,11 +14,17 @@ export function loadScript(
     PromisePonyfill: PromiseConstructor = Promise
 ): Promise<PayPalNamespace | null> {
     validateArguments(options, PromisePonyfill);
-
     // resolve with null when running in Node or Deno
     if (typeof document === "undefined") return PromisePonyfill.resolve(null);
 
+    if (!options.clientId) {
+        throw new Error(
+            `Expected clientId in options object: ${JSON.stringify(options)}`
+        );
+    }
+
     const { url, attributes } = processOptions(options);
+
     const namespace = attributes["data-namespace"] || "paypal";
     const existingWindowNamespace = getPayPalWindowNamespace(namespace);
 
@@ -104,6 +110,7 @@ function validateArguments(options: unknown, PromisePonyfill?: unknown) {
     if (typeof options !== "object" || options === null) {
         throw new Error("Expected an options object.");
     }
+
     const { environment } = options as PayPalScriptOptions;
 
     if (

--- a/packages/paypal-js/src/load-script.ts
+++ b/packages/paypal-js/src/load-script.ts
@@ -17,13 +17,13 @@ export function loadScript(
     // resolve with null when running in Node or Deno
     if (typeof document === "undefined") return PromisePonyfill.resolve(null);
 
-    if (!options.clientId) {
+    const { url, attributes, queryParams } = processOptions(options);
+
+    if (!queryParams["client-id"]) {
         throw new Error(
             `Expected clientId in options object: ${JSON.stringify(options)}`
         );
     }
-
-    const { url, attributes } = processOptions(options);
 
     const namespace = attributes["data-namespace"] || "paypal";
     const existingWindowNamespace = getPayPalWindowNamespace(namespace);

--- a/packages/paypal-js/src/utils.ts
+++ b/packages/paypal-js/src/utils.ts
@@ -65,6 +65,7 @@ export function insertScriptElement({
 export function processOptions(options: PayPalScriptOptions): {
     url: string;
     attributes: StringMap;
+    queryParams: StringMap;
 } {
     const { environment } = options;
     // Keeping production as default to maintain backward compatibility.
@@ -121,6 +122,7 @@ export function processOptions(options: PayPalScriptOptions): {
     return {
         url: `${sdkBaseUrl}?${objectToQueryString(queryParams)}`,
         attributes,
+        queryParams,
     };
 }
 


### PR DESCRIPTION
- 👽 _**Added more meaningful error handling**_ - Before, without a client ID, if you tried to load the PayPal SDK, it would throw a generic error.  It would be helpful to explicitly point out that the developer did not include the client ID.
