### PR TITLE
fix: Make `return_url` and `cancel_url` optional in `application_context` for subscriptions

### DIFF
--- a/.changeset/tricky-numbers-cross.md
+++ b/.changeset/tricky-numbers-cross.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": minor
+---
+
+Made return_url and cancel_url optional in subscription application_context

--- a/packages/paypal-js/types/apis/openapi/billing_subscriptions_v1.d.ts
+++ b/packages/paypal-js/types/apis/openapi/billing_subscriptions_v1.d.ts
@@ -1219,12 +1219,12 @@ export interface components {
              * Format: uri
              * @description The URL where the customer is redirected after the customer approves the payment.
              */
-            return_url: string;
+            return_url?: string;
             /**
              * Format: uri
              * @description The URL where the customer is redirected after the customer cancels the payment.
              */
-            cancel_url: string;
+            cancel_url?: string;
         };
         /**
          * Billing Cycle Override

--- a/packages/paypal-js/types/tests/buttons.test.ts
+++ b/packages/paypal-js/types/tests/buttons.test.ts
@@ -76,6 +76,21 @@ async function main() {
         },
     });
 
+    // createSubscription with application_context (return_url and cancel_url are optional)
+    paypal.Buttons({
+        style: { label: "subscribe" },
+        createSubscription: (data, actions) => {
+            return actions.subscription.create({
+                plan_id: "P-3RX123456M3469222L5IFM4I",
+                quantity: "1",
+                application_context: {
+                    brand_name: "My Brand",
+                    shipping_preference: "NO_SHIPPING",
+                },
+            });
+        },
+    });
+
     // validation with onInit and onClick
     // https://developer.paypal.com/docs/checkout/standard/customize/validate-user-input/
     paypal.Buttons({


### PR DESCRIPTION
### Context

Fixes #716
See also: #238

A TypeScript error occurs when using the PayPal JS SDK Buttons integration for subscriptions without specifying `return_url` and `cancel_url` in `application_context`, even though [previous guidance](https://github.com/paypal/paypal-js/issues/238) states these fields are not required/recommended for the JS SDK flow.

Error:
```
TS2739: Type `application_context` is missing the following properties: return_url, cancel_url
billing_subscriptions_v1.d.ts(1301, 13): The expected type comes from property application_context which is declared here on type ...
```

See #716 for minimal reproduction steps

### Change

Updated the type definition for `application_context` to make `return_url` and `cancel_url` optional.