### PR TITLE
Temp: Ignore react-paypal-js changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
     "access": "restricted",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
-    "ignore": []
+    "ignore": ["@paypal/react-paypal-js"]
 }


### PR DESCRIPTION
This PR temporarily adds `@paypal/react-paypal-js` to the `ignore` list in the changeset config. This will allow us to publish `paypal-js` using the standard github action without having to isolate the `react-paypal-js`-specific changesets.

This should work b/c there are no changesets that include both packages within them, PRs that had changes in both packages used multiple changesets in order to tie package-specific changes to a unique changeset.