### PR TITLE
fix type mismatch on card fields submit

### DIFF
--- a/.changeset/card-fields-submit-options.md
+++ b/.changeset/card-fields-submit-options.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Add optional submit options to CardFields submit() method, including billingAddress and name fields for 3DS authentication support

--- a/packages/paypal-js/types/components/card-fields.d.ts
+++ b/packages/paypal-js/types/components/card-fields.d.ts
@@ -39,6 +39,20 @@ export interface PayPalCardFieldsStyleOptions {
   "-webkit-transition"?: string;
 }
 
+export type PayPalCardFieldsBillingAddress = {
+  addressLine1?: string;
+  addressLine2?: string;
+  adminArea2?: string;
+  adminArea1?: string;
+  postalCode?: string;
+  countryCode?: string;
+};
+
+export type PayPalCardFieldsSubmitOptions = {
+  name?: string;
+  billingAddress?: PayPalCardFieldsBillingAddress;
+};
+
 export type CardFieldsOnApproveData = {
   orderID: string;
   liabilityShift?: string;
@@ -156,7 +170,7 @@ export type PayPalCardFieldsComponentOptions =
 export interface PayPalCardFieldsComponent {
   getState: () => Promise<PayPalCardFieldsStateObject>;
   isEligible: () => boolean;
-  submit: () => Promise<void>;
+  submit: (options?: PayPalCardFieldsSubmitOptions) => Promise<void>;
   NameField: (
     options: PayPalCardFieldsIndividualFieldOptions,
   ) => PayPalCardFieldsIndividualField;

--- a/packages/paypal-js/types/tests/card-fields.test.ts
+++ b/packages/paypal-js/types/tests/card-fields.test.ts
@@ -1,6 +1,11 @@
 import { test, vi, describe, expect } from "vitest";
 
-import { PayPalCardFieldsComponentOptions } from "../components/card-fields";
+import {
+  PayPalCardFieldsComponentOptions,
+  PayPalCardFieldsComponent,
+  PayPalCardFieldsBillingAddress,
+  PayPalCardFieldsSubmitOptions,
+} from "../components/card-fields";
 
 describe.only("testing createOrder and createVaultToken types", () => {
   test("only creatOrder", () => {
@@ -43,5 +48,62 @@ describe.only("testing createOrder and createVaultToken types", () => {
     };
 
     expect(callback).toThrowError();
+  });
+});
+
+describe("testing submit options types", () => {
+  const mockCardFields = {
+    getState: vi.fn(),
+    isEligible: vi.fn(),
+    submit: vi.fn(),
+    NameField: vi.fn(),
+    NumberField: vi.fn(),
+    CVVField: vi.fn(),
+    ExpiryField: vi.fn(),
+  } as unknown as PayPalCardFieldsComponent;
+
+  test("submit with no arguments", () => {
+    mockCardFields.submit();
+  });
+
+  test("submit with empty options", () => {
+    mockCardFields.submit({});
+  });
+
+  test("submit with billingAddress only", () => {
+    mockCardFields.submit({
+      billingAddress: {
+        postalCode: "12345",
+        countryCode: "US",
+      },
+    });
+  });
+
+  test("submit with name only", () => {
+    mockCardFields.submit({ name: "John Doe" });
+  });
+
+  test("submit with all options", () => {
+    mockCardFields.submit({
+      name: "John Doe",
+      billingAddress: {
+        addressLine1: "123 Main St",
+        addressLine2: "Apt 4B",
+        adminArea2: "San Jose",
+        adminArea1: "CA",
+        postalCode: "95131",
+        countryCode: "US",
+      },
+    });
+  });
+
+  test("BillingAddress allows all fields optional", () => {
+    const emptyAddress: PayPalCardFieldsBillingAddress = {};
+    expect(emptyAddress).toBeDefined();
+  });
+
+  test("SubmitOptions allows all fields optional", () => {
+    const emptyOptions: PayPalCardFieldsSubmitOptions = {};
+    expect(emptyOptions).toBeDefined();
   });
 });

--- a/packages/paypal-js/types/tests/card-fields.test.ts
+++ b/packages/paypal-js/types/tests/card-fields.test.ts
@@ -7,7 +7,7 @@ import {
   PayPalCardFieldsSubmitOptions,
 } from "../components/card-fields";
 
-describe.only("testing createOrder and createVaultToken types", () => {
+describe("testing createOrder and createVaultToken types", () => {
   test("only creatOrder", () => {
     const createOrderCallback: PayPalCardFieldsComponentOptions = {
       createOrder: vi.fn(),
@@ -105,5 +105,17 @@ describe("testing submit options types", () => {
   test("SubmitOptions allows all fields optional", () => {
     const emptyOptions: PayPalCardFieldsSubmitOptions = {};
     expect(emptyOptions).toBeDefined();
+  });
+
+  test("submit rejects invalid billingAddress type", () => {
+    mockCardFields.submit({
+      // @ts-expect-error: billingAddress should be an object, not a string
+      billingAddress: "123 Main St",
+    });
+  });
+
+  test("submit rejects non-object argument", () => {
+    // @ts-expect-error: submit should not accept a string
+    mockCardFields.submit("billingAddress");
   });
 });


### PR DESCRIPTION
resolving issues here: https://github.com/paypal/paypal-js/issues/649

Test successfully in storybook, used local paypal-js package and changed parameters input to submit():

<img width="1190" height="846" alt="Screenshot 2026-05-05 at 11 06 53 AM" src="https://github.com/user-attachments/assets/8a2d3c27-7c83-495d-84ba-6932fd4888c6" />

<img width="1137" height="860" alt="Screenshot 2026-05-05 at 11 07 22 AM" src="https://github.com/user-attachments/assets/9a003c72-4f3b-4e16-8792-fd3a2848cebe" />

