### PR TITLE
Fixing ApplePay styling issue

### DIFF
--- a/.changeset/clean-rules-pump.md
+++ b/.changeset/clean-rules-pump.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Fixing ApplePay styling issue

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
@@ -6,19 +6,6 @@ import { usePayPal } from "../hooks/usePayPal";
 import type { UseApplePayOneTimePaymentSessionProps } from "../hooks/useApplePayOneTimePaymentSession";
 import type { ApplePayButtonElementProps } from "../types/sdkWebComponents";
 
-/**
- * Safari's native `<apple-pay-button>` relies on `-webkit-appearance: -apple-pay-button`
- * to render its visual appearance. When the element is inserted dynamically by
- * JavaScript (as React does), Safari may not apply the native appearance
- * automatically, leaving the button invisible. Applying these styles explicitly
- * ensures the button renders reliably across Safari versions without requiring
- * consumers to add CSS in their own HTML.
- */
-const applePayButtonStyles: React.CSSProperties = {
-  WebkitAppearance:
-    "-apple-pay-button" as React.CSSProperties["WebkitAppearance"],
-};
-
 export type ApplePayOneTimePaymentButtonProps =
   UseApplePayOneTimePaymentSessionProps & ApplePayButtonElementProps;
 
@@ -104,7 +91,6 @@ export const ApplePayOneTimePaymentButton = ({
         type={type}
         locale={locale}
         disabled={isDisabled || undefined}
-        style={applePayButtonStyles}
       />
     </div>
   );


### PR DESCRIPTION
Removing the -webkit-appearance workaround from `ApplePayOneTimePaymentButton`.

Remove the explicit `-webkit-appearance: -apple-pay-button` inline style
that was applied to work around Safari not rendering dynamically inserted
<apple-pay-button> elements.

The proper fix is to load Apple's JS SDK (`apple-pay-sdk.js`), which
registers the custom element and applies styles via shadow DOM — making
the workaround unnecessary.