### PR TITLE
feat(paypal-js/types): add missing `vaultSetupToken` to `OnApproveData`

### DIFF
--- a/.changeset/slick-candles-follow.md
+++ b/.changeset/slick-candles-follow.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": major
+---
+
+Add missing vaultSetupToken type definition for OnApproveData

--- a/packages/paypal-js/types/components/buttons.d.ts
+++ b/packages/paypal-js/types/components/buttons.d.ts
@@ -52,6 +52,7 @@ export type OnApproveData = {
     paymentID?: string | null;
     subscriptionID?: string | null;
     authCode?: string | null;
+    vaultSetupToken?: string;
 };
 
 export type OnApproveActions = {


### PR DESCRIPTION
# Summary

This PR adds the missing `vaultSetupToken` property to the `OnApproveData` TypeScript type.

# Background

When using Vault with the PayPal JS SDK, the vaultSetupToken value can be returned in the onApprove callback. However, this field was not previously included in the OnApproveData type definition, leading to incomplete typings and requiring consumers to use type assertions or workarounds.

# Changes

- Added `vaultSetupToken` to the `OnApproveData` type
- Improves TypeScript accuracy for Vault-related integrations
- No runtime behavior changes

# Impact

- TypeScript-only change
- Backward compatible at runtime
- Improves developer experience and type safety

# Checklist

- [x]  Type definitions updated
- [x]  No breaking runtime changes
- [x]  Changelog / changeset included (if applicable)