### PR TITLE
Feat: V6 Context Provider

### DIFF
--- a/packages/paypal-js/src/utils.ts
+++ b/packages/paypal-js/src/utils.ts
@@ -158,3 +158,5 @@ function createScriptElement(
 
     return newScript;
 }
+
+export const isServer = typeof window === "undefined";

--- a/packages/paypal-js/src/v6/index.ts
+++ b/packages/paypal-js/src/v6/index.ts
@@ -8,6 +8,12 @@ const version = "__VERSION__";
 
 function loadCoreSdkScript(options: LoadCoreSdkScriptOptions = {}) {
     validateArguments(options);
+
+    // SSR safeguard
+    if (typeof document === "undefined") {
+        return Promise.resolve(null);
+    }
+
     const { environment, debug } = options;
 
     const baseURL =
@@ -24,7 +30,7 @@ function loadCoreSdkScript(options: LoadCoreSdkScriptOptions = {}) {
         insertScriptElement({
             url: url.toString(),
             onSuccess: () => {
-                if (!window.paypal) {
+                if (typeof window === "undefined" || !window.paypal) {
                     return reject(
                         "The window.paypal global variable is not available",
                     );

--- a/packages/paypal-js/src/v6/index.ts
+++ b/packages/paypal-js/src/v6/index.ts
@@ -1,4 +1,4 @@
-import { insertScriptElement } from "../utils";
+import { insertScriptElement, isServer } from "../utils";
 import type {
     PayPalV6Namespace,
     LoadCoreSdkScriptOptions,
@@ -30,7 +30,7 @@ function loadCoreSdkScript(options: LoadCoreSdkScriptOptions = {}) {
         insertScriptElement({
             url: url.toString(),
             onSuccess: () => {
-                if (typeof window === "undefined" || !window.paypal) {
+                if (isServer || !window.paypal) {
                     return reject(
                         "The window.paypal global variable is not available",
                     );

--- a/packages/paypal-js/types/v6/index.d.ts
+++ b/packages/paypal-js/types/v6/index.d.ts
@@ -190,7 +190,7 @@ export type LoadCoreSdkScriptOptions = {
 
 export function loadCoreSdkScript(
     options: LoadCoreSdkScriptOptions,
-): Promise<PayPalV6Namespace>;
+): Promise<PayPalV6Namespace | null>;
 
 // Components
 export * from "./components/paypal-payments";

--- a/packages/react-paypal-js/src/utils.ts
+++ b/packages/react-paypal-js/src/utils.ts
@@ -95,3 +95,5 @@ export function generateErrorMessage({
 
     return errorMessage;
 }
+
+export const isServer = typeof window === "undefined";

--- a/packages/react-paypal-js/src/v6/components/PayPalInstanceProvider.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalInstanceProvider.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from "react";
+import { loadCoreSdkScript } from "@paypal/paypal-js/sdk-v6";
+
+import { InstanceContext } from "../context/InstanceProviderContext";
+
+import type {
+    CreateInstanceOptions,
+    Components,
+    SdkInstance,
+    EligiblePaymentMethodsOutput,
+    LoadCoreSdkScriptOptions,
+} from "../types";
+import type { FC } from "react";
+
+interface PayPalInstanceProviderProps {
+    options: CreateInstanceOptions<readonly [Components, ...Components[]]>;
+    children: React.ReactNode;
+    scriptOptions: LoadCoreSdkScriptOptions;
+}
+
+export const PayPalInstanceProvider: FC<PayPalInstanceProviderProps> = ({
+    options,
+    children,
+    scriptOptions,
+}: {
+    options: CreateInstanceOptions<readonly [Components, ...Components[]]>;
+    children: React.ReactNode;
+    scriptOptions: LoadCoreSdkScriptOptions;
+}) => {
+    const [sdkInstance, setSdkInstance] = useState<SdkInstance<
+        readonly [Components, ...Components[]]
+    > | null>(null);
+    const [eligiblePaymentMethods, setEligiblePaymentMethods] =
+        useState<EligiblePaymentMethodsOutput | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    // use a useEffect to load the core sdk script
+    // ensure that we take SSR precautions
+    useEffect(() => {
+        // Skip if SSR
+        if (typeof window === "undefined") {
+            setIsLoading(false);
+            return;
+        }
+
+        const controller = new AbortController();
+
+        const initializeSdk = async () => {
+            try {
+                setIsLoading(true);
+                setError(null);
+
+                const paypalNameSapce = await loadCoreSdkScript(scriptOptions);
+
+                if (controller.signal.aborted) {
+                    return;
+                }
+
+                if (!paypalNameSapce) {
+                    throw new Error("PayPal SDK failed to load");
+                }
+
+                const instance = await paypalNameSapce.createInstance(options);
+
+                if (controller.signal.aborted) {
+                    return;
+                }
+
+                setSdkInstance(instance);
+
+                try {
+                    const eligiblePaymentMethods =
+                        await instance.findEligibleMethods({});
+
+                    if (controller.signal.aborted) {
+                        return;
+                    }
+
+                    setEligiblePaymentMethods(eligiblePaymentMethods);
+                } catch (eligibilityErr) {
+                    if (!controller.signal.aborted) {
+                        console.warn(
+                            "Failed to get eligible payment methods:",
+                            eligibilityErr,
+                        );
+                    }
+                }
+
+                if (!controller.signal.aborted) {
+                    setIsLoading(false);
+                }
+            } catch (err) {
+                if (!controller.signal.aborted) {
+                    const error =
+                        err instanceof Error ? err : new Error(String(err));
+                    setError(error);
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        initializeSdk();
+
+        return () => {
+            controller.abort();
+        };
+    }, [options, scriptOptions]);
+
+    return (
+        <InstanceContext.Provider
+            value={{ sdkInstance, eligiblePaymentMethods, isLoading, error }}
+        >
+            {children}
+        </InstanceContext.Provider>
+    );
+};

--- a/packages/react-paypal-js/src/v6/components/PayPalInstanceProvider.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalInstanceProvider.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { loadCoreSdkScript } from "@paypal/paypal-js/sdk-v6";
 
 import { InstanceContext } from "../context/InstanceProviderContext";
+import { isServer } from "../../utils";
 
 import type {
     CreateInstanceOptions,
@@ -10,7 +11,6 @@ import type {
     EligiblePaymentMethodsOutput,
     LoadCoreSdkScriptOptions,
 } from "../types";
-import type { FC } from "react";
 
 interface PayPalInstanceProviderProps {
     options: CreateInstanceOptions<readonly [Components, ...Components[]]>;
@@ -18,7 +18,7 @@ interface PayPalInstanceProviderProps {
     scriptOptions: LoadCoreSdkScriptOptions;
 }
 
-export const PayPalInstanceProvider: FC<PayPalInstanceProviderProps> = ({
+export const PayPalInstanceProvider: React.FC<PayPalInstanceProviderProps> = ({
     options,
     children,
     scriptOptions,
@@ -39,7 +39,7 @@ export const PayPalInstanceProvider: FC<PayPalInstanceProviderProps> = ({
     // ensure that we take SSR precautions
     useEffect(() => {
         // Skip if SSR
-        if (typeof window === "undefined") {
+        if (isServer) {
             setIsLoading(false);
             return;
         }

--- a/packages/react-paypal-js/src/v6/context/InstanceProviderContext.tsx
+++ b/packages/react-paypal-js/src/v6/context/InstanceProviderContext.tsx
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+import { InstanceContextState } from "../types/InstanceProviderTypes";
+
+export const InstanceContext = createContext<InstanceContextState | null>(null);

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalInstance.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalInstance.ts
@@ -9,7 +9,7 @@ import type {
     SdkInstance,
 } from "../types";
 
-function usePayPalInstance(): InstanceContextState {
+export function usePayPalInstance(): InstanceContextState {
     const context = useContext(InstanceContext);
 
     if (context === null) {

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalInstance.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalInstance.ts
@@ -1,0 +1,44 @@
+import { useContext } from "react";
+
+import { InstanceContext } from "../context/InstanceProviderContext";
+
+import type { InstanceContextState } from "../types/InstanceProviderTypes";
+import type {
+    Components,
+    EligiblePaymentMethodsOutput,
+    SdkInstance,
+} from "../types";
+
+function usePayPalInstance(): InstanceContextState {
+    const context = useContext(InstanceContext);
+
+    if (context === null) {
+        throw new Error(
+            "usePayPalInstance must be used within a PayPalInstanceProvider",
+        );
+    }
+
+    return context;
+}
+
+export function usePayPalSdkInstance(): SdkInstance<
+    readonly [Components, ...Components[]]
+> | null {
+    const { sdkInstance } = usePayPalInstance();
+    return sdkInstance;
+}
+
+export function usePayPalEligibleMethods(): EligiblePaymentMethodsOutput | null {
+    const { eligiblePaymentMethods } = usePayPalInstance();
+    return eligiblePaymentMethods;
+}
+
+export function usePayPalLoading(): boolean {
+    const { isLoading } = usePayPalInstance();
+    return isLoading;
+}
+
+export function usePayPalError(): Error | null {
+    const { error } = usePayPalInstance();
+    return error;
+}

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalInstance.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalInstance.ts
@@ -3,11 +3,6 @@ import { useContext } from "react";
 import { InstanceContext } from "../context/InstanceProviderContext";
 
 import type { InstanceContextState } from "../types/InstanceProviderTypes";
-import type {
-    Components,
-    EligiblePaymentMethodsOutput,
-    SdkInstance,
-} from "../types";
 
 export function usePayPalInstance(): InstanceContextState {
     const context = useContext(InstanceContext);
@@ -19,26 +14,4 @@ export function usePayPalInstance(): InstanceContextState {
     }
 
     return context;
-}
-
-export function usePayPalSdkInstance(): SdkInstance<
-    readonly [Components, ...Components[]]
-> | null {
-    const { sdkInstance } = usePayPalInstance();
-    return sdkInstance;
-}
-
-export function usePayPalEligibleMethods(): EligiblePaymentMethodsOutput | null {
-    const { eligiblePaymentMethods } = usePayPalInstance();
-    return eligiblePaymentMethods;
-}
-
-export function usePayPalLoading(): boolean {
-    const { isLoading } = usePayPalInstance();
-    return isLoading;
-}
-
-export function usePayPalError(): Error | null {
-    const { error } = usePayPalInstance();
-    return error;
 }

--- a/packages/react-paypal-js/src/v6/index.ts
+++ b/packages/react-paypal-js/src/v6/index.ts
@@ -1,1 +1,9 @@
 export * from "./types";
+export { PayPalInstanceProvider } from "./components/PayPalInstanceProvider";
+export { InstanceContext } from "./context/InstanceProviderContext";
+export {
+    usePayPalSdkInstance,
+    usePayPalEligibleMethods,
+    usePayPalLoading,
+    usePayPalError,
+} from "./hooks/usePayPalInstance";

--- a/packages/react-paypal-js/src/v6/types/InstanceProviderTypes.ts
+++ b/packages/react-paypal-js/src/v6/types/InstanceProviderTypes.ts
@@ -5,7 +5,7 @@ import type {
 } from "./index";
 
 export interface InstanceContextState {
-    sdkInstance?: SdkInstance<readonly [Components, ...Components[]]> | null;
+    sdkInstance: SdkInstance<readonly [Components, ...Components[]]> | null;
     eligiblePaymentMethods: EligiblePaymentMethodsOutput | null;
     isLoading: boolean;
     error: Error | null;

--- a/packages/react-paypal-js/src/v6/types/InstanceProviderTypes.ts
+++ b/packages/react-paypal-js/src/v6/types/InstanceProviderTypes.ts
@@ -1,0 +1,12 @@
+import type {
+    Components,
+    SdkInstance,
+    EligiblePaymentMethodsOutput,
+} from "./index";
+
+export interface InstanceContextState {
+    sdkInstance?: SdkInstance<readonly [Components, ...Components[]]> | null;
+    eligiblePaymentMethods: EligiblePaymentMethodsOutput | null;
+    isLoading: boolean;
+    error: Error | null;
+}

--- a/packages/react-paypal-js/src/v6/types/InstanceProviderTypes.ts
+++ b/packages/react-paypal-js/src/v6/types/InstanceProviderTypes.ts
@@ -1,8 +1,4 @@
-import type {
-    Components,
-    SdkInstance,
-    EligiblePaymentMethodsOutput,
-} from "./index";
+import type { Components, SdkInstance, EligiblePaymentMethodsOutput } from "./";
 
 export interface InstanceContextState {
     sdkInstance: SdkInstance<readonly [Components, ...Components[]]> | null;

--- a/packages/react-paypal-js/src/v6/types/index.ts
+++ b/packages/react-paypal-js/src/v6/types/index.ts
@@ -1,3 +1,1 @@
-import type { PayPalV6Namespace } from "@paypal/paypal-js/sdk-v6";
-
-export type { PayPalV6Namespace };
+export type * from "@paypal/paypal-js/sdk-v6";

--- a/packages/react-paypal-js/src/v6/types/index.ts
+++ b/packages/react-paypal-js/src/v6/types/index.ts
@@ -1,1 +1,2 @@
 export type * from "@paypal/paypal-js/sdk-v6";
+export * from "./InstanceProviderTypes";


### PR DESCRIPTION
This PR adds a Provider wrapper that can be used to access SDK instance context. This is an initial set of basic changes that leverage `paypal-js`'s `loadCoreSdkScript` and adds SSR related conditions to prevent/guard against running client-side code.

Testing instructions coming soon 👀 🧪 