### PR TITLE
chore: update `repository` field in `package.json` files

### DIFF
--- a/packages/paypal-js/package.json
+++ b/packages/paypal-js/package.json
@@ -43,7 +43,8 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git://github.com/paypal/paypal-js.git"
+        "url": "git://github.com/paypal/paypal-js.git",
+        "directory": "packages/paypal-js"
     },
     "devDependencies": {
         "@commitlint/cli": "18.4.3",

--- a/packages/react-paypal-js/package.json
+++ b/packages/react-paypal-js/package.json
@@ -41,7 +41,8 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git://github.com/paypal/react-paypal-js.git"
+        "url": "git://github.com/paypal/paypal-js.git",
+        "directory": "packages/react-paypal-js"
     },
     "homepage": "https://paypal.github.io/react-paypal-js/",
     "dependencies": {


### PR DESCRIPTION
Two small changes:
- The `repository.url` of `react-paypal-js` was still pointing to the old repository. That URL is used for the "Homepage" link on npm. 
- Added `repository.directory` to point to the correct folder within this repository