### PR TITLE
Fix(deps): DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS

### DIFF
--- a/packages/paypal-js/package.json
+++ b/packages/paypal-js/package.json
@@ -66,7 +66,7 @@
         "jsdom": "^23.0.1",
         "lint-staged": "15.2.0",
         "openapi-typescript": "^6.7.3",
-        "rollup": "4.9.1",
+        "rollup": "4.22.4",
         "semver": "7.5.4",
         "standard-version": "9.5.0",
         "tslib": "2.6.2",


### PR DESCRIPTION
We discovered a DOM Clobbering vulnerability in rollup when bundling scripts that use import.meta.url or with plugins that emit and reference asset files from code in cjs/umd/iife format. The DOM Clobbering gadget can lead to cross-site scripting (XSS) in web pages where scriptless attacker-controlled HTML elements (e.g., an img tag with an unsanitized name attribute) are present.

CVE-2024-47068
[WeaknessCWE-79](https://cwe.mitre.org/data/definitions/79.html)