### PR TITLE
fix: Add missing `paymentSource` key type for `OnApproveData`

### DIFF
--- a/packages/paypal-js/types/components/buttons.d.ts
+++ b/packages/paypal-js/types/components/buttons.d.ts
@@ -50,6 +50,7 @@ export type OnApproveData = {
     orderID: string;
     payerID?: string | null;
     paymentID?: string | null;
+    paymentSource: FUNDING_SOURCE;
     subscriptionID?: string | null;
     authCode?: string | null;
 };


### PR DESCRIPTION
Add missing `paymentSource` key which is present on the data in the `onApprove` callback.

![27n](https://github.com/user-attachments/assets/de3f40ef-5848-40ec-bdf7-fcae8d243bea)
