### PR TITLE
Adding ApplePay OneTimePayment hook and button component

### DIFF
--- a/.changeset/famous-clouds-obey.md
+++ b/.changeset/famous-clouds-obey.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Updating ApplePay types

--- a/.changeset/wise-socks-design.md
+++ b/.changeset/wise-socks-design.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+Adding ApplePay OnetimePayment hook and button component

--- a/packages/paypal-js/types/v6/components/applepay-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/applepay-payments.d.ts
@@ -305,6 +305,7 @@ declare class ApplePaySession {
     static STATUS_SUCCESS: number;
     static STATUS_FAILURE: number;
     static canMakePayments(): boolean;
+    static supportsVersion(version: number): boolean;
     constructor(version: number, paymentRequest: unknown);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/paypal-js/types/v6/components/applepay-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/applepay-payments.d.ts
@@ -149,6 +149,8 @@ export type ApplePayOneTimePaymentSession = {
     formatConfigForPaymentRequest: (config: ApplePayConfig) => {
         merchantCapabilities: ApplePayMerchantCapability[];
         supportedNetworks: ApplePaySupportedNetwork[];
+        merchantCountry?: string;
+        tokenNotificationURL: string;
     };
 
     /**
@@ -297,27 +299,19 @@ export interface ApplePayPaymentsInstance {
 
 /**
  * Native Apple Pay session API (Safari-only).
- * TypeScript's DOM lib does not include this since it's not cross-browser.
  * @see https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession
  */
 declare class ApplePaySession {
     static STATUS_SUCCESS: number;
     static STATUS_FAILURE: number;
     static canMakePayments(): boolean;
-
     constructor(version: number, paymentRequest: unknown);
 
-    onvalidatemerchant: ((event: { validationURL: string }) => void) | null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onvalidatemerchant: ((event: any) => void) | null;
     onpaymentmethodselected: (() => void) | null;
-    onpaymentauthorized:
-        | ((event: {
-              payment: {
-                  token: ApplePayPaymentToken;
-                  billingContact: ApplePayContact;
-                  shippingContact?: ApplePayContact;
-              };
-          }) => void)
-        | null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onpaymentauthorized: ((event: any) => void) | null;
     oncancel: (() => void) | null;
 
     completeMerchantValidation(merchantSession: unknown): void;

--- a/packages/paypal-js/types/v6/components/applepay-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/applepay-payments.d.ts
@@ -80,8 +80,8 @@ export type ApplePayMerchantSession = {
  */
 export type ValidateMerchantOptions = {
     validationUrl: string;
-    displayName: string;
-    domainName: string;
+    displayName?: string;
+    domainName?: string;
 };
 
 /**
@@ -293,4 +293,42 @@ export interface ApplePayPaymentsInstance {
      * ```
      */
     createApplePayOneTimePaymentSession: () => ApplePayOneTimePaymentSession;
+}
+
+/**
+ * Native Apple Pay session API (Safari-only).
+ * TypeScript's DOM lib does not include this since it's not cross-browser.
+ * @see https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession
+ */
+declare class ApplePaySession {
+    static STATUS_SUCCESS: number;
+    static STATUS_FAILURE: number;
+    static canMakePayments(): boolean;
+
+    constructor(version: number, paymentRequest: unknown);
+
+    onvalidatemerchant: ((event: { validationURL: string }) => void) | null;
+    onpaymentmethodselected: (() => void) | null;
+    onpaymentauthorized:
+        | ((event: {
+              payment: {
+                  token: ApplePayPaymentToken;
+                  billingContact: ApplePayContact;
+                  shippingContact?: ApplePayContact;
+              };
+          }) => void)
+        | null;
+    oncancel: (() => void) | null;
+
+    completeMerchantValidation(merchantSession: unknown): void;
+    completePaymentMethodSelection(update: unknown): void;
+    completePayment(result: { status: number }): void;
+    begin(): void;
+    abort(): void;
+}
+
+declare global {
+    interface Window {
+        ApplePaySession?: typeof ApplePaySession;
+    }
 }

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
@@ -43,6 +43,7 @@ describe("ApplePayOneTimePaymentButton", () => {
                 type: "final",
             },
         },
+        applePaySessionVersion: 4,
         createOrder: jest.fn().mockResolvedValue({ orderId: "ORDER-123" }),
         onApprove: jest.fn(),
     };

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
@@ -1,0 +1,267 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+
+import {
+    ApplePayOneTimePaymentButton,
+    type ApplePayOneTimePaymentButtonProps,
+} from "./ApplePayOneTimePaymentButton";
+import { useApplePayOneTimePaymentSession } from "../hooks/useApplePayOneTimePaymentSession";
+import { usePayPal } from "../hooks/usePayPal";
+
+import type { ApplePayConfig } from "../types";
+
+jest.mock("../hooks/useApplePayOneTimePaymentSession", () => ({
+    useApplePayOneTimePaymentSession: jest.fn(),
+}));
+jest.mock("../hooks/usePayPal", () => ({
+    usePayPal: jest.fn(),
+}));
+
+describe("ApplePayOneTimePaymentButton", () => {
+    const mockHandleClick = jest.fn();
+    const mockHandleCancel = jest.fn();
+    const mockHandleDestroy = jest.fn();
+    const mockUseApplePayOneTimePaymentSession =
+        useApplePayOneTimePaymentSession as jest.Mock;
+    const mockUsePayPal = usePayPal as jest.Mock;
+
+    const mockApplePayConfig: ApplePayConfig = {
+        merchantCapabilities: ["supports3DS"],
+        supportedNetworks: ["visa", "masterCard"],
+        isEligible: true,
+        tokenNotificationURL: "https://example.com/notify",
+    };
+
+    const defaultProps: ApplePayOneTimePaymentButtonProps = {
+        applePayConfig: mockApplePayConfig,
+        paymentRequest: {
+            countryCode: "US",
+            currencyCode: "USD",
+            total: {
+                label: "Test Store",
+                amount: "100.00",
+                type: "final",
+            },
+        },
+        createOrder: jest.fn().mockResolvedValue({ orderId: "ORDER-123" }),
+        onApprove: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockHandleClick.mockResolvedValue(undefined);
+        mockUseApplePayOneTimePaymentSession.mockReturnValue({
+            error: null,
+            isPending: false,
+            handleClick: mockHandleClick,
+            handleCancel: mockHandleCancel,
+            handleDestroy: mockHandleDestroy,
+        });
+        mockUsePayPal.mockReturnValue({
+            isHydrated: true,
+        });
+    });
+
+    it("should render container div with apple-pay-button when hydrated", () => {
+        const { container } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} />,
+        );
+        const applePayButton = container.querySelector("apple-pay-button");
+        expect(applePayButton).toBeInTheDocument();
+    });
+
+    it("should render a plain div when not hydrated", () => {
+        mockUsePayPal.mockReturnValue({
+            isHydrated: false,
+        });
+        const { container } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} />,
+        );
+        expect(
+            container.querySelector("apple-pay-button"),
+        ).not.toBeInTheDocument();
+        expect(container.querySelector("div")).toBeInTheDocument();
+    });
+
+    it("should call handleClick when button is clicked", () => {
+        const { container } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} />,
+        );
+        const button = container.querySelector("apple-pay-button");
+        expect(button).toBeInTheDocument();
+
+        fireEvent.click(button!);
+
+        expect(mockHandleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("should set disabled attribute when disabled prop is true", () => {
+        const { container } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} disabled={true} />,
+        );
+        const button = container.querySelector("apple-pay-button");
+        expect(button).toHaveAttribute("disabled");
+    });
+
+    it("should not set disabled attribute when error is present (allows retry)", () => {
+        jest.spyOn(console, "error").mockImplementation();
+        mockUseApplePayOneTimePaymentSession.mockReturnValue({
+            error: new Error("Test error"),
+            isPending: false,
+            handleClick: mockHandleClick,
+            handleCancel: mockHandleCancel,
+            handleDestroy: mockHandleDestroy,
+        });
+        const { container } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} />,
+        );
+        const button = container.querySelector("apple-pay-button");
+        expect(button).not.toHaveAttribute("disabled");
+    });
+
+    it("should set disabled attribute when isPending is true", () => {
+        mockUseApplePayOneTimePaymentSession.mockReturnValue({
+            error: null,
+            isPending: true,
+            handleClick: mockHandleClick,
+            handleCancel: mockHandleCancel,
+            handleDestroy: mockHandleDestroy,
+        });
+        const { container } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} />,
+        );
+        const button = container.querySelector("apple-pay-button");
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute("disabled");
+    });
+
+    it("should not set disabled attribute when state is normal", () => {
+        const { container } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} />,
+        );
+        const button = container.querySelector("apple-pay-button");
+        expect(button).not.toHaveAttribute("disabled");
+    });
+
+    it("should set default button attributes", () => {
+        const { container } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} />,
+        );
+        const button = container.querySelector("apple-pay-button");
+        expect(button).toHaveAttribute("buttonstyle", "black");
+        expect(button).toHaveAttribute("type", "pay");
+        expect(button).toHaveAttribute("locale", "en");
+    });
+
+    it("should set custom button attributes", () => {
+        const { container } = render(
+            <ApplePayOneTimePaymentButton
+                {...defaultProps}
+                buttonstyle="white"
+                type="buy"
+                locale="fr"
+            />,
+        );
+        const button = container.querySelector("apple-pay-button");
+        expect(button).toHaveAttribute("buttonstyle", "white");
+        expect(button).toHaveAttribute("type", "buy");
+        expect(button).toHaveAttribute("locale", "fr");
+    });
+
+    it("should apply className to container div", () => {
+        const { container } = render(
+            <ApplePayOneTimePaymentButton
+                {...defaultProps}
+                className="custom-class"
+            />,
+        );
+        const wrapper = container.firstElementChild;
+        expect(wrapper).toHaveClass("custom-class");
+    });
+
+    it("should pass hook props to useApplePayOneTimePaymentSession", () => {
+        render(<ApplePayOneTimePaymentButton {...defaultProps} />);
+        expect(mockUseApplePayOneTimePaymentSession).toHaveBeenCalledWith(
+            defaultProps,
+        );
+    });
+
+    it("should strip button-specific props before passing to hook", () => {
+        render(
+            <ApplePayOneTimePaymentButton
+                {...defaultProps}
+                buttonstyle="white"
+                type="buy"
+                locale="fr"
+                disabled={true}
+                className="test"
+            />,
+        );
+        // Hook should receive only hook-relevant props
+        expect(mockUseApplePayOneTimePaymentSession).toHaveBeenCalledWith(
+            defaultProps,
+        );
+    });
+
+    it("should log error to console when hook returns an error", () => {
+        const consoleErrorSpy = jest
+            .spyOn(console, "error")
+            .mockImplementation();
+        const testError = new Error("Test error");
+        mockUseApplePayOneTimePaymentSession.mockReturnValue({
+            error: testError,
+            isPending: false,
+            handleClick: mockHandleClick,
+            handleCancel: mockHandleCancel,
+            handleDestroy: mockHandleDestroy,
+        });
+        render(<ApplePayOneTimePaymentButton {...defaultProps} />);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(testError);
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("should call handleDestroy on unmount", () => {
+        const { unmount } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} />,
+        );
+        unmount();
+        expect(mockHandleDestroy).toHaveBeenCalled();
+    });
+
+    it("should remove apple-pay-button from DOM on unmount", () => {
+        const { container, unmount } = render(
+            <ApplePayOneTimePaymentButton {...defaultProps} />,
+        );
+        expect(container.querySelector("apple-pay-button")).toBeInTheDocument();
+
+        unmount();
+
+        expect(
+            container.querySelector("apple-pay-button"),
+        ).not.toBeInTheDocument();
+    });
+
+    it("should update button attributes when buttonstyle changes", () => {
+        const { container, rerender } = render(
+            <ApplePayOneTimePaymentButton
+                {...defaultProps}
+                buttonstyle="black"
+            />,
+        );
+        expect(container.querySelector("apple-pay-button")).toHaveAttribute(
+            "buttonstyle",
+            "black",
+        );
+
+        rerender(
+            <ApplePayOneTimePaymentButton
+                {...defaultProps}
+                buttonstyle="white"
+            />,
+        );
+        expect(container.querySelector("apple-pay-button")).toHaveAttribute(
+            "buttonstyle",
+            "white",
+        );
+    });
+});

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
@@ -53,8 +53,9 @@ export const ApplePayOneTimePaymentButton = ({
     // so we attach the click handler directly on the element.
     useEffect(() => {
         const el = buttonRef.current;
-        if (!el) return;
-
+        if (!el) {
+            return;
+        }
         const onClick = () => {
             handleClickRef.current().catch(() => {
                 // Errors are captured by the hook's setError

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useRef } from "react";
+
+import { useApplePayOneTimePaymentSession } from "../hooks/useApplePayOneTimePaymentSession";
+import { usePayPal } from "../hooks/usePayPal";
+
+import type { UseApplePayOneTimePaymentSessionProps } from "../hooks/useApplePayOneTimePaymentSession";
+import type { ApplePayButtonElementProps } from "../types/sdkWebComponents";
+
+export type ApplePayOneTimePaymentButtonProps =
+    UseApplePayOneTimePaymentSessionProps & ApplePayButtonElementProps;
+
+/**
+ * `ApplePayOneTimePaymentButton` renders a native Apple Pay button and manages
+ * the full Apple Pay payment flow via the PayPal SDK.
+ *
+ * @example
+ * ```tsx
+ * <ApplePayOneTimePaymentButton
+ *   applePayConfig={applePayConfig}
+ *   paymentRequest={{
+ *     countryCode: "US",
+ *     currencyCode: "USD",
+ *     total: { label: "Demo Store", amount: "100.00", type: "final" },
+ *   }}
+ *   createOrder={async () => {
+ *     const res = await fetch("/api/orders", { method: "POST" });
+ *     const data = await res.json();
+ *     return { orderId: data.id };
+ *   }}
+ *   onApprove={(data) => console.log("Approved:", data)}
+ *   onError={(err) => console.error(err)}
+ * />
+ * ```
+ */
+export const ApplePayOneTimePaymentButton = ({
+    buttonstyle = "black",
+    type = "pay",
+    locale = "en",
+    disabled = false,
+    className,
+    ...hookProps
+}: ApplePayOneTimePaymentButtonProps): JSX.Element | null => {
+    const { error, isPending, handleClick, handleDestroy } =
+        useApplePayOneTimePaymentSession(hookProps);
+    const { isHydrated } = usePayPal();
+    const buttonRef = useRef<HTMLElement>(null);
+    const handleClickRef = useRef(handleClick);
+    handleClickRef.current = handleClick;
+
+    const isDisabled = disabled || isPending;
+
+    // React's onClick doesn't work on <apple-pay-button> due to its shadow DOM,
+    // so we attach the click handler directly on the element.
+    useEffect(() => {
+        const el = buttonRef.current;
+        if (!el) return;
+
+        const onClick = () => {
+            handleClickRef.current().catch(() => {
+                // Errors are captured by the hook's setError
+            });
+        };
+
+        el.addEventListener("click", onClick);
+        return () => el.removeEventListener("click", onClick);
+    }, []);
+
+    useEffect(() => {
+        if (error) {
+            console.error(error);
+        }
+    }, [error]);
+
+    // Cleanup on unmount
+    useEffect(() => {
+        return () => {
+            handleDestroy();
+        };
+    }, [handleDestroy]);
+
+    if (!isHydrated) {
+        return <div />;
+    }
+
+    return (
+        <div className={className}>
+            <apple-pay-button
+                ref={buttonRef}
+                buttonstyle={buttonstyle}
+                type={type}
+                locale={locale}
+                disabled={isDisabled || undefined}
+            />
+        </div>
+    );
+};

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
@@ -6,6 +6,19 @@ import { usePayPal } from "../hooks/usePayPal";
 import type { UseApplePayOneTimePaymentSessionProps } from "../hooks/useApplePayOneTimePaymentSession";
 import type { ApplePayButtonElementProps } from "../types/sdkWebComponents";
 
+/**
+ * Safari's native `<apple-pay-button>` relies on `-webkit-appearance: -apple-pay-button`
+ * to render its visual appearance. When the element is inserted dynamically by
+ * JavaScript (as React does), Safari may not apply the native appearance
+ * automatically, leaving the button invisible. Applying these styles explicitly
+ * ensures the button renders reliably across Safari versions without requiring
+ * consumers to add CSS in their own HTML.
+ */
+const applePayButtonStyles: React.CSSProperties = {
+    WebkitAppearance:
+        "-apple-pay-button" as React.CSSProperties["WebkitAppearance"],
+};
+
 export type ApplePayOneTimePaymentButtonProps =
     UseApplePayOneTimePaymentSessionProps & ApplePayButtonElementProps;
 
@@ -91,6 +104,7 @@ export const ApplePayOneTimePaymentButton = ({
                 type={type}
                 locale={locale}
                 disabled={isDisabled || undefined}
+                style={applePayButtonStyles}
             />
         </div>
     );

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.test.ts
@@ -144,6 +144,7 @@ describe("useApplePayOneTimePaymentSession", () => {
                     type: "final",
                 },
             },
+            applePaySessionVersion: 4,
             createOrder: jest.fn().mockResolvedValue({ orderId: "ORDER-123" }),
             onApprove: jest.fn(),
             onCancel: jest.fn(),
@@ -260,7 +261,7 @@ describe("useApplePayOneTimePaymentSession", () => {
     });
 
     describe("handleClick - payment flow", () => {
-        test("should start Apple Pay session when handleClick is called", async () => {
+        test("should pass applePaySessionVersion to native ApplePaySession constructor", async () => {
             const { result } = renderHook(() =>
                 useApplePayOneTimePaymentSession(defaultProps),
             );
@@ -272,6 +273,22 @@ describe("useApplePayOneTimePaymentSession", () => {
             expect(
                 mockApplePaySession.formatConfigForPaymentRequest,
             ).toHaveBeenCalledWith(mockApplePayConfig);
+            expect(capturedApplePaySession!.version).toBe(4);
+        });
+
+        test("should pass custom applePaySessionVersion to native ApplePaySession constructor", async () => {
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession({
+                    ...defaultProps,
+                    applePaySessionVersion: 14,
+                }),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(capturedApplePaySession!.version).toBe(14);
         });
 
         test("should handle payment authorization, confirm order, and call onApprove", async () => {

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.test.ts
@@ -1,0 +1,661 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+
+import { expectCurrentErrorValue } from "./useErrorTestUtil";
+import { useApplePayOneTimePaymentSession } from "./useApplePayOneTimePaymentSession";
+import {
+    mockPayPalContext,
+    mockPayPalRejected,
+    mockPayPalPending,
+} from "./usePayPalTestUtils";
+import { useProxyProps } from "../utils";
+
+import type { UseApplePayOneTimePaymentSessionProps } from "./useApplePayOneTimePaymentSession";
+import type { ApplePayOneTimePaymentSession, ApplePayConfig } from "../types";
+
+jest.mock("./usePayPal");
+
+jest.mock("../utils", () => ({
+    ...jest.requireActual("../utils"),
+    useProxyProps: jest.fn(),
+}));
+
+const mockUseProxyProps = useProxyProps as jest.MockedFunction<
+    typeof useProxyProps
+>;
+
+// Mock Apple Pay Session
+let capturedApplePaySession: MockApplePaySession | null = null;
+
+class MockApplePaySession {
+    static STATUS_SUCCESS = 0;
+    static STATUS_FAILURE = 1;
+    static canMakePayments = jest.fn().mockReturnValue(true);
+
+    onvalidatemerchant: ((event: { validationURL: string }) => void) | null =
+        null;
+    onpaymentmethodselected: (() => void) | null = null;
+    onpaymentauthorized:
+        | ((event: {
+              payment: {
+                  token: unknown;
+                  billingContact: unknown;
+                  shippingContact?: unknown;
+              };
+          }) => void)
+        | null = null;
+    oncancel: (() => void) | null = null;
+
+    completeMerchantValidation = jest.fn();
+    completePaymentMethodSelection = jest.fn();
+    completePayment = jest.fn();
+    begin = jest.fn();
+    abort = jest.fn();
+
+    constructor(
+        public version: number,
+        public paymentRequest: unknown,
+    ) {
+        // Capture the instance created by the hook
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        capturedApplePaySession = this;
+    }
+}
+
+const createMockApplePaySession = (): ApplePayOneTimePaymentSession => ({
+    formatConfigForPaymentRequest: jest.fn().mockReturnValue({
+        merchantCapabilities: ["supports3DS"],
+        supportedNetworks: ["visa", "masterCard"],
+    }),
+    validateMerchant: jest.fn().mockResolvedValue({
+        merchantSession: {
+            epochTimestamp: 1234567890,
+            expiresAt: 1234567890,
+            merchantSessionIdentifier: "test-session-id",
+            nonce: "test-nonce",
+            merchantIdentifier: "test-merchant-id",
+            domainName: "example.com",
+            displayName: "Test Store",
+            signature: "test-signature",
+            operationalAnalyticsIdentifier: "test-analytics-id",
+            retries: 0,
+            pspId: "test-psp-id",
+        },
+    }),
+    confirmOrder: jest.fn().mockResolvedValue({
+        approveApplePayPayment: {
+            id: "test-payment-id",
+            status: "APPROVED",
+            payment_source: {
+                apple_pay: {
+                    name: "Test User",
+                    card: {},
+                },
+            },
+        },
+    }),
+});
+
+const createMockSdkInstance = (
+    applePaySession = createMockApplePaySession(),
+) => ({
+    createApplePayOneTimePaymentSession: jest
+        .fn()
+        .mockReturnValue(applePaySession),
+});
+
+const mockApplePayConfig: ApplePayConfig = {
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa", "masterCard"],
+    isEligible: true,
+    tokenNotificationURL: "https://example.com/notify",
+};
+
+describe("useApplePayOneTimePaymentSession", () => {
+    let mockApplePaySession: ApplePayOneTimePaymentSession;
+    let mockSdkInstance: ReturnType<typeof createMockSdkInstance>;
+    let defaultProps: UseApplePayOneTimePaymentSessionProps;
+
+    beforeEach(() => {
+        mockUseProxyProps.mockImplementation((callbacks) => callbacks);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (global.window as any).ApplePaySession = MockApplePaySession;
+        Object.defineProperty(window, "location", {
+            value: { ...window.location, protocol: "https:" },
+            writable: true,
+        });
+
+        mockApplePaySession = createMockApplePaySession();
+        mockSdkInstance = createMockSdkInstance(mockApplePaySession);
+
+        mockPayPalContext({ sdkInstance: mockSdkInstance });
+
+        // Reset captured session
+        capturedApplePaySession = null;
+
+        defaultProps = {
+            applePayConfig: mockApplePayConfig,
+            paymentRequest: {
+                countryCode: "US",
+                currencyCode: "USD",
+                total: {
+                    label: "Test Store",
+                    amount: "100.00",
+                    type: "final",
+                },
+            },
+            createOrder: jest.fn().mockResolvedValue({ orderId: "ORDER-123" }),
+            onApprove: jest.fn(),
+            onCancel: jest.fn(),
+            onError: jest.fn(),
+        };
+
+        // Reset ApplePaySession mocks
+        MockApplePaySession.canMakePayments = jest.fn().mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("initialization", () => {
+        test("should not create session when no SDK instance is available", () => {
+            mockPayPalRejected();
+
+            const {
+                result: {
+                    current: { error },
+                },
+            } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            expectCurrentErrorValue(error);
+
+            expect(error).toEqual(new Error("no sdk instance available"));
+            expect(
+                mockSdkInstance.createApplePayOneTimePaymentSession,
+            ).not.toHaveBeenCalled();
+        });
+
+        test.each([
+            {
+                description: "Error object",
+                thrownError: new Error("Required components not loaded in SDK"),
+            },
+            {
+                description: "non-Error string",
+                thrownError: "String error message",
+            },
+        ])(
+            "should handle $description thrown by createApplePayOneTimePaymentSession",
+            ({ thrownError }) => {
+                const mockSdkInstanceWithError = {
+                    createApplePayOneTimePaymentSession: jest
+                        .fn()
+                        .mockImplementation(() => {
+                            throw thrownError;
+                        }),
+                };
+
+                mockPayPalContext({ sdkInstance: mockSdkInstanceWithError });
+
+                const {
+                    result: {
+                        current: { error },
+                    },
+                } = renderHook(() =>
+                    useApplePayOneTimePaymentSession(defaultProps),
+                );
+
+                expectCurrentErrorValue(error);
+
+                expect(
+                    mockSdkInstanceWithError.createApplePayOneTimePaymentSession,
+                ).toHaveBeenCalledTimes(1);
+            },
+        );
+
+        test("should create session successfully with valid SDK instance", () => {
+            const {
+                result: {
+                    current: { error },
+                },
+            } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            expect(error).toBeNull();
+            expect(
+                mockSdkInstance.createApplePayOneTimePaymentSession,
+            ).toHaveBeenCalledTimes(1);
+        });
+
+        test("should set isPending to true when SDK is loading", () => {
+            mockPayPalPending();
+
+            const {
+                result: {
+                    current: { isPending, error },
+                },
+            } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            expect(isPending).toBe(true);
+            expect(error).toBeNull();
+        });
+
+        test("should set isPending to false when SDK is ready", () => {
+            const {
+                result: {
+                    current: { isPending },
+                },
+            } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            expect(isPending).toBe(false);
+        });
+    });
+
+    describe("handleClick - payment flow", () => {
+        test("should start Apple Pay session when handleClick is called", async () => {
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(
+                mockApplePaySession.formatConfigForPaymentRequest,
+            ).toHaveBeenCalledWith(mockApplePayConfig);
+        });
+
+        test("should handle payment authorization, confirm order, and call onApprove", async () => {
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(capturedApplePaySession).not.toBeNull();
+            const mockPayment = {
+                token: { paymentData: {} },
+                billingContact: { givenName: "John" },
+                shippingContact: { givenName: "Jane" },
+            };
+
+            await act(async () => {
+                await capturedApplePaySession!.onpaymentauthorized?.({
+                    payment: mockPayment,
+                });
+            });
+
+            expect(defaultProps.createOrder).toHaveBeenCalled();
+            expect(mockApplePaySession.confirmOrder).toHaveBeenCalled();
+            expect(
+                capturedApplePaySession!.completePayment,
+            ).toHaveBeenCalledWith({
+                status: MockApplePaySession.STATUS_SUCCESS,
+            });
+            expect(defaultProps.onApprove).toHaveBeenCalled();
+        });
+
+        test("should handle payment method selection", async () => {
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(capturedApplePaySession).not.toBeNull();
+            act(() => {
+                capturedApplePaySession!.onpaymentmethodselected?.();
+            });
+
+            expect(
+                capturedApplePaySession!.completePaymentMethodSelection,
+            ).toHaveBeenCalledWith({
+                newTotal: defaultProps.paymentRequest.total,
+            });
+        });
+
+        test("should pass displayName and domainName to validateMerchant when provided", async () => {
+            const props = {
+                ...defaultProps,
+                displayName: "My Store",
+                domainName: "example.com",
+            };
+
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(props),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(capturedApplePaySession).not.toBeNull();
+            await act(async () => {
+                await capturedApplePaySession!.onvalidatemerchant?.({
+                    validationURL: "https://apple.com/validate",
+                });
+            });
+
+            expect(mockApplePaySession.validateMerchant).toHaveBeenCalledWith({
+                validationUrl: "https://apple.com/validate",
+                displayName: "My Store",
+                domainName: "example.com",
+            });
+        });
+
+        test("should not pass displayName and domainName when not provided", async () => {
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(capturedApplePaySession).not.toBeNull();
+            await act(async () => {
+                await capturedApplePaySession!.onvalidatemerchant?.({
+                    validationURL: "https://apple.com/validate",
+                });
+            });
+
+            expect(mockApplePaySession.validateMerchant).toHaveBeenCalledWith({
+                validationUrl: "https://apple.com/validate",
+            });
+        });
+
+        test("should error when Apple Pay is not available", async () => {
+            MockApplePaySession.canMakePayments = jest
+                .fn()
+                .mockReturnValue(false);
+
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(result.current.error?.message).toBe(
+                "Apple Pay is not available",
+            );
+        });
+
+        test("should error when not on HTTPS", async () => {
+            const originalProtocol = window.location.protocol;
+            Object.defineProperty(window, "location", {
+                value: { ...window.location, protocol: "http:" },
+                writable: true,
+            });
+
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(result.current.error?.message).toBe(
+                "Apple Pay requires a secure (HTTPS) connection",
+            );
+
+            // Restore
+            Object.defineProperty(window, "location", {
+                value: { ...window.location, protocol: originalProtocol },
+                writable: true,
+            });
+        });
+
+        test("should error when session is not available", async () => {
+            mockPayPalRejected();
+
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(result.current.error?.message).toBe(
+                "Apple Pay session not available",
+            );
+        });
+    });
+
+    describe("error handling", () => {
+        test.each([
+            {
+                description: "Error object",
+                rejectedValue: new Error("Validation failed"),
+                expectedMessage: "Validation failed",
+            },
+            {
+                description: "non-Error string (normalized via toError)",
+                rejectedValue: "string error",
+                expectedMessage: "string error",
+            },
+        ])(
+            "should handle merchant validation $description and abort session",
+            async ({ rejectedValue, expectedMessage }) => {
+                mockApplePaySession.validateMerchant = jest
+                    .fn()
+                    .mockRejectedValue(rejectedValue);
+
+                const { result } = renderHook(() =>
+                    useApplePayOneTimePaymentSession(defaultProps),
+                );
+
+                await act(async () => {
+                    await result.current.handleClick();
+                });
+
+                expect(capturedApplePaySession).not.toBeNull();
+                await act(async () => {
+                    await capturedApplePaySession!.onvalidatemerchant?.({
+                        validationURL: "https://apple.com/validate",
+                    });
+                });
+
+                expect(result.current.error).toBeInstanceOf(Error);
+                expect(result.current.error?.message).toBe(expectedMessage);
+                expect(defaultProps.onError).toHaveBeenCalled();
+                expect(capturedApplePaySession!.abort).toHaveBeenCalled();
+            },
+        );
+
+        test("should handle order confirmation errors with STATUS_FAILURE", async () => {
+            const confirmError = new Error("Confirmation failed");
+            mockApplePaySession.confirmOrder = jest
+                .fn()
+                .mockRejectedValue(confirmError);
+
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(capturedApplePaySession).not.toBeNull();
+            await act(async () => {
+                await capturedApplePaySession!.onpaymentauthorized?.({
+                    payment: {
+                        token: {},
+                        billingContact: {},
+                    },
+                });
+            });
+
+            expect(result.current.error).toEqual(confirmError);
+            expect(defaultProps.onError).toHaveBeenCalledWith(confirmError);
+            expect(
+                capturedApplePaySession!.completePayment,
+            ).toHaveBeenCalledWith({
+                status: MockApplePaySession.STATUS_FAILURE,
+            });
+        });
+
+        test("should clear error when SDK instance becomes available", () => {
+            const { rerender, result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            // Initially has SDK
+            expect(result.current.error).toBeNull();
+
+            // Simulate SDK becoming unavailable
+            mockPayPalRejected();
+            rerender();
+
+            expect(result.current.error).not.toBeNull();
+
+            // SDK becomes available again
+            mockPayPalContext({ sdkInstance: mockSdkInstance });
+            rerender();
+
+            expect(result.current.error).toBeNull();
+        });
+    });
+
+    describe("handleCancel", () => {
+        test("should call onCancel callback when payment is cancelled", async () => {
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(capturedApplePaySession).not.toBeNull();
+            act(() => {
+                capturedApplePaySession!.oncancel?.();
+            });
+
+            expect(defaultProps.onCancel).toHaveBeenCalled();
+        });
+
+        test("should abort active Apple Pay session when handleCancel is called", async () => {
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(capturedApplePaySession).not.toBeNull();
+
+            act(() => {
+                result.current.handleCancel();
+            });
+
+            expect(capturedApplePaySession!.abort).toHaveBeenCalled();
+        });
+    });
+
+    describe("handleDestroy", () => {
+        test("should abort session and prevent further clicks after handleDestroy", async () => {
+            const { result } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(capturedApplePaySession).not.toBeNull();
+
+            act(() => {
+                result.current.handleDestroy();
+            });
+
+            expect(capturedApplePaySession!.abort).toHaveBeenCalled();
+
+            // After destroy, handleClick should error because sessionRef is null
+            await act(async () => {
+                await result.current.handleClick();
+            });
+
+            expect(result.current.error?.message).toBe(
+                "Apple Pay session not available",
+            );
+        });
+    });
+
+    describe("cleanup", () => {
+        test("should not retry session creation after SDK error", () => {
+            const mockSdkInstanceWithError = {
+                createApplePayOneTimePaymentSession: jest
+                    .fn()
+                    .mockImplementation(() => {
+                        throw new Error("SDK error");
+                    }),
+            };
+
+            mockPayPalContext({ sdkInstance: mockSdkInstanceWithError });
+
+            const { rerender } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            // First attempt
+            expect(
+                mockSdkInstanceWithError.createApplePayOneTimePaymentSession,
+            ).toHaveBeenCalledTimes(1);
+
+            // Rerender should not trigger another attempt with same failed SDK
+            rerender();
+
+            expect(
+                mockSdkInstanceWithError.createApplePayOneTimePaymentSession,
+            ).toHaveBeenCalledTimes(1);
+        });
+
+        test("should retry session creation when SDK instance changes", () => {
+            const mockSdkInstanceWithError = {
+                createApplePayOneTimePaymentSession: jest
+                    .fn()
+                    .mockImplementation(() => {
+                        throw new Error("SDK error");
+                    }),
+            };
+
+            mockPayPalContext({ sdkInstance: mockSdkInstanceWithError });
+
+            const { rerender } = renderHook(() =>
+                useApplePayOneTimePaymentSession(defaultProps),
+            );
+
+            expect(
+                mockSdkInstanceWithError.createApplePayOneTimePaymentSession,
+            ).toHaveBeenCalledTimes(1);
+
+            // New SDK instance should trigger retry
+            const newMockSdkInstance = createMockSdkInstance();
+            mockPayPalContext({ sdkInstance: newMockSdkInstance });
+            rerender();
+
+            expect(
+                newMockSdkInstance.createApplePayOneTimePaymentSession,
+            ).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
@@ -4,7 +4,7 @@ import { usePayPal } from "./usePayPal";
 import { useIsMountedRef } from "./useIsMounted";
 import { useError } from "./useError";
 import { useProxyProps, createPaymentSession, toError } from "../utils";
-import { INSTANCE_LOADING_STATE } from "../types/PayPalProviderEnums";
+import { INSTANCE_LOADING_STATE } from "../types/ProviderEnums";
 
 import type {
     ApplePayOneTimePaymentSession,

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
@@ -15,21 +15,23 @@ import type {
     BasePaymentSessionReturn,
 } from "../types";
 
+export type ApplePayLineItem = {
+    label: string;
+    amount: string;
+    type?: "final" | "pending";
+};
+
 export type ApplePayPaymentRequest = {
     countryCode: string;
     currencyCode: string;
-    total: {
-        label: string;
-        amount: string;
-        type: "final" | "pending";
-    };
-    supportedNetworks?: string[];
-    merchantCapabilities?: string[];
+    total: ApplePayLineItem;
     requiredBillingContactFields?: string[];
     requiredShippingContactFields?: string[];
     shippingMethods?: unknown[];
-    lineItems?: unknown[];
+    lineItems?: ApplePayLineItem[];
     applicationData?: string;
+    /** Allows additional ApplePayPaymentRequest fields not explicitly typed above. */
+    [key: string]: unknown;
 };
 
 export type UseApplePayOneTimePaymentSessionProps = {

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
@@ -72,6 +72,12 @@ export type UseApplePayOneTimePaymentSessionProps = {
      * Optional callback invoked when an error occurs.
      */
     onError?: (error: Error) => void;
+    /**
+     * Apple Pay JS API version passed to the ApplePaySession constructor.
+     * Must be at least 4 (required by completePaymentMethodSelection update object form).
+     * Higher versions unlock newer payment request features but require newer devices.
+     */
+    applePaySessionVersion: number;
 };
 
 /**
@@ -132,6 +138,7 @@ export function useApplePayOneTimePaymentSession({
     displayName,
     domainName,
     createOrder,
+    applePaySessionVersion,
     ...callbacks
 }: UseApplePayOneTimePaymentSessionProps): BasePaymentSessionReturn {
     const { sdkInstance, loadingStatus } = usePayPal();
@@ -249,7 +256,7 @@ export function useApplePayOneTimePaymentSession({
 
             // Create Apple's native payment session
             const applePaySession = new ApplePaySessionConstructor(
-                4,
+                applePaySessionVersion,
                 fullPaymentRequest,
             );
             activeApplePaySessionRef.current = applePaySession;
@@ -339,6 +346,7 @@ export function useApplePayOneTimePaymentSession({
         displayName,
         domainName,
         createOrder,
+        applePaySessionVersion,
         proxyCallbacks,
         setError,
     ]);

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
@@ -1,0 +1,351 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import { usePayPal } from "./usePayPal";
+import { useIsMountedRef } from "./useIsMounted";
+import { useError } from "./useError";
+import { useProxyProps, createPaymentSession, toError } from "../utils";
+import { INSTANCE_LOADING_STATE } from "../types/PayPalProviderEnums";
+
+import type {
+    ApplePayOneTimePaymentSession,
+    ApplePayConfig,
+    ApplePayContact,
+    ApplePayPaymentToken,
+    ConfirmOrderResponse,
+    BasePaymentSessionReturn,
+} from "../types";
+
+export type ApplePayPaymentRequest = {
+    countryCode: string;
+    currencyCode: string;
+    total: {
+        label: string;
+        amount: string;
+        type: "final" | "pending";
+    };
+    supportedNetworks?: string[];
+    merchantCapabilities?: string[];
+    requiredBillingContactFields?: string[];
+    requiredShippingContactFields?: string[];
+    shippingMethods?: unknown[];
+    lineItems?: unknown[];
+    applicationData?: string;
+};
+
+export type UseApplePayOneTimePaymentSessionProps = {
+    /**
+     * Apple Pay configuration from findEligibleMethods.
+     * Used to format the payment request with merchant capabilities and supported networks.
+     */
+    applePayConfig: ApplePayConfig;
+    /**
+     * Payment request configuration for Apple Pay.
+     * This includes amount, country, currency, and other payment details.
+     */
+    paymentRequest: ApplePayPaymentRequest;
+    /**
+     * Optional display name for merchant validation.
+     * Defaults to domain name if not provided.
+     */
+    displayName?: string;
+    /**
+     * Optional domain name for merchant validation.
+     * Defaults to current domain if not provided.
+     */
+    domainName?: string;
+    /**
+     * Callback function to create an order.
+     * Should return a promise that resolves to an object with orderId.
+     */
+    createOrder: () => Promise<{ orderId: string }>;
+    /**
+     * Callback invoked when the payment is successfully approved.
+     */
+    onApprove: (data: ConfirmOrderResponse) => void | Promise<void>;
+    /**
+     * Optional callback invoked when the payment is cancelled.
+     */
+    onCancel?: () => void;
+    /**
+     * Optional callback invoked when an error occurs.
+     */
+    onError?: (error: Error) => void;
+};
+
+/**
+ * Hook for managing Apple Pay one-time payment sessions.
+ *
+ * This hook creates and manages a complete Apple Pay payment session, handling the entire
+ * flow from button click through merchant validation to payment confirmation.
+ *
+ * @example
+ * ```typescript
+ * function ApplePayCheckoutButton() {
+ *   const { sdkInstance } = usePayPal();
+ *   const [applePayConfig, setApplePayConfig] = useState(null);
+ *
+ *   useEffect(() => {
+ *     const fetchConfig = async () => {
+ *       const methods = await sdkInstance?.findEligibleMethods({ currencyCode: "USD" });
+ *       if (methods?.isEligible("applepay")) {
+ *         setApplePayConfig(methods.getDetails("applepay").config);
+ *       }
+ *     };
+ *     fetchConfig();
+ *   }, [sdkInstance]);
+ *
+ *   const { isPending, error, handleClick } = useApplePayOneTimePaymentSession({
+ *     applePayConfig,
+ *     paymentRequest: {
+ *       countryCode: "US",
+ *       currencyCode: "USD",
+ *       total: { label: "Demo Store", amount: "100.00", type: "final" },
+ *     },
+ *     createOrder: async () => {
+ *       const response = await fetch("/api/orders", { method: "POST" });
+ *       const data = await response.json();
+ *       return { orderId: data.id };
+ *     },
+ *     onApprove: (data) => console.log("Payment approved:", data),
+ *     onError: (err) => console.error("Payment error:", err),
+ *   });
+ *
+ *   if (isPending || !applePayConfig) return null;
+ *   if (error) return <div>Error: {error.message}</div>;
+ *
+ *   return (
+ *     <apple-pay-button
+ *       buttonstyle="black"
+ *       type="buy"
+ *       locale="en"
+ *       onClick={handleClick}
+ *     />
+ *   );
+ * }
+ * ```
+ */
+export function useApplePayOneTimePaymentSession({
+    applePayConfig,
+    paymentRequest,
+    displayName,
+    domainName,
+    createOrder,
+    ...callbacks
+}: UseApplePayOneTimePaymentSessionProps): BasePaymentSessionReturn {
+    const { sdkInstance, loadingStatus } = usePayPal();
+    const isMountedRef = useIsMountedRef();
+    const sessionRef = useRef<ApplePayOneTimePaymentSession | null>(null);
+    const activeApplePaySessionRef = useRef<{
+        abort: () => void;
+    } | null>(null);
+    const proxyCallbacks = useProxyProps(callbacks);
+    const [error, setError] = useError();
+
+    // Prevents retrying session creation with a failed SDK instance
+    const failedSdkRef = useRef<unknown>(null);
+
+    const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
+
+    const handleCancel = useCallback(() => {
+        if (activeApplePaySessionRef.current) {
+            try {
+                activeApplePaySessionRef.current.abort();
+            } catch {
+                // Session may already be complete
+            }
+            activeApplePaySessionRef.current = null;
+        }
+    }, []);
+
+    const handleDestroy = useCallback(() => {
+        handleCancel();
+        sessionRef.current = null;
+    }, [handleCancel]);
+
+    // Handle SDK availability
+    useEffect(() => {
+        // Reset failed SDK tracking when SDK instance changes
+        if (failedSdkRef.current !== sdkInstance) {
+            failedSdkRef.current = null;
+        }
+
+        if (sdkInstance) {
+            setError(null);
+        } else if (loadingStatus !== INSTANCE_LOADING_STATE.PENDING) {
+            setError(new Error("no sdk instance available"));
+        }
+    }, [sdkInstance, setError, loadingStatus]);
+
+    // Create and manage session lifecycle
+    useEffect(() => {
+        if (!sdkInstance) {
+            return;
+        }
+
+        const newSession = createPaymentSession(
+            () => sdkInstance.createApplePayOneTimePaymentSession(),
+            failedSdkRef,
+            sdkInstance,
+            setError,
+            "applepay-payments",
+        );
+
+        if (!newSession) {
+            return;
+        }
+
+        sessionRef.current = newSession;
+
+        return () => {
+            sessionRef.current = null;
+        };
+    }, [sdkInstance, setError]);
+
+    const handleClick = useCallback(async () => {
+        if (!isMountedRef.current) {
+            return;
+        }
+
+        // Clear any error from a previous attempt so the user can retry
+        setError(null);
+
+        if (!sessionRef.current) {
+            setError(new Error("Apple Pay session not available"));
+            return;
+        }
+
+        // Check if Apple Pay is available on this device/browser
+        if (
+            typeof window === "undefined" ||
+            !window.ApplePaySession?.canMakePayments()
+        ) {
+            setError(new Error("Apple Pay is not available"));
+            return;
+        }
+
+        // ApplePaySession constructor throws InvalidAccessError on non-HTTPS; provide a clearer message
+        if (window.location.protocol !== "https:") {
+            setError(
+                new Error("Apple Pay requires a secure (HTTPS) connection"),
+            );
+            return;
+        }
+
+        const { ApplePaySession: ApplePaySessionConstructor } = window;
+
+        try {
+            const paypalSession = sessionRef.current;
+
+            // Format the payment request with Apple Pay config
+            const formattedConfig =
+                paypalSession.formatConfigForPaymentRequest(applePayConfig);
+
+            const fullPaymentRequest = {
+                ...formattedConfig,
+                ...paymentRequest,
+            };
+
+            // Create Apple's native payment session
+            const applePaySession = new ApplePaySessionConstructor(
+                4,
+                fullPaymentRequest,
+            );
+            activeApplePaySessionRef.current = applePaySession;
+
+            // Handle merchant validation
+            applePaySession.onvalidatemerchant = async (event: {
+                validationURL: string;
+            }) => {
+                try {
+                    const payload = await paypalSession.validateMerchant({
+                        validationUrl: event.validationURL,
+                        ...(displayName && { displayName }),
+                        ...(domainName && { domainName }),
+                    });
+                    applePaySession.completeMerchantValidation(
+                        payload.merchantSession,
+                    );
+                } catch (err) {
+                    const merchantError = toError(err);
+                    setError(merchantError);
+                    proxyCallbacks.onError?.(merchantError);
+                    applePaySession.abort();
+                }
+            };
+
+            // Handle payment method selection
+            applePaySession.onpaymentmethodselected = () => {
+                applePaySession.completePaymentMethodSelection({
+                    newTotal: paymentRequest.total,
+                });
+            };
+
+            // Handle payment authorization
+            applePaySession.onpaymentauthorized = async (event: {
+                payment: {
+                    token: ApplePayPaymentToken;
+                    billingContact: ApplePayContact;
+                    shippingContact?: ApplePayContact;
+                };
+            }) => {
+                try {
+                    // Create the order
+                    const order = await createOrder();
+
+                    // Confirm the order with PayPal
+                    const confirmResult = await paypalSession.confirmOrder({
+                        orderId: order.orderId,
+                        token: event.payment.token,
+                        billingContact: event.payment.billingContact,
+                        shippingContact: event.payment.shippingContact,
+                    });
+
+                    // Complete the Apple Pay session successfully
+                    applePaySession.completePayment({
+                        status: ApplePaySessionConstructor.STATUS_SUCCESS,
+                    });
+
+                    // Call onApprove callback
+                    await proxyCallbacks.onApprove(confirmResult);
+                } catch (err) {
+                    const paymentError = toError(err);
+                    setError(paymentError);
+                    proxyCallbacks.onError?.(paymentError);
+                    applePaySession.completePayment({
+                        status: ApplePaySessionConstructor.STATUS_FAILURE,
+                    });
+                }
+            };
+
+            // Handle cancellation
+            applePaySession.oncancel = () => {
+                activeApplePaySessionRef.current = null;
+                proxyCallbacks.onCancel?.();
+            };
+
+            // Begin the Apple Pay session
+            applePaySession.begin();
+        } catch (err) {
+            const sessionError = toError(err);
+            setError(sessionError);
+            proxyCallbacks.onError?.(sessionError);
+        }
+    }, [
+        isMountedRef,
+        applePayConfig,
+        paymentRequest,
+        displayName,
+        domainName,
+        createOrder,
+        proxyCallbacks,
+        setError,
+    ]);
+
+    return {
+        error,
+        isPending,
+        handleClick,
+        handleCancel,
+        handleDestroy,
+    };
+}

--- a/packages/react-paypal-js/src/v6/index.ts
+++ b/packages/react-paypal-js/src/v6/index.ts
@@ -44,6 +44,10 @@ export {
 export { PayPalProvider } from "./components/PayPalProvider";
 export { PayPalSavePaymentButton } from "./components/PayPalSavePaymentButton";
 export { VenmoOneTimePaymentButton } from "./components/VenmoOneTimePaymentButton";
+export {
+    ApplePayOneTimePaymentButton,
+    type ApplePayOneTimePaymentButtonProps,
+} from "./components/ApplePayOneTimePaymentButton";
 export { PayPalCardNumberField } from "./components/PayPalCardNumberField";
 export { PayPalCardExpiryField } from "./components/PayPalCardExpiryField";
 export { PayPalCardCvvField } from "./components/PayPalCardCvvField";
@@ -101,6 +105,10 @@ export {
     useVenmoOneTimePaymentSession,
     type UseVenmoOneTimePaymentSessionProps,
 } from "./hooks/useVenmoOneTimePaymentSession";
+export {
+    useApplePayOneTimePaymentSession,
+    type UseApplePayOneTimePaymentSessionProps,
+} from "./hooks/useApplePayOneTimePaymentSession";
 
 // React 19+ JSX SDK Web Components type declaration
 declare global {

--- a/packages/react-paypal-js/src/v6/types/sdkWebComponents.ts
+++ b/packages/react-paypal-js/src/v6/types/sdkWebComponents.ts
@@ -9,8 +9,7 @@ export interface InternalButtonProps {
 }
 
 export interface ButtonProps
-    extends
-        Omit<HTMLAttributes<HTMLButtonElement>, "onError">,
+    extends Omit<HTMLAttributes<HTMLButtonElement>, "onError">,
         InternalButtonProps {}
 
 /**
@@ -23,13 +22,15 @@ export interface PayLaterButtonProps extends HTMLAttributes<HTMLButtonElement> {
     disabled?: boolean;
 }
 
-export interface PayPalBasicCardButtonProps extends HTMLAttributes<HTMLButtonElement> {
+export interface PayPalBasicCardButtonProps
+    extends HTMLAttributes<HTMLButtonElement> {
     buyerCountry?: string;
     disabled?: boolean;
     ref?: Ref<HTMLElement>;
 }
 
-export interface PayPalCreditButtonProps extends HTMLAttributes<HTMLButtonElement> {
+export interface PayPalCreditButtonProps
+    extends HTMLAttributes<HTMLButtonElement> {
     countryCode?: string;
     disabled?: boolean;
 }
@@ -75,6 +76,14 @@ export interface PayPalMessagesElement extends HTMLAttributes<HTMLElement> {
 
     setContent?: (content: Record<string, unknown>) => void;
 }
+export interface ApplePayButtonElementProps
+    extends HTMLAttributes<HTMLElement> {
+    buttonstyle?: string;
+    type?: string;
+    locale?: string;
+    disabled?: boolean;
+    ref?: Ref<HTMLElement>;
+}
 
 export type SDKWebComponents = {
     "paypal-button": ButtonProps;
@@ -84,4 +93,5 @@ export type SDKWebComponents = {
     "paypal-basic-card-button": PayPalBasicCardButtonProps;
     "paypal-basic-card-container": HTMLAttributes<HTMLElement>;
     "paypal-message": PayPalMessagesElement;
+    "apple-pay-button": ApplePayButtonElementProps;
 };


### PR DESCRIPTION
This PR is for adding ApplePay OneTimePayment hook and button component to support ApplePay in the react v6 wrapper.