### PR TITLE
Updated permissions for trusted publishing for npm packages.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
     id-token: write # Required for OIDC
-    contents: read
+    contents: write
     pull-requests: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This updates the permissions for the GitHub Release Action, which is using trusted publishing, to allow it to create pull-requests. See https://docs.npmjs.com/trusted-publishers for details.