### PR TITLE
Fix: Add liabilityShift property to CardFields CardFieldsOnApproveData type

### DIFF
--- a/.changeset/forty-bushes-add.md
+++ b/.changeset/forty-bushes-add.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Fixes an issue with a missing type in the Card Fields component.

--- a/packages/paypal-js/types/components/card-fields.d.ts
+++ b/packages/paypal-js/types/components/card-fields.d.ts
@@ -41,6 +41,7 @@ export interface PayPalCardFieldsStyleOptions {
 
 export type CardFieldsOnApproveData = {
     orderID: string;
+    liabilityShift?: string;
 };
 
 export interface PayPalCardFieldsInputEvents {


### PR DESCRIPTION
Fixes the type with an optional property, `liabilityShift`. Addresses [this issue](https://github.com/paypal/paypal-js/issues/652).