### PR TITLE
fix: message props update without button teardown

### DIFF
--- a/.changeset/cold-mangos-sleep.md
+++ b/.changeset/cold-mangos-sleep.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+Fixes Button rerendering unnecessarily when Buttons Message params change

--- a/packages/paypal-js/types/components/buttons.d.ts
+++ b/packages/paypal-js/types/components/buttons.d.ts
@@ -322,4 +322,5 @@ export interface PayPalButtonsComponent {
     close: () => Promise<void>;
     isEligible: () => boolean;
     render: (container: HTMLElement | string) => Promise<void>;
+    updateProps: (props: PayPalButtonsComponentOptions) => Promise<void>;
 }

--- a/packages/react-paypal-js/src/components/PayPalButtons.test.tsx
+++ b/packages/react-paypal-js/src/components/PayPalButtons.test.tsx
@@ -349,6 +349,7 @@ describe("<PayPalButtons />", () => {
                         }
                         return Promise.reject("Unknown error");
                     }),
+                    updateProps: jest.fn().mockResolvedValue({}),
                 };
             },
             version: "",
@@ -423,6 +424,7 @@ describe("<PayPalButtons />", () => {
                     close: jest.fn().mockResolvedValue({}),
                     isEligible: jest.fn().mockReturnValue(true),
                     render: mockRender,
+                    updateProps: jest.fn().mockResolvedValue({}),
                 };
             },
             version: "",

--- a/packages/react-paypal-js/src/components/PayPalButtons.tsx
+++ b/packages/react-paypal-js/src/components/PayPalButtons.tsx
@@ -39,9 +39,11 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
         }
     }
 
-    buttons.current?.updateProps({
-        message: buttonProps.message
-    })
+    if (buttons.current?.updateProps) {
+        buttons.current.updateProps({
+            message: buttonProps.message
+        })
+    }
 
     // useEffect hook for rendering the buttons
     useEffect(() => {

--- a/packages/react-paypal-js/src/components/PayPalButtons.tsx
+++ b/packages/react-paypal-js/src/components/PayPalButtons.tsx
@@ -39,7 +39,9 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
         }
     }
 
-    const buttonMessageContent = JSON.stringify(buttonProps.message);
+    buttons.current?.updateProps({
+        message: buttonProps.message
+    })
 
     // useEffect hook for rendering the buttons
     useEffect(() => {
@@ -125,8 +127,7 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
     }, [
         isResolved,
         ...forceReRender,
-        buttonProps.fundingSource,
-        buttonMessageContent
+        buttonProps.fundingSource
     ]);
 
     // useEffect hook for managing disabled state


### PR DESCRIPTION
There was a bug where updating button message properties such as `amount` would tear down then rebuild the entire button component to render the new message.  This fix allows just the message to rerender and preserves the button.


**Testing instructions:** 

_Setup_

- open this `paypal-js` PR locally
- execute `npm run build` in paypal-js
- open `paypal-js` file explorer to `packages/react-paypal-js/dist` and copy the `cjs` and `esm` directories
- open [this lighthouse-ecommerce AKA "Palmart" PR](https://github.paypal.com/credit-merchant/lighthouse-ecommerce/pull/4) locally
- run `npm install`
- open Palmart file explorer to `node_modules/@paypal/react-paypal-js/dist`
- delete the `cjs` and `esm` directories
- paste copied `cjs` and `esm` directories there
- delete `.next` directory (previous node_module builds are cached there, and we do not want to use those)
- execute `npm run dev`
  - if it does not launch and gives `node: --openssl-legacy-provider is not allowed in NODE_OPTIONS`, you must first set the node version to the version specified in the `.nvmrc` file

_Validation_

- go to a product page and change the item quantity.  The button message quantity should update but not tear down the buttons.