### PR TITLE
feat: only build and deploy docs when specified paths have changes

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -10,7 +10,7 @@ on:
             - "docs/index.html"
             - "docs/paypal-fonts.css"
             - "docs/*.md"
-            - "packages/paypal-js/typedoc.json"
+            - "**/typedoc.json"
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR is for saving CI resources by only building and deploying docs when specified files and file types change. The workflow can still be run manually if changes fall outside of these paths that require publishing the docs.