### PR TITLE
fix: build packages for `build-and-deploy-docs` workflow

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -40,6 +40,9 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
+            - name: Build packages
+              run: npm run build
+
             - name: Build v6 reference documentation
               run: npm run docs:v6
 


### PR DESCRIPTION
This PR builds packages during the `build-and-deploy-docs` workflow in order to fix [the error](https://github.com/paypal/paypal-js/actions/runs/19641243294/job/56244999689#step:6:2564) that occurs when building the v5 storybook:

<img width="1102" height="110" alt="Screenshot 2025-11-24 at 11 45 00 AM" src="https://github.com/user-attachments/assets/7aabda16-1eb6-499b-9eba-697eb3e786b8" />
