### PR TITLE
fix: return isLoading=true when eligibility data is stale due to payl…

### DIFF
--- a/.changeset/fix-eligibility-stale-loading.md
+++ b/.changeset/fix-eligibility-stale-loading.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Fix useEligibleMethods hook returning isLoading=false with stale eligibility data when payload changes (e.g., navigating between different payment flows)

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -660,6 +660,23 @@ function PaymentOptions() {
 }
 ```
 
+#### Stale Eligibility Data Prevention
+
+When navigating between different payment flows (e.g., from a save payment page with `paymentFlow: "VAULT_WITHOUT_PAYMENT"` to a checkout page with `paymentFlow: "ONE_TIME_PAYMENT"`), `isLoading` will return `true` while the new eligibility data is being fetched. This prevents stale buttons from flashing before the updated eligibility response arrives.
+
+If your app uses a single `PayPalProvider` across multiple routes with different `paymentFlow` values, always check `isLoading` before rendering eligibility-dependent buttons:
+
+```tsx
+const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+    payload: { currencyCode: "USD", paymentFlow: "ONE_TIME_PAYMENT" },
+});
+
+// Guard eligibility-dependent buttons with isLoading to avoid rendering
+// buttons based on stale data from a previous payment flow
+const isPayLaterEligible =
+    !isLoading && eligiblePaymentMethods?.isEligible("paylater");
+```
+
 ### usePayPalMessages
 
 Hook for integrating PayPal messaging (Pay Later promotions).

--- a/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.test.ts
@@ -381,6 +381,35 @@ describe("useEligibleMethods", () => {
             expect(result.current.isLoading).toBe(true);
         });
 
+        test("should return isLoading=true when eligibility data exists but payload differs (stale data)", () => {
+            const mockSdkInstance = createMockSdkInstance();
+
+            const { result } = renderHook(
+                () =>
+                    useEligibleMethods({
+                        payload: {
+                            currencyCode: "USD",
+                            paymentFlow: "ONE_TIME_PAYMENT",
+                        } as never,
+                    }),
+                {
+                    wrapper: createWrapper({
+                        sdkInstance: mockSdkInstance,
+                        eligiblePaymentMethods: mockEligibilityResult,
+                        eligiblePaymentMethodsPayload: {
+                            currencyCode: "USD",
+                            paymentFlow: "VAULT_WITHOUT_PAYMENT",
+                        }, // different paymentFlow
+                        loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
+                    }),
+                },
+            );
+
+            // isLoading should be true because the existing data was fetched
+            // with a different payload — it's stale and a re-fetch is needed
+            expect(result.current.isLoading).toBe(true);
+        });
+
         test("should return isLoading=false when eligibility data exists with matching payload", () => {
             const mockSdkInstance = createMockSdkInstance();
 

--- a/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.ts
@@ -164,10 +164,22 @@ export function useEligibleMethods(
 
     // isLoading should be true if:
     // 1. We're actively fetching, OR
-    // 2. We don't have eligibility data yet and no error occurred
-    // This prevents a flash where isLoading=false before the effect runs
+    // 2. We don't have eligibility data yet and no error occurred, OR
+    // 3. Eligibility data exists but was fetched with a different payload
+    //    (e.g., navigating from VAULT_WITHOUT_PAYMENT to ONE_TIME_PAYMENT)
+    // This prevents a flash of stale buttons before the new fetch completes
+    const isStaleData =
+        !!eligiblePaymentMethods &&
+        // Normalize null to undefined so deepEqual doesn't treat
+        // null (no stored payload) as different from undefined (no provided payload)
+        !deepEqual(
+            eligiblePaymentMethodsPayload ?? undefined,
+            memoizedPayload ?? undefined,
+        );
     const isLoading =
-        isFetching || (!eligiblePaymentMethods && !eligibilityError);
+        isFetching ||
+        (!eligiblePaymentMethods && !eligibilityError) ||
+        isStaleData;
 
     if (contextError) {
         return {


### PR DESCRIPTION
Fix issue of using cached eligibility when there's a change in payload