### PR TITLE
fix shell command built from environment values 

### DIFF
--- a/scripts/readme-package-version.js
+++ b/scripts/readme-package-version.js
@@ -1,6 +1,6 @@
 const { readFileSync, writeFileSync } = require("fs");
 const { join } = require("path");
-const { exec } = require("child_process");
+const { execFile } = require("child_process");
 
 const { version: newVersion } = require("../package.json");
 
@@ -12,7 +12,7 @@ const newReadmeText = readmeText.replace(
 );
 
 writeFileSync(readmeFile, newReadmeText, "utf-8");
-exec(`git add ${readmeFile}`, (error) => {
+execFile("git", ["add", readmeFile], (error) => {
     if (error) {
         console.error(`exec error: ${error}`);
     }


### PR DESCRIPTION
https://github.com/paypal/paypal-js/blob/a2e716e0a0982fe79c8c51e8c04e18755abbc76b/scripts/readme-package-version.js#L3-L15

Fix the issue will replace the use of `exec` with `execFile`, which allows us to pass arguments to the command as an array. This approach avoids the need to dynamically construct the shell command as a single string, thereby preventing the shell from misinterpreting special characters in the file path.

Specifically:
1. Replace the `exec` call with `execFile`.
2. Pass the `git` command as the first argument and the `add` subcommand along with the `readmeFile` path as separate elements in an array.
3. Ensure the callback function remains unchanged to handle potential errors.



