### PR TITLE
Refactor `processOptions` to prevent modifying its arguments

### DIFF
--- a/.changeset/wild-turtles-remain.md
+++ b/.changeset/wild-turtles-remain.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Prevent option paremeter being modified by processOptions()

--- a/packages/paypal-js/src/utils.test.ts
+++ b/packages/paypal-js/src/utils.test.ts
@@ -9,6 +9,7 @@ import {
     insertScriptElement,
     objectToQueryString,
     processOptions,
+    processSdkBaseUrl,
 } from "./utils";
 
 describe("objectToQueryString()", () => {
@@ -138,6 +139,18 @@ describe("processOptions()", () => {
             "https://www.paypal.com/sdk/js?client-id=test&merchant-id=*",
         );
         expect(attributes2).toEqual({ "data-merchant-id": "123,456,789" });
+    });
+
+    test("did not modified options parameter", () => {
+        const options: PayPalScriptOptions = {
+            clientId: "",
+            sdkBaseUrl: "sdkBaseUrl",
+        };
+        const optionsCopy = JSON.parse(JSON.stringify(options));
+
+        processOptions(options);
+
+        expect(options).toEqual(optionsCopy);
     });
 });
 
@@ -301,5 +314,25 @@ describe("insertScriptElement()", () => {
             vi.runAllTimers();
             expect(onErrorMock).toBeCalled();
         });
+    });
+});
+
+describe("processSdkBaseUrl()", () => {
+    const sandboxBaseUrl = "https://www.sandbox.paypal.com/sdk/js";
+    const productionUrl = "https://www.paypal.com/sdk/js";
+
+    test("returns sandboxUrl", () => {
+        const sdkBaseUrl = processSdkBaseUrl("sandbox");
+        expect(sdkBaseUrl).toEqual(sandboxBaseUrl);
+    });
+
+    test("returns production url", () => {
+        const sdkBaseUrl = processSdkBaseUrl("production");
+        expect(sdkBaseUrl).toEqual(productionUrl);
+    });
+
+    test("defaults to production url", () => {
+        const sdkBaseUrl = processSdkBaseUrl(undefined);
+        expect(sdkBaseUrl).toEqual(productionUrl);
     });
 });

--- a/packages/paypal-js/src/utils.ts
+++ b/packages/paypal-js/src/utils.ts
@@ -131,6 +131,16 @@ export function objectToQueryString(params: StringMap): string {
     return queryString;
 }
 
+export function processSdkBaseUrl(
+    environment: PayPalScriptOptions["environment"],
+): string {
+    // Keeping production as default to maintain backward compatibility.
+    // In the future this logic needs to be changed to use sandbox domain as default instead of production.
+    return environment === "sandbox"
+        ? "https://www.sandbox.paypal.com/sdk/js"
+        : "https://www.paypal.com/sdk/js";
+}
+
 function createScriptElement(
     url: string,
     attributes: StringMap = {},
@@ -147,14 +157,4 @@ function createScriptElement(
     });
 
     return newScript;
-}
-
-function processSdkBaseUrl(
-    environment: PayPalScriptOptions["environment"],
-): string {
-    // Keeping production as default to maintain backward compatibility.
-    // In the future this logic needs to be changed to use sandbox domain as default instead of production.
-    return environment === "sandbox"
-        ? "https://www.sandbox.paypal.com/sdk/js"
-        : "https://www.paypal.com/sdk/js";
 }

--- a/packages/paypal-js/src/utils.ts
+++ b/packages/paypal-js/src/utils.ts
@@ -62,24 +62,15 @@ export function insertScriptElement({
     document.head.insertBefore(newScript, document.head.firstElementChild);
 }
 
-export function processOptions(options: PayPalScriptOptions): {
+export function processOptions({
+    sdkBaseUrl: customSdkBaseUrl,
+    environment,
+    ...options
+}: PayPalScriptOptions): {
     url: string;
     attributes: StringMap;
 } {
-    const { environment } = options;
-    // Keeping production as default to maintain backward compatibility.
-    // In the future this logic needs to be changed to use sandbox domain as default instead of production.
-    let sdkBaseUrl =
-        environment === "sandbox"
-            ? "https://www.sandbox.paypal.com/sdk/js"
-            : "https://www.paypal.com/sdk/js";
-    // env is not an allowed key for sdk/js url.
-    delete options.environment;
-
-    if (options.sdkBaseUrl) {
-        sdkBaseUrl = options.sdkBaseUrl;
-        delete options.sdkBaseUrl;
-    }
+    const sdkBaseUrl = customSdkBaseUrl || processSdkBaseUrl(environment);
 
     const optionsWithStringIndex =
         options as PayPalScriptOptionsWithStringIndex;
@@ -156,4 +147,14 @@ function createScriptElement(
     });
 
     return newScript;
+}
+
+function processSdkBaseUrl(
+    environment: PayPalScriptOptions["environment"],
+): string {
+    // Keeping production as default to maintain backward compatibility.
+    // In the future this logic needs to be changed to use sandbox domain as default instead of production.
+    return environment === "sandbox"
+        ? "https://www.sandbox.paypal.com/sdk/js"
+        : "https://www.paypal.com/sdk/js";
 }


### PR DESCRIPTION
Removed `delete` statements from `processOptions` function to prevent modifying its argument and having side-effects.

Deleting `sdkBaseUrl` property is causing to React script loader to not properly set a custom `sdkBaseUrl` because `useEffect` is running twice.