### PR TITLE
Upgrade/react bt sdk version

### DIFF
--- a/.changeset/afraid-eyes-impress.md
+++ b/.changeset/afraid-eyes-impress.md
@@ -1,0 +1,7 @@
+---
+"@paypal/react-paypal-js": major
+---
+
+WHAT: Temporary fix for Braintree SDK versioning in React JS SDK. BT SDK version has been upgraded to latest version statically in the React SDK.
+
+WHY: The BT SDK version is statically typed to an old version in our React SDK. As a short-term fix, we need to upgrade this version to the latest statically.

--- a/.changeset/afraid-eyes-impress.md
+++ b/.changeset/afraid-eyes-impress.md
@@ -1,5 +1,5 @@
 ---
-"@paypal/react-paypal-js": major
+"@paypal/react-paypal-js": patch
 ---
 
 WHAT: Temporary fix for Braintree SDK versioning in React JS SDK. BT SDK version has been upgraded to latest version statically in the React SDK.

--- a/packages/react-paypal-js/src/constants.ts
+++ b/packages/react-paypal-js/src/constants.ts
@@ -21,7 +21,7 @@ export const LOAD_SCRIPT_ERROR = "Failed to load the PayPal JS SDK script.";
 export const EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE =
     "Invalid authorization data. Use dataClientToken or dataUserIdToken to authorize.";
 
-const braintreeVersion = "3.84.0";
+const braintreeVersion = "3.117.0";
 export const BRAINTREE_SOURCE = `https://js.braintreegateway.com/web/${braintreeVersion}/js/client.min.js`;
 export const BRAINTREE_PAYPAL_CHECKOUT_SOURCE = `https://js.braintreegateway.com/web/${braintreeVersion}/js/paypal-checkout.min.js`;
 


### PR DESCRIPTION
The BT SDK version is statically typed to an old version in our React SDK. As a short-term fix, we need to upgrade this version to the latest statically. The BT SDK was updated to 3.117.0 in the React SDK.

Jira ticket: [https://paypal.atlassian.net/browse/DTPPCPSDK-3082](url)

