### PR TITLE
Add missing button border radius type

### DIFF
--- a/.changeset/small-cups-buy.md
+++ b/.changeset/small-cups-buy.md
@@ -1,0 +1,6 @@
+---
+"@paypal/paypal-js": patch
+"@paypal/react-paypal-js": patch
+---
+
+Add button style borderRadius type

--- a/packages/paypal-js/types/components/buttons.d.ts
+++ b/packages/paypal-js/types/components/buttons.d.ts
@@ -287,6 +287,7 @@ export interface PayPalButtonsComponentOptions {
      * [Styling options](https://developer.paypal.com/docs/business/checkout/reference/style-guide/#customize-the-payment-buttons) for customizing the button appearance.
      */
     style?: {
+        borderRadius?: number;
         color?: "gold" | "blue" | "silver" | "white" | "black";
         disableMaxWidth?: boolean;
         height?: number;


### PR DESCRIPTION
Using the latest v8.5.0 version of the `@paypal/react-paypal-js` package, the `style` object for `<PayPalButtons>` doesn’t include a typed field for the `borderRadius` option listed in the button’s [SDK documentation](https://developer.paypal.com/sdk/js/reference/#link-borderradius).

This PR adds `PayPalButtonsComponentOptions.style.borderRadius` with the documented `number` type.