### PR TITLE
ApplePay: Fix to prevent merchant paymentRequest from overriding SDK-managed Apple Pay…

### DIFF
--- a/.changeset/common-beers-march.md
+++ b/.changeset/common-beers-march.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Fix to prevent merchant paymentRequest from overriding SDK-managed Apple Pay config

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
@@ -250,8 +250,8 @@ export function useApplePayOneTimePaymentSession({
                 paypalSession.formatConfigForPaymentRequest(applePayConfig);
 
             const fullPaymentRequest = {
-                ...formattedConfig,
                 ...paymentRequest,
+                ...formattedConfig,
             };
 
             // Create Apple's native payment session


### PR DESCRIPTION
Applying a fix to give precedence to SDK config derived from PayPal's backend to overrider merchant provided details. SDK derived config values are need for the payment to succeed. If the merchant could override the SDK config values, they could produce a mismatch between what PayPal expects and what Apple Pay processes leading to silent failure or rejected transactions.

