### PR TITLE
Fix style fields to CardField Types

### DIFF
--- a/.changeset/few-countries-develop.md
+++ b/.changeset/few-countries-develop.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": major
+---
+
+Added the missing style properties to the type definitions so developers can correctly pass styling options to PayPal card fields or PayPalCardFieldsProvider without TypeScript errors.

--- a/packages/paypal-js/types/components/card-fields.d.ts
+++ b/packages/paypal-js/types/components/card-fields.d.ts
@@ -3,6 +3,9 @@ export interface PayPalCardFieldsStyleOptions {
     color?: string;
     direction?: string;
     font?: string;
+    border?: string;
+    borderRadius?: string;
+    boxShadow?: string;
     "font-family"?: string;
     "font-size"?: string;
     "font-size-adjust"?: string;


### PR DESCRIPTION
This MR fixes a TypeScript bug with the style prop in PayPal Card Fields that was reported in [#624](https://github.com/paypal/paypal-js/issues/624)

The previous fix attempt in [#640](https://github.com/paypal/paypal-js/pull/640) did not resolve the issue because it updated `CardFieldStyle`, which is not used in the Card Fields type chain.

Here’s the actual type flow:

`PayPalCardFieldsProvider` → `CardFieldsProviderProps`

`CardFieldsProviderProps` → `PayPalCardFieldsComponentOptions`

`PayPalCardFieldsComponentOptions` → `PayPalCardFieldsComponentCreateOrder`

`PayPalCardFieldsComponentCreateOrder` → `PayPalCardFieldsComponentBasics`

`PayPalCardFieldsComponentBasics` → style: `Record<string, PayPalCardFieldsStyleOptions>`

The problem: `PayPalCardFieldsStyleOptions` was missing the necessary style definitions, so passing valid style options still caused TypeScript errors.

Fix

Added the missing type definitions directly to `PayPalCardFieldsStyleOptions`.

Ensured the style prop in the Card Fields chain now correctly accepts the documented PayPal styling options.

Impact

Developers can now safely pass style options to `PayPalCardFieldsProvider` without TypeScript errors.

Resolves [#624](https://github.com/paypal/paypal-js/issues/624)
 completely.