### PR TITLE
(chore) add types for PPCP v5 App Switch

### DIFF
--- a/.changeset/mean-chefs-love.md
+++ b/.changeset/mean-chefs-love.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Adds types for v5 Direct App Switch

--- a/packages/paypal-js/types/components/buttons.d.ts
+++ b/packages/paypal-js/types/components/buttons.d.ts
@@ -351,7 +351,7 @@ export interface PayPalButtonsComponentOptions {
      */
     message?: PayPalButtonMessage;
     /**
-     * When true, clicking on the button will first attempt to open paysheet in PayPal app before opening Checkout window when supported.
+     * When true, clicking the button will first attempt to open the paysheet in the PayPal app (if supported). If not supported, Checkout will open in the web flow.
      */
     appSwitchWhenAvailable?: boolean;
 }

--- a/packages/paypal-js/types/components/buttons.d.ts
+++ b/packages/paypal-js/types/components/buttons.d.ts
@@ -350,6 +350,10 @@ export interface PayPalButtonsComponentOptions {
      * [Message options](https://developer.paypal.com/sdk/js/reference/#message) for customizing the message appearance and limited content control.
      */
     message?: PayPalButtonMessage;
+    /**
+     * When true, clicking on the button will first attempt to open paysheet in PayPal app before opening Checkout window when supported.
+     * */
+    appSwitchWhenAvailable?: boolean;
 }
 
 export interface PayPalButtonsComponent {
@@ -357,4 +361,6 @@ export interface PayPalButtonsComponent {
     isEligible: () => boolean;
     render: (container: HTMLElement | string) => Promise<void>;
     updateProps: (props: PayPalButtonsComponentOptions) => Promise<void>;
+    resume?: () => void;
+    hasReturned?: () => boolean;
 }

--- a/packages/paypal-js/types/components/buttons.d.ts
+++ b/packages/paypal-js/types/components/buttons.d.ts
@@ -352,7 +352,7 @@ export interface PayPalButtonsComponentOptions {
     message?: PayPalButtonMessage;
     /**
      * When true, clicking on the button will first attempt to open paysheet in PayPal app before opening Checkout window when supported.
-     * */
+     */
     appSwitchWhenAvailable?: boolean;
 }
 

--- a/packages/paypal-js/types/components/buttons.d.ts
+++ b/packages/paypal-js/types/components/buttons.d.ts
@@ -361,6 +361,6 @@ export interface PayPalButtonsComponent {
     isEligible: () => boolean;
     render: (container: HTMLElement | string) => Promise<void>;
     updateProps: (props: PayPalButtonsComponentOptions) => Promise<void>;
-    resume?: () => void;
-    hasReturned?: () => boolean;
+    resume: () => void;
+    hasReturned: () => boolean;
 }


### PR DESCRIPTION
Extends `PayPalButtonsComponent` and `PayPalButtonsComponentOptions` to include direct app switch props and methods.