### PR TITLE
update to resolve ambiguity in usage of our buttons

### DIFF
--- a/packages/react-paypal-js-storybook/v6/src/components/V6DocPageStructure.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/components/V6DocPageStructure.tsx
@@ -18,8 +18,12 @@ import {
  */
 const V6DocPageStructure = ({
     code = "",
+    codeTitle,
+    additionalExamples = [],
 }: {
     code: string;
+    codeTitle?: string;
+    additionalExamples?: Array<{ title: string; code: string }>;
 }): React.JSX.Element => (
     <>
         <Title />
@@ -29,7 +33,14 @@ const V6DocPageStructure = ({
             <Primary />
         </Canvas>
         <h3>Example Code</h3>
+        {codeTitle && <h4>{codeTitle}</h4>}
         <Source language="tsx" code={code} dark={false} />
+        {additionalExamples.map(({ title, code }) => (
+            <React.Fragment key={title}>
+                <h4>{title}</h4>
+                <Source language="tsx" code={code} dark={false} />
+            </React.Fragment>
+        ))}
         <ArgTypes />
     </>
 );

--- a/packages/react-paypal-js-storybook/v6/src/shared/code.ts
+++ b/packages/react-paypal-js-storybook/v6/src/shared/code.ts
@@ -271,6 +271,7 @@ export default function App() {
 export const getPayLaterOneTimePaymentButtonCode = (): string => `
 // Option 1: Lazy order creation (Recommended)
 // The order is created only when the buyer clicks the button.
+// Pay Later requires an eligibility check before rendering.
 import {
     PayPalProvider,
     PayLaterOneTimePaymentButton,
@@ -287,12 +288,23 @@ async function createOrder() {
 }
 
 function Checkout() {
-    useEligibleMethods({
+    const {
+        eligiblePaymentMethods,
+        isLoading: isEligibilityLoading,
+        error: eligibilityError,
+    } = useEligibleMethods({
         payload: {
             currencyCode: "USD",
             paymentFlow: "ONE_TIME_PAYMENT",
         },
     });
+
+    const isPayLaterEligible =
+        !isEligibilityLoading && eligiblePaymentMethods?.isEligible("paylater");
+
+    if (isEligibilityLoading) return <div>Checking eligibility...</div>;
+    if (eligibilityError) return <div>Failed to check eligibility.</div>;
+    if (!isPayLaterEligible) return null;
 
     return (
         <PayLaterOneTimePaymentButton
@@ -323,6 +335,7 @@ export default function App() {
 export const getPayLaterOneTimePaymentButtonEagerCode = (): string => `
 // Option 2: Eager order creation
 // The order is created on page load and passed directly as a prop.
+// Pay Later requires an eligibility check before rendering.
 import { useEffect, useState } from "react";
 import {
     PayPalProvider,
@@ -333,12 +346,18 @@ import {
 function Checkout() {
     const [orderId, setOrderId] = useState<string | null>(null);
 
-    useEligibleMethods({
+    const {
+        eligiblePaymentMethods,
+        isLoading: isEligibilityLoading,
+    } = useEligibleMethods({
         payload: {
             currencyCode: "USD",
             paymentFlow: "ONE_TIME_PAYMENT",
         },
     });
+
+    const isPayLaterEligible =
+        !isEligibilityLoading && eligiblePaymentMethods?.isEligible("paylater");
 
     useEffect(() => {
         fetch("/api/paypal/create-order", {
@@ -349,7 +368,8 @@ function Checkout() {
             .then((data) => setOrderId(data.id));
     }, []);
 
-    if (!orderId) return <div>Loading...</div>;
+    if (isEligibilityLoading || !orderId) return <div>Loading...</div>;
+    if (!isPayLaterEligible) return null;
 
     return (
         <PayLaterOneTimePaymentButton
@@ -499,6 +519,7 @@ export default function App() {
 export const getPayPalCreditSavePaymentButtonCode = (): string => `
 // Option 1: Lazy vault token creation (Recommended)
 // The vault setup token is created only when the buyer clicks the button.
+// PayPal Credit requires an eligibility check before rendering.
 import {
     PayPalProvider,
     PayPalCreditSavePaymentButton,
@@ -515,12 +536,23 @@ async function createVaultToken() {
 }
 
 function Checkout() {
-    useEligibleMethods({
+    const {
+        eligiblePaymentMethods,
+        isLoading: isEligibilityLoading,
+        error: eligibilityError,
+    } = useEligibleMethods({
         payload: {
             currencyCode: "USD",
             paymentFlow: "VAULT_WITHOUT_PAYMENT",
         },
     });
+
+    const isCreditEligible =
+        !isEligibilityLoading && eligiblePaymentMethods?.isEligible("credit");
+
+    if (isEligibilityLoading) return <div>Checking eligibility...</div>;
+    if (eligibilityError) return <div>Failed to check eligibility.</div>;
+    if (!isCreditEligible) return null;
 
     return (
         <PayPalCreditSavePaymentButton
@@ -549,6 +581,7 @@ export default function App() {
 export const getPayPalCreditSavePaymentButtonEagerCode = (): string => `
 // Option 2: Eager vault token creation
 // The vault setup token is created on page load and passed directly as a prop.
+// PayPal Credit requires an eligibility check before rendering.
 import { useEffect, useState } from "react";
 import {
     PayPalProvider,
@@ -559,12 +592,18 @@ import {
 function Checkout() {
     const [vaultSetupToken, setVaultSetupToken] = useState<string | null>(null);
 
-    useEligibleMethods({
+    const {
+        eligiblePaymentMethods,
+        isLoading: isEligibilityLoading,
+    } = useEligibleMethods({
         payload: {
             currencyCode: "USD",
             paymentFlow: "VAULT_WITHOUT_PAYMENT",
         },
     });
+
+    const isCreditEligible =
+        !isEligibilityLoading && eligiblePaymentMethods?.isEligible("credit");
 
     useEffect(() => {
         fetch("/api/paypal/create-vault-token", {
@@ -575,7 +614,8 @@ function Checkout() {
             .then((data) => setVaultSetupToken(data.id));
     }, []);
 
-    if (!vaultSetupToken) return <div>Loading...</div>;
+    if (isEligibilityLoading || !vaultSetupToken) return <div>Loading...</div>;
+    if (!isCreditEligible) return null;
 
     return (
         <PayPalCreditSavePaymentButton
@@ -606,6 +646,7 @@ export default function App() {
 export const getCardFieldsOneTimePaymentCode = (): string => `
 // Option 1: One-Time Payment (Recommended for standard checkout)
 // Create an order, then submit the card details to capture payment.
+// Card Fields require an eligibility check with isEligible("advanced_cards").
 import {
     PayPalProvider,
     PayPalCardFieldsProvider,
@@ -614,6 +655,7 @@ import {
     PayPalCardCvvField,
     usePayPalCardFields,
     usePayPalCardFieldsOneTimePaymentSession,
+    useEligibleMethods,
 } from "@paypal/react-paypal-js/sdk-v6";
 import { useEffect } from "react";
 
@@ -633,7 +675,7 @@ async function captureOrder(orderId: string) {
     return response.json();
 }
 
-function CardFieldsForm() {
+function CardFields() {
     const { error: cardFieldsError } = usePayPalCardFields();
     const { error: submitError, submit, submitResponse } =
         usePayPalCardFieldsOneTimePaymentSession();
@@ -654,6 +696,12 @@ function CardFieldsForm() {
                 break;
         }
     }, [submitResponse]);
+
+    useEffect(() => {
+        if (submitError) {
+            console.error("Card submission error:", submitError.message);
+        }
+    }, [submitError]);
 
     const handleSubmit = async () => {
         const { orderId } = await createOrder();
@@ -681,6 +729,33 @@ function CardFieldsForm() {
     );
 }
 
+function Checkout() {
+    const {
+        eligiblePaymentMethods,
+        isLoading: isEligibilityLoading,
+        error: eligibilityError,
+    } = useEligibleMethods({
+        payload: {
+            currencyCode: "USD",
+            paymentFlow: "ONE_TIME_PAYMENT",
+        },
+    });
+
+    const isCardFieldsEligible =
+        !isEligibilityLoading &&
+        eligiblePaymentMethods?.isEligible("advanced_cards");
+
+    if (isEligibilityLoading) return <div>Checking eligibility...</div>;
+    if (eligibilityError) return <div>Failed to check eligibility.</div>;
+    if (!isCardFieldsEligible) return null;
+
+    return (
+        <PayPalCardFieldsProvider>
+            <CardFields />
+        </PayPalCardFieldsProvider>
+    );
+}
+
 export default function App() {
     return (
         <PayPalProvider
@@ -688,9 +763,7 @@ export default function App() {
             components={["card-fields"]}
             pageType="checkout"
         >
-            <PayPalCardFieldsProvider>
-                <CardFieldsForm />
-            </PayPalCardFieldsProvider>
+            <Checkout />
         </PayPalProvider>
     );
 }
@@ -699,6 +772,7 @@ export default function App() {
 export const getCardFieldsSavePaymentCode = (): string => `
 // Option 2: Save Payment Method (for vaulting cards without immediate payment)
 // Create a vault setup token, then submit the card details to save the payment method.
+// Card Fields require an eligibility check with isEligible("advanced_cards").
 import {
     PayPalProvider,
     PayPalCardFieldsProvider,
@@ -707,6 +781,7 @@ import {
     PayPalCardCvvField,
     usePayPalCardFields,
     usePayPalCardFieldsSavePaymentSession,
+    useEligibleMethods,
 } from "@paypal/react-paypal-js/sdk-v6";
 import { useEffect } from "react";
 
@@ -719,7 +794,7 @@ async function createVaultSetupToken() {
     return data.id;
 }
 
-function CardFieldsForm() {
+function CardFields() {
     const { error: cardFieldsError } = usePayPalCardFields();
     const { error: submitError, submit, submitResponse } =
         usePayPalCardFieldsSavePaymentSession();
@@ -738,6 +813,12 @@ function CardFieldsForm() {
                 break;
         }
     }, [submitResponse]);
+
+    useEffect(() => {
+        if (submitError) {
+            console.error("Card submission error:", submitError.message);
+        }
+    }, [submitError]);
 
     const handleSubmit = async () => {
         const vaultSetupToken = await createVaultSetupToken();
@@ -765,6 +846,33 @@ function CardFieldsForm() {
     );
 }
 
+function Checkout() {
+    const {
+        eligiblePaymentMethods,
+        isLoading: isEligibilityLoading,
+        error: eligibilityError,
+    } = useEligibleMethods({
+        payload: {
+            currencyCode: "USD",
+            paymentFlow: "VAULT_WITHOUT_PAYMENT",
+        },
+    });
+
+    const isCardFieldsEligible =
+        !isEligibilityLoading &&
+        eligiblePaymentMethods?.isEligible("advanced_cards");
+
+    if (isEligibilityLoading) return <div>Checking eligibility...</div>;
+    if (eligibilityError) return <div>Failed to check eligibility.</div>;
+    if (!isCardFieldsEligible) return null;
+
+    return (
+        <PayPalCardFieldsProvider>
+            <CardFields />
+        </PayPalCardFieldsProvider>
+    );
+}
+
 export default function App() {
     return (
         <PayPalProvider
@@ -772,9 +880,7 @@ export default function App() {
             components={["card-fields"]}
             pageType="checkout"
         >
-            <PayPalCardFieldsProvider>
-                <CardFieldsForm />
-            </PayPalCardFieldsProvider>
+            <Checkout />
         </PayPalProvider>
     );
 }

--- a/packages/react-paypal-js-storybook/v6/src/shared/code.ts
+++ b/packages/react-paypal-js-storybook/v6/src/shared/code.ts
@@ -1,8 +1,16 @@
 /**
  * Code examples for V6 Button components
+ *
+ * Each button with XOR props (e.g., createOrder vs orderId) has two code examples:
+ * - A "lazy" (recommended) example where the resource is created on button click
+ * - An "eager" example where the resource is pre-created before rendering
  */
 
+// ─── PayPalOneTimePaymentButton ─────────────────────────────────────────────
+
 export const getPayPalOneTimePaymentButtonCode = (): string => `
+// Option 1: Lazy order creation (Recommended)
+// The order is created only when the buyer clicks the button.
 import { PayPalProvider, PayPalOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 async function createOrder() {
@@ -45,7 +53,62 @@ export default function App() {
 }
 `;
 
+export const getPayPalOneTimePaymentButtonEagerCode = (): string => `
+// Option 2: Eager order creation
+// The order is created on page load and passed directly as a prop.
+// Useful when you need to create the order before the button renders
+// (e.g., server-side order creation, or shared order across multiple buttons).
+import { useEffect, useState } from "react";
+import { PayPalProvider, PayPalOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
+
+function Checkout() {
+    const [orderId, setOrderId] = useState<string | null>(null);
+
+    useEffect(() => {
+        fetch("/api/paypal/create-order", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+        })
+            .then((res) => res.json())
+            .then((data) => setOrderId(data.id));
+    }, []);
+
+    if (!orderId) return <div>Loading...</div>;
+
+    return (
+        <PayPalOneTimePaymentButton
+            orderId={orderId}
+            onApprove={async (data) => {
+                await fetch(\`/api/paypal/capture/\${data.orderId}\`, {
+                    method: "POST",
+                });
+            }}
+            onCancel={(data) => console.log("Cancelled:", data)}
+            onError={(error) => console.error("Error:", error)}
+            presentationMode="auto"
+            type="checkout"
+        />
+    );
+}
+
+export default function App() {
+    return (
+        <PayPalProvider
+            clientId="YOUR_CLIENT_ID"
+            components={["paypal-payments"]}
+            pageType="checkout"
+        >
+            <Checkout />
+        </PayPalProvider>
+    );
+}
+`;
+
+// ─── VenmoOneTimePaymentButton ──────────────────────────────────────────────
+
 export const getVenmoOneTimePaymentButtonCode = (): string => `
+// Option 1: Lazy order creation (Recommended)
+// The order is created only when the buyer clicks the button.
 import { PayPalProvider, VenmoOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 async function createOrder() {
@@ -78,7 +141,57 @@ export default function App() {
 }
 `;
 
+export const getVenmoOneTimePaymentButtonEagerCode = (): string => `
+// Option 2: Eager order creation
+// The order is created on page load and passed directly as a prop.
+import { useEffect, useState } from "react";
+import { PayPalProvider, VenmoOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
+
+function Checkout() {
+    const [orderId, setOrderId] = useState<string | null>(null);
+
+    useEffect(() => {
+        fetch("/api/paypal/create-order", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+        })
+            .then((res) => res.json())
+            .then((data) => setOrderId(data.id));
+    }, []);
+
+    if (!orderId) return <div>Loading...</div>;
+
+    return (
+        <VenmoOneTimePaymentButton
+            orderId={orderId}
+            onApprove={async (data) => {
+                await fetch(\`/api/paypal/capture/\${data.orderId}\`, {
+                    method: "POST",
+                });
+            }}
+            presentationMode="auto"
+        />
+    );
+}
+
+export default function App() {
+    return (
+        <PayPalProvider
+            clientId="YOUR_CLIENT_ID"
+            components={["venmo-payments"]}
+            pageType="checkout"
+        >
+            <Checkout />
+        </PayPalProvider>
+    );
+}
+`;
+
+// ─── PayPalSavePaymentButton ────────────────────────────────────────────────
+
 export const getPayPalSavePaymentButtonCode = (): string => `
+// Option 1: Lazy vault token creation (Recommended)
+// The vault setup token is created only when the buyer clicks the button.
 import { PayPalProvider, PayPalSavePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 async function createVaultToken() {
@@ -109,7 +222,55 @@ export default function App() {
 }
 `;
 
+export const getPayPalSavePaymentButtonEagerCode = (): string => `
+// Option 2: Eager vault token creation
+// The vault setup token is created on page load and passed directly as a prop.
+import { useEffect, useState } from "react";
+import { PayPalProvider, PayPalSavePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
+
+function Checkout() {
+    const [vaultSetupToken, setVaultSetupToken] = useState<string | null>(null);
+
+    useEffect(() => {
+        fetch("/api/paypal/create-vault-token", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+        })
+            .then((res) => res.json())
+            .then((data) => setVaultSetupToken(data.id));
+    }, []);
+
+    if (!vaultSetupToken) return <div>Loading...</div>;
+
+    return (
+        <PayPalSavePaymentButton
+            vaultSetupToken={vaultSetupToken}
+            onApprove={async (data) => {
+                console.log("Payment method saved:", data.vaultSetupToken);
+            }}
+            presentationMode="auto"
+        />
+    );
+}
+
+export default function App() {
+    return (
+        <PayPalProvider
+            clientId="YOUR_CLIENT_ID"
+            components={["paypal-payments"]}
+            pageType="checkout"
+        >
+            <Checkout />
+        </PayPalProvider>
+    );
+}
+`;
+
+// ─── PayLaterOneTimePaymentButton ───────────────────────────────────────────
+
 export const getPayLaterOneTimePaymentButtonCode = (): string => `
+// Option 1: Lazy order creation (Recommended)
+// The order is created only when the buyer clicks the button.
 import {
     PayPalProvider,
     PayLaterOneTimePaymentButton,
@@ -159,7 +320,68 @@ export default function App() {
 }
 `;
 
+export const getPayLaterOneTimePaymentButtonEagerCode = (): string => `
+// Option 2: Eager order creation
+// The order is created on page load and passed directly as a prop.
+import { useEffect, useState } from "react";
+import {
+    PayPalProvider,
+    PayLaterOneTimePaymentButton,
+    useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
+
+function Checkout() {
+    const [orderId, setOrderId] = useState<string | null>(null);
+
+    useEligibleMethods({
+        payload: {
+            currencyCode: "USD",
+            paymentFlow: "ONE_TIME_PAYMENT",
+        },
+    });
+
+    useEffect(() => {
+        fetch("/api/paypal/create-order", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+        })
+            .then((res) => res.json())
+            .then((data) => setOrderId(data.id));
+    }, []);
+
+    if (!orderId) return <div>Loading...</div>;
+
+    return (
+        <PayLaterOneTimePaymentButton
+            orderId={orderId}
+            onApprove={async (data) => {
+                await fetch(\`/api/paypal/capture/\${data.orderId}\`, {
+                    method: "POST",
+                });
+            }}
+            presentationMode="auto"
+        />
+    );
+}
+
+export default function App() {
+    return (
+        <PayPalProvider
+            clientId="YOUR_CLIENT_ID"
+            components={["paypal-payments"]}
+            pageType="checkout"
+        >
+            <Checkout />
+        </PayPalProvider>
+    );
+}
+`;
+
+// ─── PayPalGuestPaymentButton ───────────────────────────────────────────────
+
 export const getPayPalGuestPaymentButtonCode = (): string => `
+// Option 1: Lazy order creation (Recommended)
+// The order is created only when the buyer clicks the button.
 import { PayPalProvider, PayPalGuestPaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 async function createOrder() {
@@ -190,6 +412,53 @@ export default function App() {
     );
 }
 `;
+
+export const getPayPalGuestPaymentButtonEagerCode = (): string => `
+// Option 2: Eager order creation
+// The order is created on page load and passed directly as a prop.
+import { useEffect, useState } from "react";
+import { PayPalProvider, PayPalGuestPaymentButton } from "@paypal/react-paypal-js/sdk-v6";
+
+function Checkout() {
+    const [orderId, setOrderId] = useState<string | null>(null);
+
+    useEffect(() => {
+        fetch("/api/paypal/create-order", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+        })
+            .then((res) => res.json())
+            .then((data) => setOrderId(data.id));
+    }, []);
+
+    if (!orderId) return <div>Loading...</div>;
+
+    return (
+        <PayPalGuestPaymentButton
+            orderId={orderId}
+            onApprove={async (data) => {
+                await fetch(\`/api/paypal/capture/\${data.orderId}\`, {
+                    method: "POST",
+                });
+            }}
+        />
+    );
+}
+
+export default function App() {
+    return (
+        <PayPalProvider
+            clientId="YOUR_CLIENT_ID"
+            components={["paypal-guest-payments"]}
+            pageType="checkout"
+        >
+            <Checkout />
+        </PayPalProvider>
+    );
+}
+`;
+
+// ─── PayPalSubscriptionButton (no XOR pattern) ─────────────────────────────
 
 export const getPayPalSubscriptionButtonCode = (): string => `
 import { PayPalProvider, PayPalSubscriptionButton } from "@paypal/react-paypal-js/sdk-v6";
@@ -225,7 +494,11 @@ export default function App() {
 }
 `;
 
+// ─── PayPalCreditSavePaymentButton ──────────────────────────────────────────
+
 export const getPayPalCreditSavePaymentButtonCode = (): string => `
+// Option 1: Lazy vault token creation (Recommended)
+// The vault setup token is created only when the buyer clicks the button.
 import {
     PayPalProvider,
     PayPalCreditSavePaymentButton,
@@ -273,7 +546,66 @@ export default function App() {
 }
 `;
 
+export const getPayPalCreditSavePaymentButtonEagerCode = (): string => `
+// Option 2: Eager vault token creation
+// The vault setup token is created on page load and passed directly as a prop.
+import { useEffect, useState } from "react";
+import {
+    PayPalProvider,
+    PayPalCreditSavePaymentButton,
+    useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
+
+function Checkout() {
+    const [vaultSetupToken, setVaultSetupToken] = useState<string | null>(null);
+
+    useEligibleMethods({
+        payload: {
+            currencyCode: "USD",
+            paymentFlow: "VAULT_WITHOUT_PAYMENT",
+        },
+    });
+
+    useEffect(() => {
+        fetch("/api/paypal/create-vault-token", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+        })
+            .then((res) => res.json())
+            .then((data) => setVaultSetupToken(data.id));
+    }, []);
+
+    if (!vaultSetupToken) return <div>Loading...</div>;
+
+    return (
+        <PayPalCreditSavePaymentButton
+            vaultSetupToken={vaultSetupToken}
+            onApprove={async (data) => {
+                console.log("Payment method saved:", data.vaultSetupToken);
+            }}
+            presentationMode="auto"
+        />
+    );
+}
+
+export default function App() {
+    return (
+        <PayPalProvider
+            clientId="YOUR_CLIENT_ID"
+            components={["paypal-payments"]}
+            pageType="checkout"
+        >
+            <Checkout />
+        </PayPalProvider>
+    );
+}
+`;
+
+// ─── Card Fields ────────────────────────────────────────────────────────────
+
 export const getCardFieldsOneTimePaymentCode = (): string => `
+// Option 1: One-Time Payment (Recommended for standard checkout)
+// Create an order, then submit the card details to capture payment.
 import {
     PayPalProvider,
     PayPalCardFieldsProvider,
@@ -344,6 +676,90 @@ function CardFieldsForm() {
             />
             {!cardFieldsError && (
                 <button onClick={handleSubmit}>Pay</button>
+            )}
+        </div>
+    );
+}
+
+export default function App() {
+    return (
+        <PayPalProvider
+            clientId="YOUR_CLIENT_ID"
+            components={["card-fields"]}
+            pageType="checkout"
+        >
+            <PayPalCardFieldsProvider>
+                <CardFieldsForm />
+            </PayPalCardFieldsProvider>
+        </PayPalProvider>
+    );
+}
+`;
+
+export const getCardFieldsSavePaymentCode = (): string => `
+// Option 2: Save Payment Method (for vaulting cards without immediate payment)
+// Create a vault setup token, then submit the card details to save the payment method.
+import {
+    PayPalProvider,
+    PayPalCardFieldsProvider,
+    PayPalCardNumberField,
+    PayPalCardExpiryField,
+    PayPalCardCvvField,
+    usePayPalCardFields,
+    usePayPalCardFieldsSavePaymentSession,
+} from "@paypal/react-paypal-js/sdk-v6";
+import { useEffect } from "react";
+
+async function createVaultSetupToken() {
+    const response = await fetch("/api/paypal/create-vault-token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+    });
+    const data = await response.json();
+    return data.id;
+}
+
+function CardFieldsForm() {
+    const { error: cardFieldsError } = usePayPalCardFields();
+    const { error: submitError, submit, submitResponse } =
+        usePayPalCardFieldsSavePaymentSession();
+
+    useEffect(() => {
+        if (!submitResponse) return;
+
+        const { vaultSetupToken, message } = submitResponse.data;
+
+        switch (submitResponse.state) {
+            case "succeeded":
+                console.log("Card saved successfully:", vaultSetupToken);
+                break;
+            case "failed":
+                console.error("Save failed:", message);
+                break;
+        }
+    }, [submitResponse]);
+
+    const handleSubmit = async () => {
+        const vaultSetupToken = await createVaultSetupToken();
+        await submit(vaultSetupToken);
+    };
+
+    return (
+        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+            <PayPalCardNumberField
+                containerStyles={{ height: "3rem" }}
+                placeholder="Enter card number"
+            />
+            <PayPalCardExpiryField
+                containerStyles={{ height: "3rem" }}
+                placeholder="MM/YY"
+            />
+            <PayPalCardCvvField
+                containerStyles={{ height: "3rem" }}
+                placeholder="Enter CVV"
+            />
+            {!cardFieldsError && (
+                <button onClick={handleSubmit}>Save Card</button>
             )}
         </div>
     );

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayLaterOneTimePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayLaterOneTimePaymentButton.stories.tsx
@@ -20,18 +20,34 @@ import {
 /**
  * Wrapper that calls useEligibleMethods with the ONE_TIME_PAYMENT flow,
  * which is required for Pay Later eligibility (countryCode and productCode).
+ * Only renders children if Pay Later is eligible.
  */
 function PayLaterEligibilityWrapper({
     children,
 }: {
     children: React.ReactNode;
 }) {
-    useEligibleMethods({
+    const {
+        eligiblePaymentMethods,
+        isLoading: isEligibilityLoading,
+        error: eligibilityError,
+    } = useEligibleMethods({
         payload: {
             currencyCode: "USD",
             paymentFlow: "ONE_TIME_PAYMENT",
         },
     });
+
+    const isPayLaterEligible =
+        !isEligibilityLoading && eligiblePaymentMethods?.isEligible("paylater");
+
+    if (isEligibilityLoading) return <div>Checking eligibility...</div>;
+    if (eligibilityError)
+        return (
+            <div>Failed to check eligibility: {eligibilityError.message}</div>
+        );
+    if (!isPayLaterEligible)
+        return <div>Pay Later is not eligible for this configuration.</div>;
 
     return <>{children}</>;
 }

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayLaterOneTimePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayLaterOneTimePaymentButton.stories.tsx
@@ -12,7 +12,10 @@ import {
     disabledArgType,
 } from "../../shared/utils";
 import { V6DocPageStructure } from "../../components";
-import { getPayLaterOneTimePaymentButtonCode } from "../../shared/code";
+import {
+    getPayLaterOneTimePaymentButtonCode,
+    getPayLaterOneTimePaymentButtonEagerCode,
+} from "../../shared/code";
 
 /**
  * Wrapper that calls useEligibleMethods with the ONE_TIME_PAYMENT flow,
@@ -59,6 +62,13 @@ For more information, see [PayPal Pay Later](https://docs.paypal.ai/payments/met
             page: () => (
                 <V6DocPageStructure
                     code={getPayLaterOneTimePaymentButtonCode()}
+                    codeTitle="Option 1: Lazy Order Creation (Recommended)"
+                    additionalExamples={[
+                        {
+                            title: "Option 2: Eager Order Creation",
+                            code: getPayLaterOneTimePaymentButtonEagerCode(),
+                        },
+                    ]}
                 />
             ),
         },
@@ -68,7 +78,12 @@ For more information, see [PayPal Pay Later](https://docs.paypal.ai/payments/met
         disabled: disabledArgType,
         createOrder: {
             description:
-                "Function that creates an order and returns the order ID.",
+                "Function that lazily creates an order on button click and returns `{ orderId }`. Mutually exclusive with `orderId`. (Recommended)",
+            table: { category: "Events" },
+        },
+        orderId: {
+            description:
+                "Pre-created order ID string. Use when the order is created before rendering. Mutually exclusive with `createOrder`.",
             table: { category: "Events" },
         },
         onApprove: {

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalCreditSavePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalCreditSavePaymentButton.stories.tsx
@@ -12,7 +12,10 @@ import {
     disabledArgType,
 } from "../../shared/utils";
 import { V6DocPageStructure } from "../../components";
-import { getPayPalCreditSavePaymentButtonCode } from "../../shared/code";
+import {
+    getPayPalCreditSavePaymentButtonCode,
+    getPayPalCreditSavePaymentButtonEagerCode,
+} from "../../shared/code";
 
 /**
  * Wrapper that calls useEligibleMethods with the VAULT_WITHOUT_PAYMENT flow,
@@ -58,6 +61,13 @@ It relies on the \`<PayPalProvider />\` parent component for managing SDK initia
             page: () => (
                 <V6DocPageStructure
                     code={getPayPalCreditSavePaymentButtonCode()}
+                    codeTitle="Option 1: Lazy Vault Token Creation (Recommended)"
+                    additionalExamples={[
+                        {
+                            title: "Option 2: Eager Vault Token Creation",
+                            code: getPayPalCreditSavePaymentButtonEagerCode(),
+                        },
+                    ]}
                 />
             ),
         },
@@ -67,7 +77,12 @@ It relies on the \`<PayPalProvider />\` parent component for managing SDK initia
         disabled: disabledArgType,
         createVaultToken: {
             description:
-                "Function that creates a vault setup token and returns the token ID.",
+                "Function that lazily creates a vault setup token on button click and returns `{ vaultSetupToken }`. Mutually exclusive with `vaultSetupToken`. (Recommended)",
+            table: { category: "Events" },
+        },
+        vaultSetupToken: {
+            description:
+                "Pre-created vault setup token string. Use when the token is created before rendering. Mutually exclusive with `createVaultToken`.",
             table: { category: "Events" },
         },
         onApprove: {

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalCreditSavePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalCreditSavePaymentButton.stories.tsx
@@ -20,18 +20,34 @@ import {
 /**
  * Wrapper that calls useEligibleMethods with the VAULT_WITHOUT_PAYMENT flow,
  * which is required for PayPal Credit eligibility.
+ * Only renders children if PayPal Credit is eligible.
  */
 function CreditSaveEligibilityWrapper({
     children,
 }: {
     children: React.ReactNode;
 }) {
-    useEligibleMethods({
+    const {
+        eligiblePaymentMethods,
+        isLoading: isEligibilityLoading,
+        error: eligibilityError,
+    } = useEligibleMethods({
         payload: {
             currencyCode: "USD",
             paymentFlow: "VAULT_WITHOUT_PAYMENT",
         },
     });
+
+    const isCreditEligible =
+        !isEligibilityLoading && eligiblePaymentMethods?.isEligible("credit");
+
+    if (isEligibilityLoading) return <div>Checking eligibility...</div>;
+    if (eligibilityError)
+        return (
+            <div>Failed to check eligibility: {eligibilityError.message}</div>
+        );
+    if (!isCreditEligible)
+        return <div>PayPal Credit is not eligible for this configuration.</div>;
 
     return <>{children}</>;
 }

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalGuestPaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalGuestPaymentButton.stories.tsx
@@ -7,7 +7,10 @@ import {
     disabledArgType,
 } from "../../shared/utils";
 import { V6DocPageStructure } from "../../components";
-import { getPayPalGuestPaymentButtonCode } from "../../shared/code";
+import {
+    getPayPalGuestPaymentButtonCode,
+    getPayPalGuestPaymentButtonEagerCode,
+} from "../../shared/code";
 
 const meta: Meta<typeof PayPalGuestPaymentButton> = {
     title: "V6/Buttons/PayPalGuestPaymentButton",
@@ -28,7 +31,16 @@ For more information, see [PayPal Basic Card Checkout](https://docs.paypal.ai/pa
 `,
             },
             page: () => (
-                <V6DocPageStructure code={getPayPalGuestPaymentButtonCode()} />
+                <V6DocPageStructure
+                    code={getPayPalGuestPaymentButtonCode()}
+                    codeTitle="Option 1: Lazy Order Creation (Recommended)"
+                    additionalExamples={[
+                        {
+                            title: "Option 2: Eager Order Creation",
+                            code: getPayPalGuestPaymentButtonEagerCode(),
+                        },
+                    ]}
+                />
             ),
         },
     },
@@ -36,7 +48,12 @@ For more information, see [PayPal Basic Card Checkout](https://docs.paypal.ai/pa
         disabled: disabledArgType,
         createOrder: {
             description:
-                "Function that creates an order and returns the order ID.",
+                "Function that lazily creates an order on button click and returns `{ orderId }`. Mutually exclusive with `orderId`. (Recommended)",
+            table: { category: "Events" },
+        },
+        orderId: {
+            description:
+                "Pre-created order ID string. Use when the order is created before rendering. Mutually exclusive with `createOrder`.",
             table: { category: "Events" },
         },
         onApprove: {

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalOneTimePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalOneTimePaymentButton.stories.tsx
@@ -9,7 +9,10 @@ import {
     disabledArgType,
 } from "../../shared/utils";
 import { V6DocPageStructure } from "../../components";
-import { getPayPalOneTimePaymentButtonCode } from "../../shared/code";
+import {
+    getPayPalOneTimePaymentButtonCode,
+    getPayPalOneTimePaymentButtonEagerCode,
+} from "../../shared/code";
 
 const meta: Meta<typeof PayPalOneTimePaymentButton> = {
     title: "V6/Buttons/PayPalOneTimePaymentButton",
@@ -28,6 +31,13 @@ For more information, see [PayPal V6 Web SDK Documentation](https://docs.paypal.
             page: () => (
                 <V6DocPageStructure
                     code={getPayPalOneTimePaymentButtonCode()}
+                    codeTitle="Option 1: Lazy Order Creation (Recommended)"
+                    additionalExamples={[
+                        {
+                            title: "Option 2: Eager Order Creation",
+                            code: getPayPalOneTimePaymentButtonEagerCode(),
+                        },
+                    ]}
                 />
             ),
         },
@@ -38,7 +48,12 @@ For more information, see [PayPal V6 Web SDK Documentation](https://docs.paypal.
         disabled: disabledArgType,
         createOrder: {
             description:
-                "Function that creates an order and returns the order ID.",
+                "Function that lazily creates an order on button click and returns `{ orderId }`. Mutually exclusive with `orderId`. (Recommended)",
+            table: { category: "Events" },
+        },
+        orderId: {
+            description:
+                "Pre-created order ID string. Use when the order is created before rendering. Mutually exclusive with `createOrder`.",
             table: { category: "Events" },
         },
         onApprove: {

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalSavePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/PayPalSavePaymentButton.stories.tsx
@@ -9,7 +9,10 @@ import {
     disabledArgType,
 } from "../../shared/utils";
 import { V6DocPageStructure } from "../../components";
-import { getPayPalSavePaymentButtonCode } from "../../shared/code";
+import {
+    getPayPalSavePaymentButtonCode,
+    getPayPalSavePaymentButtonEagerCode,
+} from "../../shared/code";
 
 const meta: Meta<typeof PayPalSavePaymentButton> = {
     title: "V6/Buttons/PayPalSavePaymentButton",
@@ -28,7 +31,16 @@ For more information, see [PayPal Vaulting](https://docs.paypal.ai/payments/save
 `,
             },
             page: () => (
-                <V6DocPageStructure code={getPayPalSavePaymentButtonCode()} />
+                <V6DocPageStructure
+                    code={getPayPalSavePaymentButtonCode()}
+                    codeTitle="Option 1: Lazy Vault Token Creation (Recommended)"
+                    additionalExamples={[
+                        {
+                            title: "Option 2: Eager Vault Token Creation",
+                            code: getPayPalSavePaymentButtonEagerCode(),
+                        },
+                    ]}
+                />
             ),
         },
     },
@@ -38,7 +50,12 @@ For more information, see [PayPal Vaulting](https://docs.paypal.ai/payments/save
         disabled: disabledArgType,
         createVaultToken: {
             description:
-                "Function that creates a vault setup token and returns the token ID.",
+                "Function that lazily creates a vault setup token on button click and returns `{ vaultSetupToken }`. Mutually exclusive with `vaultSetupToken`. (Recommended)",
+            table: { category: "Events" },
+        },
+        vaultSetupToken: {
+            description:
+                "Pre-created vault setup token string. Use when the token is created before rendering. Mutually exclusive with `createVaultToken`.",
             table: { category: "Events" },
         },
         onApprove: {

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/VenmoOneTimePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/VenmoOneTimePaymentButton.stories.tsx
@@ -9,7 +9,10 @@ import {
     disabledArgType,
 } from "../../shared/utils";
 import { V6DocPageStructure } from "../../components";
-import { getVenmoOneTimePaymentButtonCode } from "../../shared/code";
+import {
+    getVenmoOneTimePaymentButtonCode,
+    getVenmoOneTimePaymentButtonEagerCode,
+} from "../../shared/code";
 
 const meta: Meta<typeof VenmoOneTimePaymentButton> = {
     title: "V6/Buttons/VenmoOneTimePaymentButton",
@@ -26,7 +29,16 @@ For more information, see [Pay with Venmo](https://docs.paypal.ai/payments/metho
 `,
             },
             page: () => (
-                <V6DocPageStructure code={getVenmoOneTimePaymentButtonCode()} />
+                <V6DocPageStructure
+                    code={getVenmoOneTimePaymentButtonCode()}
+                    codeTitle="Option 1: Lazy Order Creation (Recommended)"
+                    additionalExamples={[
+                        {
+                            title: "Option 2: Eager Order Creation",
+                            code: getVenmoOneTimePaymentButtonEagerCode(),
+                        },
+                    ]}
+                />
             ),
         },
     },
@@ -36,7 +48,12 @@ For more information, see [Pay with Venmo](https://docs.paypal.ai/payments/metho
         disabled: disabledArgType,
         createOrder: {
             description:
-                "Function that creates an order and returns the order ID.",
+                "Function that lazily creates an order on button click and returns `{ orderId }`. Mutually exclusive with `orderId`. (Recommended)",
+            table: { category: "Events" },
+        },
+        orderId: {
+            description:
+                "Pre-created order ID string. Use when the order is created before rendering. Mutually exclusive with `createOrder`.",
             table: { category: "Events" },
         },
         onApprove: {

--- a/packages/react-paypal-js-storybook/v6/src/stories/card-fields/CardFieldsOneTimePayment.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/card-fields/CardFieldsOneTimePayment.stories.tsx
@@ -13,7 +13,10 @@ import { action } from "storybook/actions";
 import { createOrder, captureOrder } from "../../shared/utils";
 import { dispatchPaymentResult } from "../../shared/PaymentResult";
 import { V6DocPageStructure } from "../../components";
-import { getCardFieldsOneTimePaymentCode } from "../../shared/code";
+import {
+    getCardFieldsOneTimePaymentCode,
+    getCardFieldsSavePaymentCode,
+} from "../../shared/code";
 
 function CardFieldsForm() {
     const { error: cardFieldsError } = usePayPalCardFields();
@@ -151,7 +154,16 @@ It relies on the \`<PayPalProvider />\` parent component for managing SDK initia
 `,
             },
             page: () => (
-                <V6DocPageStructure code={getCardFieldsOneTimePaymentCode()} />
+                <V6DocPageStructure
+                    code={getCardFieldsOneTimePaymentCode()}
+                    codeTitle="Option 1: One-Time Payment (Recommended)"
+                    additionalExamples={[
+                        {
+                            title: "Option 2: Save Payment Method (Vaulting)",
+                            code: getCardFieldsSavePaymentCode(),
+                        },
+                    ]}
+                />
             ),
         },
     },

--- a/packages/react-paypal-js-storybook/v6/src/stories/card-fields/CardFieldsOneTimePayment.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/card-fields/CardFieldsOneTimePayment.stories.tsx
@@ -8,6 +8,7 @@ import {
     PayPalCardCvvField,
     usePayPalCardFields,
     usePayPalCardFieldsOneTimePaymentSession,
+    useEligibleMethods,
 } from "@paypal/react-paypal-js/sdk-v6";
 import { action } from "storybook/actions";
 import { createOrder, captureOrder } from "../../shared/utils";
@@ -18,7 +19,7 @@ import {
     getCardFieldsSavePaymentCode,
 } from "../../shared/code";
 
-function CardFieldsForm() {
+function CardFields() {
     const { error: cardFieldsError } = usePayPalCardFields();
     const {
         error: submitError,
@@ -81,6 +82,9 @@ function CardFieldsForm() {
                 `Card field error: ${cardFieldsError.message || "Unknown error"}`,
             );
         }
+    }, [cardFieldsError]);
+
+    useEffect(() => {
         if (submitError) {
             action("error")({
                 source: "submit",
@@ -91,7 +95,7 @@ function CardFieldsForm() {
                 `Card submission error: ${submitError.message || "Unknown error"}`,
             );
         }
-    }, [cardFieldsError, submitError]);
+    }, [submitError]);
 
     const handleSubmit = async () => {
         const { orderId } = await createOrder();
@@ -129,9 +133,32 @@ function CardFieldsForm() {
 }
 
 function CardFieldsStory() {
+    const {
+        eligiblePaymentMethods,
+        isLoading: isEligibilityLoading,
+        error: eligibilityError,
+    } = useEligibleMethods({
+        payload: {
+            currencyCode: "USD",
+            paymentFlow: "ONE_TIME_PAYMENT",
+        },
+    });
+
+    const isCardFieldsEligible =
+        !isEligibilityLoading &&
+        eligiblePaymentMethods?.isEligible("advanced_cards");
+
+    if (isEligibilityLoading) return <div>Checking eligibility...</div>;
+    if (eligibilityError)
+        return (
+            <div>Failed to check eligibility: {eligibilityError.message}</div>
+        );
+    if (!isCardFieldsEligible)
+        return <div>Card Fields are not eligible for this configuration.</div>;
+
     return (
         <PayPalCardFieldsProvider>
-            <CardFieldsForm />
+            <CardFields />
         </PayPalCardFieldsProvider>
     );
 }


### PR DESCRIPTION
Addressing [issue](https://github.com/paypal/paypal-js/issues/878)
Added more examples in buttons and card-fields component to reduce ambiguity.

PayLater Button:
<img width="2671" height="1478" alt="Screenshot 2026-04-13 at 2 15 10 PM" src="https://github.com/user-attachments/assets/015c6a8f-0d2c-47ae-8853-92c22b3b679a" />
<img width="2671" height="1478" alt="Screenshot 2026-04-13 at 2 15 18 PM" src="https://github.com/user-attachments/assets/a0fde458-9383-4742-b35b-79453381a92f" />

Venmo OneTimePayment Button:
<img width="2715" height="1522" alt="Screenshot 2026-04-13 at 2 15 35 PM" src="https://github.com/user-attachments/assets/bf97bce2-2874-4749-8661-1ec7037b333f" />
<img width="2671" height="1478" alt="Screenshot 2026-04-13 at 2 15 44 PM" src="https://github.com/user-attachments/assets/1f46533c-50be-4ac0-bf4a-7521e5164d1b" />

SavePaymentButton & GuestPaymentButton:
<img width="2671" height="1478" alt="Screenshot 2026-04-13 at 2 16 15 PM" src="https://github.com/user-attachments/assets/5067974e-0e80-4311-bf6c-732a967305df" />
<img width="2671" height="1478" alt="Screenshot 2026-04-13 at 2 16 22 PM" src="https://github.com/user-attachments/assets/539e95c1-23f7-4a37-bafe-77ac2f4fdb5a" />

<img width="2715" height="1522" alt="Screenshot 2026-04-13 at 2 16 50 PM" src="https://github.com/user-attachments/assets/227ea109-f3b5-4363-9dd7-1ed3539dbb7b" />
<img width="2671" height="1478" alt="Screenshot 2026-04-13 at 2 16 56 PM" src="https://github.com/user-attachments/assets/f4afcc35-8f76-485a-ab23-3d5f2a6146c3" />

Card Fields:
<img width="2715" height="1522" alt="Screenshot 2026-04-13 at 2 17 25 PM" src="https://github.com/user-attachments/assets/f0d816fd-c527-4a01-80d7-1ca51fdefe30" />
<img width="2671" height="1478" alt="Screenshot 2026-04-13 at 2 17 40 PM" src="https://github.com/user-attachments/assets/7daceb94-2b19-4591-b7b8-426e13514e55" />



