### PR TITLE
chore: Breakout enums from type file

### DIFF
--- a/packages/react-paypal-js/src/v6/components/PayPalProvider.ssr.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalProvider.ssr.test.tsx
@@ -8,7 +8,7 @@ import { loadCoreSdkScript } from "@paypal/paypal-js/sdk-v6";
 
 import { PayPalProvider } from "./PayPalProvider";
 import { usePayPal } from "../hooks/usePayPal";
-import { INSTANCE_LOADING_STATE } from "../types/PayPalProviderTypes";
+import { INSTANCE_LOADING_STATE } from "../types/PayPalProviderEnums";
 import { isServer } from "../utils";
 import { TEST_CLIENT_TOKEN, expectInitialState } from "./providerTestUtils";
 

--- a/packages/react-paypal-js/src/v6/components/PayPalProvider.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalProvider.test.tsx
@@ -5,7 +5,7 @@ import { loadCoreSdkScript } from "@paypal/paypal-js/sdk-v6";
 
 import { PayPalProvider } from "./PayPalProvider";
 import { usePayPal } from "../hooks/usePayPal";
-import { INSTANCE_LOADING_STATE } from "../types/PayPalProviderTypes";
+import { INSTANCE_LOADING_STATE } from "../types/PayPalProviderEnums";
 import {
     TEST_CLIENT_TOKEN,
     TEST_ERROR_MESSAGE,

--- a/packages/react-paypal-js/src/v6/components/PayPalProvider.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalProvider.tsx
@@ -8,7 +8,7 @@ import {
 import {
     INSTANCE_LOADING_STATE,
     INSTANCE_DISPATCH_ACTION,
-} from "../types/PayPalProviderTypes";
+} from "../types/PayPalProviderEnums";
 import { isServer, useDeepCompareMemoize } from "../utils";
 
 import type {

--- a/packages/react-paypal-js/src/v6/components/providerTestUtils.ts
+++ b/packages/react-paypal-js/src/v6/components/providerTestUtils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { INSTANCE_LOADING_STATE } from "../types/PayPalProviderTypes";
+import { INSTANCE_LOADING_STATE } from "../types/PayPalProviderEnums";
 
 import type { PayPalContextState } from "../types";
 

--- a/packages/react-paypal-js/src/v6/context/PayPalProviderContext.test.ts
+++ b/packages/react-paypal-js/src/v6/context/PayPalProviderContext.test.ts
@@ -4,10 +4,12 @@ import { instanceReducer } from "./PayPalProviderContext";
 import {
     INSTANCE_LOADING_STATE,
     INSTANCE_DISPATCH_ACTION,
+} from "../types/PayPalProviderEnums";
+
+import type {
     PayPalState,
     InstanceAction,
-} from "../types/PayPalProviderTypes";
-
+} from "../types/PayPalProviderTypes.d.ts";
 import type {
     SdkInstance,
     EligiblePaymentMethodsOutput,

--- a/packages/react-paypal-js/src/v6/context/PayPalProviderContext.tsx
+++ b/packages/react-paypal-js/src/v6/context/PayPalProviderContext.tsx
@@ -1,12 +1,15 @@
 import { createContext } from "react";
 
 import {
+    INSTANCE_LOADING_STATE,
+    INSTANCE_DISPATCH_ACTION,
+} from "../types/PayPalProviderEnums";
+
+import type {
     PayPalContextState,
     PayPalState,
     InstanceAction,
-    INSTANCE_LOADING_STATE,
-    INSTANCE_DISPATCH_ACTION,
-} from "../types/PayPalProviderTypes";
+} from "../types/PayPalProviderTypes.d.ts";
 
 export function instanceReducer(
     state: PayPalState,

--- a/packages/react-paypal-js/src/v6/hooks/usePayPal.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPal.ts
@@ -2,7 +2,7 @@ import { useContext } from "react";
 
 import { PayPalContext } from "../context/PayPalProviderContext";
 
-import type { PayPalContextState } from "../types/PayPalProviderTypes";
+import type { PayPalContextState } from "../types/PayPalProviderTypes.d.ts";
 
 export function usePayPal(): PayPalContextState {
     const context = useContext(PayPalContext);

--- a/packages/react-paypal-js/src/v6/types/PayPalProviderEnums.ts
+++ b/packages/react-paypal-js/src/v6/types/PayPalProviderEnums.ts
@@ -1,0 +1,14 @@
+export enum INSTANCE_LOADING_STATE {
+    INITIAL = "initial",
+    PENDING = "pending",
+    RESOLVED = "resolved",
+    REJECTED = "rejected",
+}
+
+export enum INSTANCE_DISPATCH_ACTION {
+    SET_LOADING_STATUS = "setLoadingStatus",
+    SET_INSTANCE = "setInstance",
+    SET_ELIGIBILITY = "setEligibility",
+    SET_ERROR = "setError",
+    RESET_STATE = "resetState",
+}

--- a/packages/react-paypal-js/src/v6/types/PayPalProviderTypes.d.ts
+++ b/packages/react-paypal-js/src/v6/types/PayPalProviderTypes.d.ts
@@ -1,19 +1,8 @@
 import type { Components, SdkInstance, EligiblePaymentMethodsOutput } from ".";
-
-export enum INSTANCE_LOADING_STATE {
-    INITIAL = "initial",
-    PENDING = "pending",
-    RESOLVED = "resolved",
-    REJECTED = "rejected",
-}
-
-export enum INSTANCE_DISPATCH_ACTION {
-    SET_LOADING_STATUS = "setLoadingStatus",
-    SET_INSTANCE = "setInstance",
-    SET_ELIGIBILITY = "setEligibility",
-    SET_ERROR = "setError",
-    RESET_STATE = "resetState",
-}
+import type {
+    INSTANCE_LOADING_STATE,
+    INSTANCE_DISPATCH_ACTION,
+} from "./PayPalProviderEnums";
 
 export interface PayPalState {
     sdkInstance: SdkInstance<readonly [Components, ...Components[]]> | null;

--- a/packages/react-paypal-js/src/v6/types/index.ts
+++ b/packages/react-paypal-js/src/v6/types/index.ts
@@ -1,2 +1,3 @@
 export type * from "@paypal/paypal-js/sdk-v6";
-export * from "./PayPalProviderTypes";
+export type * from "./PayPalProviderTypes";
+export * from "./PayPalProviderEnums";


### PR DESCRIPTION
The build was failing because there were enums inside of the type file