### PR TITLE
feat: Add `loadCoreSdkScript` script loader for v6 sdk

### DIFF
--- a/.changeset/twenty-emus-build.md
+++ b/.changeset/twenty-emus-build.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": minor
+---
+
+Add new script loader for v6 core sdk script

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { loadCoreSdkScript } from "./index";
 import { insertScriptElement, type ScriptElement } from "../utils";
@@ -43,12 +43,12 @@ describe("loadCoreSdkScript()", () => {
 
     test("should error due to unvalid input", async () => {
         expect(async () => {
-            // @ts-ignore invalid arguments
+            // @ts-expect-error invalid arguments
             await loadCoreSdkScript(123);
         }).rejects.toThrowError("Expected an options object");
 
         expect(async () => {
-            // @ts-ignore invalid arguments
+            // @ts-expect-error invalid arguments
             await loadCoreSdkScript({ environment: "bad_value" });
         }).rejects.toThrowError(
             'The "environment" option must be either "production" or "sandbox"',

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
+
+import { loadCoreSdkScript } from "./index";
+import { insertScriptElement, type ScriptElement } from "../utils";
+
+vi.mock("../utils", async () => {
+    const actual = await vi.importActual<typeof import("../utils")>("../utils");
+    return {
+        ...actual,
+        // default mock for insertScriptElement
+        insertScriptElement: vi
+            .fn()
+            .mockImplementation(({ onSuccess }: ScriptElement) => {
+                vi.stubGlobal("paypal", { version: "6" });
+                process.nextTick(() => onSuccess());
+            }),
+    };
+});
+
+const mockedInsertScriptElement = vi.mocked(insertScriptElement);
+
+describe("loadCoreSdkScript()", () => {
+    beforeEach(() => {
+        document.head.innerHTML = "";
+        vi.clearAllMocks();
+    });
+
+    test("should default to using the production environment", async () => {
+        await loadCoreSdkScript();
+        expect(mockedInsertScriptElement.mock.calls[0][0].url).toEqual(
+            "https://www.paypal.com/web-sdk/v6/core",
+        );
+        expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
+    });
+
+    test("should support options for using sandbox environment and enabling debugging", async () => {
+        await loadCoreSdkScript({ environment: "sandbox", debug: true });
+        expect(mockedInsertScriptElement.mock.calls[0][0].url).toEqual(
+            "https://www.sandbox.paypal.com/web-sdk/v6/core?debug=true",
+        );
+        expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
+    });
+
+    test("should error due to unvalid input", async () => {
+        expect(async () => {
+            // @ts-ignore invalid arguments
+            await loadCoreSdkScript(123);
+        }).rejects.toThrowError("Expected an options object");
+
+        expect(async () => {
+            // @ts-ignore invalid arguments
+            await loadCoreSdkScript({ environment: "bad_value" });
+        }).rejects.toThrowError(
+            'The "environment" option must be either "production" or "sandbox"',
+        );
+    });
+});

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -25,16 +25,24 @@ describe("loadCoreSdkScript()", () => {
         vi.clearAllMocks();
     });
 
-    test("should default to using the production environment", async () => {
+    test("should default to using the sandbox environment", async () => {
         await loadCoreSdkScript();
+        expect(mockedInsertScriptElement.mock.calls[0][0].url).toEqual(
+            "https://www.sandbox.paypal.com/web-sdk/v6/core",
+        );
+        expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
+    });
+
+    test("should support options for using production environment", async () => {
+        await loadCoreSdkScript({ environment: "production" });
         expect(mockedInsertScriptElement.mock.calls[0][0].url).toEqual(
             "https://www.paypal.com/web-sdk/v6/core",
         );
         expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
     });
 
-    test("should support options for using sandbox environment and enabling debugging", async () => {
-        await loadCoreSdkScript({ environment: "sandbox", debug: true });
+    test("should support enabling debugging", async () => {
+        await loadCoreSdkScript({ debug: true });
         expect(mockedInsertScriptElement.mock.calls[0][0].url).toEqual(
             "https://www.sandbox.paypal.com/web-sdk/v6/core?debug=true",
         );

--- a/packages/paypal-js/src/v6/index.ts
+++ b/packages/paypal-js/src/v6/index.ts
@@ -1,13 +1,64 @@
-import { loadCustomScript as originalLoadCustomScript } from "../load-script";
+import { insertScriptElement } from "../utils";
 
 const version = "__VERSION__";
 
-// V6-specific loadCustomScript without PromisePonyfill
-function loadCustomScript(options: {
-    url: string;
-    attributes?: Record<string, string>;
-}): Promise<void> {
-    return originalLoadCustomScript(options); // Uses default Promise
+type LoadScriptOptions = {
+    environment?: "production" | "sandbox";
+    debug?: boolean;
+};
+
+function loadCoreSdkScript(options: LoadScriptOptions = {}) {
+    validateArguments(options);
+    const { environment, debug } = options;
+
+    // resolve with null when running in Node or Deno
+    if (typeof document === "undefined") return Promise.resolve(null);
+
+    const baseURL =
+        environment === "sandbox"
+            ? "https://www.sandbox.paypal.com"
+            : "https://www.paypal.com";
+    const url = new URL("/web-sdk/v6/core", baseURL);
+
+    if (debug) {
+        url.searchParams.append("debug", "true");
+    }
+
+    insertScriptElement({
+        url: url.toString(),
+        onSuccess: () => {
+            if (!window.paypal) {
+                return Promise.reject(
+                    "The window.paypal global variable is not available",
+                );
+            }
+            return Promise.resolve(window.paypal);
+        },
+        onError: () => {
+            const defaultError = new Error(
+                `The script "${url}" failed to load. Check the HTTP status code and response body in DevTools to learn more.`,
+            );
+
+            return Promise.reject(defaultError);
+        },
+    });
 }
 
-export { loadCustomScript, version };
+function validateArguments(options: unknown) {
+    if (typeof options !== "object" || options === null) {
+        throw new Error("Expected an options object");
+    }
+    const { environment } = options as LoadScriptOptions;
+
+    if (
+        environment &&
+        environment !== "production" &&
+        environment !== "sandbox"
+    ) {
+        throw new Error(
+            'The "environment" option must be either "production" or "sandbox"',
+        );
+    }
+}
+
+export { loadCoreSdkScript, version };

--- a/packages/paypal-js/src/v6/index.ts
+++ b/packages/paypal-js/src/v6/index.ts
@@ -15,9 +15,9 @@ function loadCoreSdkScript(options: LoadScriptOptions = {}) {
     if (typeof document === "undefined") return Promise.resolve(null);
 
     const baseURL =
-        environment === "sandbox"
-            ? "https://www.sandbox.paypal.com"
-            : "https://www.paypal.com";
+        environment === "production"
+            ? "https://www.paypal.com"
+            : "https://www.sandbox.paypal.com";
     const url = new URL("/web-sdk/v6/core", baseURL);
 
     if (debug) {


### PR DESCRIPTION
This PR adds the `loadCoreSdkScript()` script loader function for v6. Ex:
```ts
import {
  loadCoreSdkScript
} from "@paypal/paypal-js/sdk-v6";

const paypalNamespaceReference = await loadCoreSdkScript({ environment: "sandbox", debug: true });
const sdkInstance = await paypalNamespaceReference.createInstance({ 
  clientToken, 
  components: ["paypal-payments"] 
});
```

The `loadCustomScript()` function was removed and replaced with this new `loadCoreSdkScript()` function for improved readability.