### PR TITLE
fix: button rerender issue due to obj in dependency array

### DIFF
--- a/.changeset/fluffy-tigers-mate.md
+++ b/.changeset/fluffy-tigers-mate.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+fixes button rerender issue due to obj in dependency array

--- a/packages/react-paypal-js/src/components/PayPalButtons.tsx
+++ b/packages/react-paypal-js/src/components/PayPalButtons.tsx
@@ -39,6 +39,8 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
         }
     }
 
+    const buttonMessageContent = JSON.stringify(buttonProps.message);
+
     // useEffect hook for rendering the buttons
     useEffect(() => {
         // verify the sdk script has successfully loaded
@@ -124,7 +126,7 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
         isResolved,
         ...forceReRender,
         buttonProps.fundingSource,
-        JSON.stringify(buttonProps.message)
+        buttonMessageContent
     ]);
 
     // useEffect hook for managing disabled state

--- a/packages/react-paypal-js/src/components/PayPalButtons.tsx
+++ b/packages/react-paypal-js/src/components/PayPalButtons.tsx
@@ -124,11 +124,7 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
         isResolved,
         ...forceReRender,
         buttonProps.fundingSource,
-        buttonProps.message?.amount,
-        buttonProps.message?.align,
-        buttonProps.message?.color,
-        buttonProps.message?.position,
-        buttonProps.message?.offer,
+        JSON.stringify(buttonProps.message)
     ]);
 
     // useEffect hook for managing disabled state

--- a/packages/react-paypal-js/src/components/PayPalButtons.tsx
+++ b/packages/react-paypal-js/src/components/PayPalButtons.tsx
@@ -124,7 +124,11 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
         isResolved,
         ...forceReRender,
         buttonProps.fundingSource,
-        buttonProps.message,
+        buttonProps.message?.amount,
+        buttonProps.message?.align,
+        buttonProps.message?.color,
+        buttonProps.message?.position,
+        buttonProps.message?.offer,
     ]);
 
     // useEffect hook for managing disabled state


### PR DESCRIPTION
Button rerender was rerendering unintentionally due to a non-primitive value, the message obj, being passed into the useEffect dependency array.  This fixes the issue by stringify-ing the message.