### PR TITLE
create new types for createOrder and creatVaultToken

### DIFF
--- a/.changeset/modern-drinks-think.md
+++ b/.changeset/modern-drinks-think.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": minor
+---
+
+Adding test for card-fields.test.ts

--- a/.changeset/silly-bears-boil.md
+++ b/.changeset/silly-bears-boil.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": major
+---
+
+create new type for createOrder, createVaultToken and add onCancel to card-field

--- a/.changeset/silly-bears-boil.md
+++ b/.changeset/silly-bears-boil.md
@@ -1,5 +1,0 @@
----
-"@paypal/paypal-js": major
----
-
-create new type for createOrder, createVaultToken and add onCancel to card-field

--- a/packages/paypal-js/types/components/card-fields.d.ts
+++ b/packages/paypal-js/types/components/card-fields.d.ts
@@ -127,16 +127,31 @@ export interface PayPalCardFieldsIndividualField {
     close: () => Promise<void>;
 }
 
-export interface PayPalCardFieldsComponentOptions {
-    createOrder: () => Promise<string>;
+export interface PayPalCardFieldsComponentBasics {
     onApprove: (data: CardFieldsOnApproveData) => void;
     onError: (err: Record<string, unknown>) => void;
-    createVaultSetupToken?: () => Promise<string>;
     inputEvents?: PayPalCardFieldsInputEvents;
     style?: Record<string, PayPalCardFieldsStyleOptions>;
 }
 
-export interface PayPalCardFieldsComponent {
+export interface PayPalCardFieldsComponentCreateOrder
+    extends PayPalCardFieldsComponentBasics {
+    createOrder: () => Promise<string>;
+    createVaultSetupToken?: never;
+}
+
+export interface PayPalCardFieldsComponentCreateVaultSetupToken
+    extends PayPalCardFieldsComponentBasics {
+    createOrder?: never;
+    createVaultSetupToken: () => Promise<string>;
+}
+
+export type PayPalCardFieldsComponentOptions =
+    | PayPalCardFieldsComponentCreateOrder
+    | PayPalCardFieldsComponentCreateVaultSetupToken;
+
+export interface PayPalCardFieldsComponent
+    extends PayPalCardFieldsComponentOptions {
     getState: () => Promise<PayPalCardFieldsStateObject>;
     isEligible: () => boolean;
     submit: () => Promise<void>;

--- a/packages/paypal-js/types/components/card-fields.d.ts
+++ b/packages/paypal-js/types/components/card-fields.d.ts
@@ -130,6 +130,7 @@ export interface PayPalCardFieldsIndividualField {
 export interface PayPalCardFieldsComponentBasics {
     onApprove: (data: CardFieldsOnApproveData) => void;
     onError: (err: Record<string, unknown>) => void;
+    onCancel?: () => Promise<void> | void;
     inputEvents?: PayPalCardFieldsInputEvents;
     style?: Record<string, PayPalCardFieldsStyleOptions>;
 }
@@ -150,8 +151,7 @@ export type PayPalCardFieldsComponentOptions =
     | PayPalCardFieldsComponentCreateOrder
     | PayPalCardFieldsComponentCreateVaultSetupToken;
 
-export interface PayPalCardFieldsComponent
-    extends PayPalCardFieldsComponentOptions {
+export interface PayPalCardFieldsComponent {
     getState: () => Promise<PayPalCardFieldsStateObject>;
     isEligible: () => boolean;
     submit: () => Promise<void>;

--- a/packages/paypal-js/types/tests/card-fields.test.ts
+++ b/packages/paypal-js/types/tests/card-fields.test.ts
@@ -1,0 +1,48 @@
+import { test, vi, describe, expect } from "vitest";
+
+import { PayPalCardFieldsComponentOptions } from "../components/card-fields";
+
+describe("testing", () => {
+    test("only creatOrder", () => {
+        const createOrderCallback: PayPalCardFieldsComponentOptions = {
+            createOrder: vi.fn(),
+            onApprove: vi.fn(),
+            onError: vi.fn(),
+        };
+
+        expect(createOrderCallback.createVaultSetupToken).toBeUndefined();
+    });
+
+    test("only createVaultSetupToken", () => {
+        const createVaultSetupTokenCallback: PayPalCardFieldsComponentOptions =
+            {
+                createVaultSetupToken: vi.fn(),
+                onApprove: vi.fn(),
+                onError: vi.fn(),
+            };
+
+        expect(createVaultSetupTokenCallback.createOrder).toBeUndefined();
+    });
+
+    test.skip("Can't have both", () => {
+        // @ts-expect-error : should throw error if both createOrder and createVaultSetuptoken called
+        const callback: PayPalCardFieldsComponentOptions = {
+            createOrder: vi.fn(),
+            createVaultSetupToken: vi.fn(),
+            onApprove: vi.fn(),
+            onError: vi.fn(),
+        };
+
+        expect(callback).toThrowError();
+    });
+
+    test.skip("Can't have both", () => {
+        // @ts-expect-error: should throw error if neither createOrder or createVaultSetuptoken called
+        const callback: PayPalCardFieldsComponentOptions = {
+            onApprove: vi.fn(),
+            onError: vi.fn(),
+        };
+
+        expect(callback).toThrowError();
+    });
+});

--- a/packages/paypal-js/types/tests/card-fields.test.ts
+++ b/packages/paypal-js/types/tests/card-fields.test.ts
@@ -2,7 +2,7 @@ import { test, vi, describe, expect } from "vitest";
 
 import { PayPalCardFieldsComponentOptions } from "../components/card-fields";
 
-describe("testing", () => {
+describe.only("testing createOrder and createVaultToken types", () => {
     test("only creatOrder", () => {
         const createOrderCallback: PayPalCardFieldsComponentOptions = {
             createOrder: vi.fn(),
@@ -24,8 +24,8 @@ describe("testing", () => {
         expect(createVaultSetupTokenCallback.createOrder).toBeUndefined();
     });
 
-    test.skip("Can't have both", () => {
-        // @ts-expect-error : should throw error if both createOrder and createVaultSetuptoken called
+    test.skip("Can't have both createOrdre and createVaultSetupToken", () => {
+        // @ts-expect-error : should throw error if both createOrder and createVaultSetupToken called
         const callback: PayPalCardFieldsComponentOptions = {
             createOrder: vi.fn(),
             createVaultSetupToken: vi.fn(),
@@ -36,7 +36,7 @@ describe("testing", () => {
         expect(callback).toThrowError();
     });
 
-    test.skip("Can't have both", () => {
+    test.skip("Can't implement neither", () => {
         // @ts-expect-error: should throw error if neither createOrder or createVaultSetuptoken called
         const callback: PayPalCardFieldsComponentOptions = {
             onApprove: vi.fn(),


### PR DESCRIPTION
This pr is to fix this [LI-73058](https://paypal.atlassian.net/browse/LI-73058)

Problem: the createOrder callback is require when createVaultToken is implement when it should be one or the other and not both. 

Closes #587
Closes #580