### PR TITLE
fix style fields to CardField Types

### DIFF
--- a/.changeset/curly-otters-clean.md
+++ b/.changeset/curly-otters-clean.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": major
+---
+
+fix style types on CardField react component

--- a/packages/react-paypal-js/src/types/payPalCardFieldsTypes.ts
+++ b/packages/react-paypal-js/src/types/payPalCardFieldsTypes.ts
@@ -36,6 +36,9 @@ export type PayPalCardFieldsNamespace = {
 export type CardFieldStyle = {
     appearance?: string;
     background?: string;
+    border?: string;
+    borderRadius?: string;
+    boxShadow?: string;
     color?: string;
     direction?: string;
     font?: string;
@@ -63,7 +66,7 @@ export type CardFieldStyle = {
     paddingLeft?: string;
     textShadow?: string;
     transition?: string;
-    MozApperance?: string;
+    MozAppearance?: string;
     MozOsxFontSmoothing?: string;
     MozTapHighlightColor?: string;
     MozTransition?: string;


### PR DESCRIPTION
Implement a fix for issue https://github.com/paypal/paypal-js/issues/624

Now the types are matching the docs entirely: https://developer.paypal.com/docs/checkout/advanced/customize/card-field-style/

There is a similar PR already approved (solves a few, but not for all styles): https://github.com/paypal/paypal-js/pull/616

For the MozAppearance, there was a typo error