### PR TITLE
Feature/googlepay hook button component

### DIFF
--- a/.changeset/lemon-sloths-bet.md
+++ b/.changeset/lemon-sloths-bet.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": minor
+---
+
+Consolidating the shared GooglePay types to paypal-js package.

--- a/.changeset/salty-signs-stare.md
+++ b/.changeset/salty-signs-stare.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+Implementing GooglePay hook and the button component

--- a/packages/paypal-js/types/v6/components/googlepay-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/googlepay-payments.d.ts
@@ -46,6 +46,63 @@ export type GooglePayConfig = {
 };
 
 /**
+ * Transaction information for Google Pay payment requests
+ *
+ * @remarks
+ * Passed to Google PaymentsClient.loadPaymentData() as part of the request payload.
+ */
+export type GooglePayTransactionInfo = {
+  countryCode: string;
+  currencyCode: string;
+  totalPriceStatus: "FINAL" | "ESTIMATED" | "NOT_CURRENTLY_KNOWN";
+  totalPrice: string;
+  totalPriceLabel?: string;
+  displayItems?: Array<{
+    label: string;
+    type: string;
+    price: string;
+  }>;
+  [key: string]: unknown;
+};
+
+/**
+ * Request payload for Google PaymentsClient.isReadyToPay()
+ */
+export type GooglePayIsReadyToPayRequest = {
+  allowedPaymentMethods: GooglePayConfig["allowedPaymentMethods"];
+  apiVersion: GooglePayConfig["apiVersion"];
+  apiVersionMinor: GooglePayConfig["apiVersionMinor"];
+};
+
+/**
+ * Request payload for Google PaymentsClient.loadPaymentData()
+ */
+export type GooglePayPaymentDataRequest = GooglePayIsReadyToPayRequest & {
+  merchantInfo: GooglePayConfig["merchantInfo"];
+  transactionInfo: GooglePayTransactionInfo;
+  callbackIntents: ReadonlyArray<"PAYMENT_AUTHORIZATION">;
+};
+
+/**
+ * Options for Google PaymentsClient.createButton()
+ */
+export type GooglePayButtonOptions = {
+  onClick: () => void;
+  buttonType?:
+    | "book"
+    | "buy"
+    | "checkout"
+    | "donate"
+    | "order"
+    | "pay"
+    | "plain"
+    | "subscribe";
+  buttonColor?: "default" | "black" | "white";
+  buttonSizeMode?: "static" | "fill";
+  buttonLocale?: string;
+};
+
+/**
  * Google Pay configuration from the eligibility response
  *
  * @remarks

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -306,6 +306,16 @@ import { VenmoOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 Renders a native Google Pay button for one-time payments. Requires `"googlepay-payments"` in the provider's `components` array.
 
+Google Pay prerequisites:
+
+1. Load Google Pay JS in your app HTML shell (for example `public/index.html`):
+
+```html
+<script async src="https://pay.google.com/gp/p/js/pay.js"></script>
+```
+
+2. Ensure the script is available before rendering `GooglePayOneTimePaymentButton`, since this component depends on `window.google.payments.api.PaymentsClient`.
+
 ```tsx
 import {
   PayPalProvider,

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -48,6 +48,7 @@ Integrating PayPal into React applications requires careful handling of SDK scri
 - **PayPal Subscriptions** - Recurring billing subscriptions
 - **PayPal Save** - Vault payment methods without purchase
 - **PayPal Credit** - PayPal Credit one-time and save payments
+- **Google Pay** - Native Google Pay button flow through PaymentsClient
 
 ## Resources
 
@@ -140,6 +141,7 @@ The `components` prop accepts an array of the following values:
 - `"paypal-guest-payments"` - Guest checkout (card payments)
 - `"paypal-subscriptions"` - Subscription payments
 - `"card-fields"` - Card Fields (advanced card payment UI)
+- `"googlepay-payments"` - Google Pay
 
 ### With Promise-based Client ID
 
@@ -299,6 +301,91 @@ import { VenmoOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
   />
 </PayPalProvider>;
 ```
+
+### GooglePayOneTimePaymentButton
+
+Renders a native Google Pay button for one-time payments. Requires `"googlepay-payments"` in the provider's `components` array.
+
+```tsx
+import {
+  PayPalProvider,
+  GooglePayOneTimePaymentButton,
+  useEligibleMethods,
+  INSTANCE_LOADING_STATE,
+  usePayPal,
+} from "@paypal/react-paypal-js/sdk-v6";
+
+function GooglePayCheckout() {
+  const { loadingStatus } = usePayPal();
+  const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+    payload: { currencyCode: "USD" },
+  });
+
+  if (loadingStatus === INSTANCE_LOADING_STATE.PENDING || isLoading) {
+    return <div>Loading Google Pay...</div>;
+  }
+
+  const googlePayConfig = eligiblePaymentMethods?.isEligible("googlepay")
+    ? eligiblePaymentMethods.getDetails("googlepay").config
+    : null;
+
+  if (!googlePayConfig) {
+    return <div>Google Pay is not eligible for this buyer.</div>;
+  }
+
+  return (
+    <GooglePayOneTimePaymentButton
+      googlePayConfig={googlePayConfig}
+      transactionInfo={{
+        countryCode: "US",
+        currencyCode: "USD",
+        totalPriceStatus: "FINAL",
+        totalPrice: "100.00",
+      }}
+      createOrder={async () => {
+        const response = await fetch("/api/create-order", { method: "POST" });
+        const { orderId } = await response.json();
+        return { orderId };
+      }}
+      onApprove={(data) => console.log("Google Pay approved", data)}
+      onCancel={() => console.log("Google Pay cancelled")}
+      onError={(error) => console.error("Google Pay error", error)}
+      buttonType="pay"
+      buttonColor="default"
+      buttonSizeMode="fill"
+    />
+  );
+}
+
+function App() {
+  return (
+    <PayPalProvider
+      clientId="your-client-id"
+      components={["paypal-payments", "googlepay-payments"]}
+      pageType="checkout"
+    >
+      <GooglePayCheckout />
+    </PayPalProvider>
+  );
+}
+```
+
+**Props:**
+
+| Prop              | Type                                     | Description                                                                            |
+| ----------------- | ---------------------------------------- | -------------------------------------------------------------------------------------- |
+| `googlePayConfig` | `GooglePayConfigFromFindEligibleMethods` | Google Pay config returned by `eligiblePaymentMethods.getDetails("googlepay")`         |
+| `transactionInfo` | `GooglePayTransactionInfo`               | Google Pay transaction details (country, currency, amount, and optional display items) |
+| `createOrder`     | `() => Promise<{ orderId: string }>`     | Async function to create an order                                                      |
+| `onApprove`       | `(data) => void \| Promise<void>`        | Called when Google Pay payment is approved                                             |
+| `onCancel`        | `() => void`                             | Called when buyer cancels the Google Pay sheet                                         |
+| `onError`         | `(error: Error) => void`                 | Called on setup or payment errors                                                      |
+| `environment`     | `"TEST" \| "PRODUCTION"`                 | Google Pay environment (default: `"TEST"`)                                             |
+| `buttonType`      | `"pay" \| ...`                           | Google Pay button type                                                                 |
+| `buttonColor`     | `"default" \| "black" \| "white"`        | Google Pay button color                                                                |
+| `buttonSizeMode`  | `"fill" \| "static"`                     | Google Pay button size mode                                                            |
+| `buttonLocale`    | `string`                                 | Google Pay button locale                                                               |
+| `disabled`        | `boolean`                                | Disable interaction                                                                    |
 
 ### PayLaterOneTimePaymentButton
 
@@ -722,6 +809,7 @@ For advanced use cases where you need full control over the payment flow, use th
 | `usePayPalSavePaymentSession`          | Save Payment Method |
 | `usePayPalCreditOneTimePaymentSession` | Credit (One-time)   |
 | `usePayPalCreditSavePaymentSession`    | Credit (Save)       |
+| `useGooglePayOneTimePaymentSession`    | Google Pay          |
 
 #### usePayPalOneTimePaymentSession
 

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -361,7 +361,7 @@ function App() {
   return (
     <PayPalProvider
       clientId="your-client-id"
-      components={["paypal-payments", "googlepay-payments"]}
+      components={["googlepay-payments"]}
       pageType="checkout"
     >
       <GooglePayCheckout />

--- a/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.test.tsx
@@ -197,6 +197,7 @@ describe("GooglePayOneTimePaymentButton", () => {
     const wrapper = container.firstElementChild as HTMLElement;
     expect(wrapper.style.pointerEvents).toBe("none");
     expect(wrapper.style.opacity).toBe("0.5");
+    expect(wrapper).toHaveAttribute("aria-disabled", "true");
   });
 
   it("applies disabled styling when isPending is true", () => {
@@ -220,7 +221,7 @@ describe("GooglePayOneTimePaymentButton", () => {
     expect(mockCreateGooglePayButton).not.toHaveBeenCalled();
   });
 
-  it("applies disabled styling when hook returns an error", () => {
+  it("does not apply disabled styling when hook returns an error", () => {
     const testError = new Error("Test error");
     mockUseGooglePayOneTimePaymentSession.mockReturnValue({
       error: testError,
@@ -237,8 +238,8 @@ describe("GooglePayOneTimePaymentButton", () => {
       <GooglePayOneTimePaymentButton {...defaultProps} />,
     );
     const wrapper = container.firstElementChild as HTMLElement;
-    expect(wrapper.style.pointerEvents).toBe("none");
-    expect(wrapper.style.opacity).toBe("0.5");
+    expect(wrapper.style.pointerEvents).toBe("");
+    expect(wrapper.style.opacity).toBe("");
   });
 
   it("passes only hook props to useGooglePayOneTimePaymentSession", () => {

--- a/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+
+import {
+  GooglePayOneTimePaymentButton,
+  type GooglePayOneTimePaymentButtonProps,
+} from "./GooglePayOneTimePaymentButton";
+import { useGooglePayOneTimePaymentSession } from "../hooks/useGooglePayOneTimePaymentSession";
+import { usePayPal } from "../hooks/usePayPal";
+
+import type { GooglePayConfigFromFindEligibleMethods } from "../types";
+
+jest.mock("../hooks/useGooglePayOneTimePaymentSession", () => ({
+  useGooglePayOneTimePaymentSession: jest.fn(),
+}));
+jest.mock("../hooks/usePayPal", () => ({
+  usePayPal: jest.fn(),
+}));
+
+let capturedButtonOnClick: (() => void) | null = null;
+let capturedButtonOptions: Record<string, unknown> | null = null;
+const mockCreateGooglePayButton = jest.fn();
+
+const createMockGooglePayButton = (options: {
+  onClick: () => void;
+  [key: string]: unknown;
+}) => {
+  capturedButtonOnClick = options.onClick;
+  capturedButtonOptions = options;
+  const button = document.createElement("button");
+  button.className = "gpay-button";
+  button.textContent = "Google Pay";
+  return button;
+};
+
+describe("GooglePayOneTimePaymentButton", () => {
+  const mockHandleClick = jest.fn().mockResolvedValue(undefined);
+  const mockHandleCancel = jest.fn();
+  const mockHandleDestroy = jest.fn();
+  const mockUseGooglePayOneTimePaymentSession =
+    useGooglePayOneTimePaymentSession as jest.Mock;
+  const mockUsePayPal = usePayPal as jest.Mock;
+
+  const mockGooglePayConfig: GooglePayConfigFromFindEligibleMethods = {
+    eligible: true,
+    merchantCountry: "US",
+    apiVersion: 2,
+    apiVersionMinor: 0,
+    allowedPaymentMethods: [
+      {
+        type: "CARD",
+        parameters: {
+          allowedAuthMethods: ["CRYPTOGRAM_3DS", "PAN_ONLY"],
+          supportedNetworks: ["VISA", "MASTERCARD"],
+          billingAddressRequired: true,
+          assuranceDetailsRequired: true,
+          billingAddressParameters: {
+            format: "FULL",
+          },
+        },
+        tokenizationSpecification: {
+          type: "PAYMENT_GATEWAY",
+          parameters: {
+            gateway: "paypal",
+            gatewayMerchantId: "test-merchant-id",
+          },
+        },
+      },
+    ],
+    merchantInfo: {
+      merchantOrigin: "example.com",
+      merchantId: "test-merchant-id",
+    },
+  };
+
+  const defaultProps: GooglePayOneTimePaymentButtonProps = {
+    googlePayConfig: mockGooglePayConfig,
+    transactionInfo: {
+      countryCode: "US",
+      currencyCode: "USD",
+      totalPriceStatus: "FINAL",
+      totalPrice: "100.00",
+    },
+    createOrder: jest.fn().mockResolvedValue({ orderId: "ORDER-123" }),
+    onApprove: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedButtonOnClick = null;
+    capturedButtonOptions = null;
+    mockCreateGooglePayButton.mockImplementation(async (options) =>
+      createMockGooglePayButton(options),
+    );
+
+    mockUseGooglePayOneTimePaymentSession.mockReturnValue({
+      error: null,
+      isPending: false,
+      paymentsClient: null,
+      formattedConfig: null,
+      createGooglePayButton: mockCreateGooglePayButton,
+      handleClick: mockHandleClick,
+      handleCancel: mockHandleCancel,
+      handleDestroy: mockHandleDestroy,
+    });
+    mockUsePayPal.mockReturnValue({
+      isHydrated: true,
+    });
+  });
+
+  it("renders a plain div when not hydrated", () => {
+    mockUsePayPal.mockReturnValue({ isHydrated: false });
+    const { container } = render(
+      <GooglePayOneTimePaymentButton {...defaultProps} />,
+    );
+    expect(container.querySelector("div")).toBeInTheDocument();
+    expect(container.querySelector(".gpay-button")).not.toBeInTheDocument();
+    expect(mockCreateGooglePayButton).not.toHaveBeenCalled();
+  });
+
+  it("calls createGooglePayButton and mounts the Google Pay button", async () => {
+    const { container } = render(
+      <GooglePayOneTimePaymentButton {...defaultProps} />,
+    );
+
+    await waitFor(() => {
+      expect(mockCreateGooglePayButton).toHaveBeenCalled();
+      expect(container.querySelector(".gpay-button")).toBeInTheDocument();
+    });
+  });
+
+  it("does not mount button when createGooglePayButton returns null", async () => {
+    mockCreateGooglePayButton.mockResolvedValue(null);
+
+    const { container } = render(
+      <GooglePayOneTimePaymentButton {...defaultProps} />,
+    );
+
+    await waitFor(() => {
+      expect(mockCreateGooglePayButton).toHaveBeenCalled();
+    });
+
+    expect(container.querySelector(".gpay-button")).not.toBeInTheDocument();
+  });
+
+  it("passes default button options to createGooglePayButton", async () => {
+    render(<GooglePayOneTimePaymentButton {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(capturedButtonOptions).toMatchObject({
+        buttonType: "pay",
+        buttonColor: "default",
+        buttonSizeMode: "fill",
+      });
+    });
+  });
+
+  it("passes custom button options to createGooglePayButton", async () => {
+    render(
+      <GooglePayOneTimePaymentButton
+        {...defaultProps}
+        buttonType="buy"
+        buttonColor="black"
+        buttonSizeMode="static"
+        buttonLocale="fr"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(capturedButtonOptions).toMatchObject({
+        buttonType: "buy",
+        buttonColor: "black",
+        buttonSizeMode: "static",
+        buttonLocale: "fr",
+      });
+    });
+  });
+
+  it("calls handleClick when Google Pay button callback fires", async () => {
+    render(<GooglePayOneTimePaymentButton {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(capturedButtonOnClick).not.toBeNull();
+    });
+
+    capturedButtonOnClick!();
+    expect(mockHandleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies disabled styling when disabled prop is true", () => {
+    const { container } = render(
+      <GooglePayOneTimePaymentButton {...defaultProps} disabled={true} />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.pointerEvents).toBe("none");
+    expect(wrapper.style.opacity).toBe("0.5");
+  });
+
+  it("applies disabled styling when isPending is true", () => {
+    mockUseGooglePayOneTimePaymentSession.mockReturnValue({
+      error: null,
+      isPending: true,
+      paymentsClient: null,
+      formattedConfig: null,
+      createGooglePayButton: mockCreateGooglePayButton,
+      handleClick: mockHandleClick,
+      handleCancel: mockHandleCancel,
+      handleDestroy: mockHandleDestroy,
+    });
+
+    const { container } = render(
+      <GooglePayOneTimePaymentButton {...defaultProps} />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.pointerEvents).toBe("none");
+    expect(wrapper.style.opacity).toBe("0.5");
+    expect(mockCreateGooglePayButton).not.toHaveBeenCalled();
+  });
+
+  it("applies disabled styling when hook returns an error", () => {
+    const testError = new Error("Test error");
+    mockUseGooglePayOneTimePaymentSession.mockReturnValue({
+      error: testError,
+      isPending: false,
+      paymentsClient: null,
+      formattedConfig: null,
+      createGooglePayButton: mockCreateGooglePayButton,
+      handleClick: mockHandleClick,
+      handleCancel: mockHandleCancel,
+      handleDestroy: mockHandleDestroy,
+    });
+
+    const { container } = render(
+      <GooglePayOneTimePaymentButton {...defaultProps} />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.pointerEvents).toBe("none");
+    expect(wrapper.style.opacity).toBe("0.5");
+  });
+
+  it("passes only hook props to useGooglePayOneTimePaymentSession", () => {
+    render(
+      <GooglePayOneTimePaymentButton
+        {...defaultProps}
+        buttonType="buy"
+        buttonColor="black"
+        buttonSizeMode="static"
+        buttonLocale="fr"
+        disabled={true}
+      />,
+    );
+
+    expect(mockUseGooglePayOneTimePaymentSession).toHaveBeenCalledWith(
+      defaultProps,
+    );
+  });
+
+  it("calls handleDestroy on unmount", () => {
+    const { unmount } = render(
+      <GooglePayOneTimePaymentButton {...defaultProps} />,
+    );
+    unmount();
+    expect(mockHandleDestroy).toHaveBeenCalled();
+  });
+});

--- a/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
@@ -4,37 +4,9 @@ import { useGooglePayOneTimePaymentSession } from "../hooks/useGooglePayOneTimeP
 import { usePayPal } from "../hooks/usePayPal";
 
 import type { UseGooglePayOneTimePaymentSessionProps } from "../hooks/useGooglePayOneTimePaymentSession";
+import type { GooglePayButtonOptions } from "../types";
 
-export type GooglePayButtonStyle = {
-  /**
-   * The Google Pay button type.
-   * @see https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions
-   * @default "pay"
-   */
-  buttonType?:
-    | "book"
-    | "buy"
-    | "checkout"
-    | "donate"
-    | "order"
-    | "pay"
-    | "plain"
-    | "subscribe";
-  /**
-   * The Google Pay button color.
-   * @default "default"
-   */
-  buttonColor?: "default" | "black" | "white";
-  /**
-   * The Google Pay button size mode.
-   * @default "fill"
-   */
-  buttonSizeMode?: "static" | "fill";
-  /**
-   * The Google Pay button locale (BCP 47).
-   */
-  buttonLocale?: string;
-};
+export type GooglePayButtonStyle = Omit<GooglePayButtonOptions, "onClick">;
 
 export type GooglePayOneTimePaymentButtonProps =
   UseGooglePayOneTimePaymentSessionProps &

--- a/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
@@ -55,20 +55,15 @@ export const GooglePayOneTimePaymentButton = ({
   buttonLocale,
   ...hookProps
 }: GooglePayOneTimePaymentButtonProps): JSX.Element | null => {
-  const {
-    error,
-    isPending,
-    handleClick,
-    handleDestroy,
-    createGooglePayButton,
-  } = useGooglePayOneTimePaymentSession(hookProps);
+  const { isPending, handleClick, handleDestroy, createGooglePayButton } =
+    useGooglePayOneTimePaymentSession(hookProps);
   const { isHydrated } = usePayPal();
   const containerRef = useRef<HTMLDivElement>(null);
   const buttonMountedRef = useRef(false);
   const handleClickRef = useRef(handleClick);
   handleClickRef.current = handleClick;
 
-  const isDisabled = disabled || isPending || error !== null;
+  const isDisabled = disabled || isPending;
 
   // Create and mount the Google Pay button
   const mountButton = useCallback(() => {
@@ -130,6 +125,7 @@ export const GooglePayOneTimePaymentButton = ({
   return (
     <div
       ref={containerRef}
+      aria-disabled={isDisabled || undefined}
       style={isDisabled ? { pointerEvents: "none", opacity: "0.5" } : undefined}
     />
   );

--- a/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useRef, useCallback } from "react";
+
+import { useGooglePayOneTimePaymentSession } from "../hooks/useGooglePayOneTimePaymentSession";
+import { usePayPal } from "../hooks/usePayPal";
+
+import type { UseGooglePayOneTimePaymentSessionProps } from "../hooks/useGooglePayOneTimePaymentSession";
+
+export type GooglePayButtonStyle = {
+  /**
+   * The Google Pay button type.
+   * @see https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions
+   * @default "pay"
+   */
+  buttonType?:
+    | "book"
+    | "buy"
+    | "checkout"
+    | "donate"
+    | "order"
+    | "pay"
+    | "plain"
+    | "subscribe";
+  /**
+   * The Google Pay button color.
+   * @default "default"
+   */
+  buttonColor?: "default" | "black" | "white";
+  /**
+   * The Google Pay button size mode.
+   * @default "fill"
+   */
+  buttonSizeMode?: "static" | "fill";
+  /**
+   * The Google Pay button locale (BCP 47).
+   */
+  buttonLocale?: string;
+};
+
+export type GooglePayOneTimePaymentButtonProps =
+  UseGooglePayOneTimePaymentSessionProps &
+    GooglePayButtonStyle & {
+      /**
+       * Whether the button is disabled.
+       * @default false
+       */
+      disabled?: boolean;
+    };
+
+/**
+ * `GooglePayOneTimePaymentButton` renders a native Google Pay button and manages
+ * the full Google Pay payment flow via the PayPal SDK.
+ *
+ * Unlike PayPal/Venmo buttons (which use PayPal web components), this component
+ * mounts the native Google Pay button created by `google.payments.api.PaymentsClient.createButton()`.
+ *
+ * @example
+ * ```tsx
+ * <GooglePayOneTimePaymentButton
+ *   googlePayConfig={googlePayConfig}
+ *   transactionInfo={{
+ *     countryCode: "US",
+ *     currencyCode: "USD",
+ *     totalPriceStatus: "FINAL",
+ *     totalPrice: "100.00",
+ *   }}
+ *   createOrder={async () => {
+ *     const res = await fetch("/api/orders", { method: "POST" });
+ *     const data = await res.json();
+ *     return { orderId: data.id };
+ *   }}
+ *   onApprove={(data) => console.log("Approved:", data)}
+ *   onError={(err) => console.error(err)}
+ *   buttonColor="black"
+ *   buttonType="pay"
+ * />
+ * ```
+ */
+export const GooglePayOneTimePaymentButton = ({
+  disabled = false,
+  buttonType = "pay",
+  buttonColor = "default",
+  buttonSizeMode = "fill",
+  buttonLocale,
+  ...hookProps
+}: GooglePayOneTimePaymentButtonProps): JSX.Element | null => {
+  const {
+    error,
+    isPending,
+    handleClick,
+    handleDestroy,
+    createGooglePayButton,
+  } = useGooglePayOneTimePaymentSession(hookProps);
+  const { isHydrated } = usePayPal();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonMountedRef = useRef(false);
+  const handleClickRef = useRef(handleClick);
+  handleClickRef.current = handleClick;
+
+  const isDisabled = disabled || isPending || error !== null;
+
+  // Create and mount the Google Pay button
+  const mountButton = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || buttonMountedRef.current) {
+      return;
+    }
+
+    const mountIfReady = async () => {
+      const button = await createGooglePayButton({
+        onClick: () => {
+          // handleClick already normalizes callback errors into hook state + onError
+          handleClickRef.current();
+        },
+        buttonType,
+        buttonColor,
+        buttonSizeMode,
+        ...(buttonLocale && { buttonLocale }),
+      });
+
+      if (!button) {
+        return;
+      }
+
+      // Clear any previous content and mount the button
+      container.replaceChildren(button);
+      buttonMountedRef.current = true;
+    };
+
+    void mountIfReady();
+  }, [
+    createGooglePayButton,
+    buttonType,
+    buttonColor,
+    buttonSizeMode,
+    buttonLocale,
+  ]);
+
+  // Mount the button when hydrated and not pending
+  useEffect(() => {
+    if (isHydrated && !isPending) {
+      // Reset mounted flag when button options change so we remount
+      buttonMountedRef.current = false;
+      mountButton();
+    }
+  }, [isHydrated, isPending, mountButton]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      handleDestroy();
+    };
+  }, [handleDestroy]);
+
+  if (!isHydrated) {
+    return <div />;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      style={isDisabled ? { pointerEvents: "none", opacity: "0.5" } : undefined}
+    />
+  );
+};

--- a/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.test.ts
@@ -1,0 +1,737 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from "@testing-library/react-hooks";
+
+import { expectCurrentErrorValue } from "./useErrorTestUtil";
+import { useGooglePayOneTimePaymentSession } from "./useGooglePayOneTimePaymentSession";
+import {
+  mockPayPalContext,
+  mockPayPalRejected,
+  mockPayPalPending,
+} from "./usePayPalTestUtils";
+import { useProxyProps } from "../utils";
+
+import type { UseGooglePayOneTimePaymentSessionProps } from "./useGooglePayOneTimePaymentSession";
+import type {
+  GooglePayOneTimePaymentSession,
+  GooglePayConfigFromFindEligibleMethods,
+} from "../types";
+
+jest.mock("./usePayPal");
+
+jest.mock("../utils", () => ({
+  ...jest.requireActual("../utils"),
+  useProxyProps: jest.fn(),
+}));
+
+const mockUseProxyProps = useProxyProps as jest.MockedFunction<
+  typeof useProxyProps
+>;
+
+let stableProxyCallbacks: Record<string, unknown> | null = null;
+
+// Mock Google Pay PaymentsClient
+let capturedOnPaymentAuthorized:
+  | ((paymentData: unknown) => Promise<unknown>)
+  | null = null;
+
+let mockLoadPaymentData = jest.fn().mockResolvedValue(undefined);
+
+class MockPaymentsClient {
+  loadPaymentData: jest.Mock;
+  isReadyToPay = jest.fn().mockResolvedValue({ result: true });
+  createButton = jest.fn().mockReturnValue(document.createElement("div"));
+
+  constructor(config: {
+    environment: string;
+    paymentDataCallbacks?: {
+      onPaymentAuthorized?: (paymentData: unknown) => Promise<unknown>;
+    };
+  }) {
+    this.loadPaymentData = mockLoadPaymentData;
+    capturedOnPaymentAuthorized =
+      config.paymentDataCallbacks?.onPaymentAuthorized ?? null;
+  }
+}
+
+const setupGooglePayGlobal = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).google = {
+    payments: {
+      api: {
+        PaymentsClient: MockPaymentsClient,
+      },
+    },
+  };
+};
+
+const removeGooglePayGlobal = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).google;
+};
+
+const createMockGooglePaySession = (): GooglePayOneTimePaymentSession => ({
+  formatConfigForPaymentRequest: jest.fn().mockReturnValue({
+    allowedPaymentMethods: [
+      {
+        type: "CARD",
+        parameters: {
+          allowedAuthMethods: ["CRYPTOGRAM_3DS", "PAN_ONLY"],
+          allowedCardNetworks: ["VISA", "MASTERCARD"],
+        },
+        tokenizationSpecification: {
+          type: "PAYMENT_GATEWAY",
+          parameters: {
+            gateway: "paypal",
+            gatewayMerchantId: "test-merchant-id",
+          },
+        },
+      },
+    ],
+    apiVersion: 2,
+    apiVersionMinor: 0,
+    countryCode: "US",
+    merchantInfo: {
+      merchantId: "test-merchant-id",
+      merchantOrigin: "example.com",
+    },
+  }),
+  getGooglePayConfig: jest.fn().mockResolvedValue({
+    allowedPaymentMethods: [],
+    merchantInfo: {
+      authJwt: "test-jwt",
+      merchantId: "test-merchant-id",
+      merchantName: "Test Store",
+      merchantOrigin: "example.com",
+    },
+  }),
+  confirmOrder: jest.fn().mockResolvedValue({
+    id: "test-order-id",
+    status: "APPROVED",
+    payment_source: {
+      google_pay: {
+        name: "Test User",
+        card: {
+          last_digits: "1234",
+          type: "CREDIT",
+          brand: "VISA",
+        },
+      },
+    },
+    links: [],
+  }),
+  initiatePayerAction: jest.fn(),
+});
+
+const createMockSdkInstance = (
+  googlePaySession = createMockGooglePaySession(),
+) => ({
+  createGooglePayOneTimePaymentSession: jest
+    .fn()
+    .mockReturnValue(googlePaySession),
+});
+
+const mockGooglePayConfig: GooglePayConfigFromFindEligibleMethods = {
+  eligible: true,
+  merchantCountry: "US",
+  apiVersion: 2,
+  apiVersionMinor: 0,
+  allowedPaymentMethods: [
+    {
+      type: "CARD",
+      parameters: {
+        allowedAuthMethods: ["CRYPTOGRAM_3DS", "PAN_ONLY"],
+        supportedNetworks: ["VISA", "MASTERCARD"],
+        billingAddressRequired: true,
+        assuranceDetailsRequired: true,
+        billingAddressParameters: {
+          format: "FULL",
+        },
+      },
+      tokenizationSpecification: {
+        type: "PAYMENT_GATEWAY",
+        parameters: {
+          gateway: "paypal",
+          gatewayMerchantId: "test-merchant-id",
+        },
+      },
+    },
+  ],
+  merchantInfo: {
+    merchantOrigin: "example.com",
+    merchantId: "test-merchant-id",
+  },
+};
+
+const mockPaymentData = {
+  paymentMethodData: {
+    description: "Visa •••• 1234",
+    tokenizationData: {
+      type: "PAYMENT_GATEWAY",
+      token: '{"signature":"test"}',
+    },
+    type: "CARD",
+    info: {
+      cardDetails: "1234",
+      cardNetwork: "VISA",
+      assuranceDetails: {
+        accountVerified: true,
+        cardHolderAuthenticated: true,
+      },
+    },
+  },
+};
+
+describe("useGooglePayOneTimePaymentSession", () => {
+  let mockGooglePaySession: GooglePayOneTimePaymentSession;
+  let mockSdkInstance: ReturnType<typeof createMockSdkInstance>;
+  let defaultProps: UseGooglePayOneTimePaymentSessionProps;
+
+  beforeEach(() => {
+    stableProxyCallbacks = null;
+    mockUseProxyProps.mockImplementation((callbacks) => {
+      if (!stableProxyCallbacks) {
+        stableProxyCallbacks = { ...callbacks };
+        return stableProxyCallbacks;
+      }
+
+      Object.assign(stableProxyCallbacks, callbacks);
+      return stableProxyCallbacks;
+    });
+
+    setupGooglePayGlobal();
+
+    mockGooglePaySession = createMockGooglePaySession();
+    mockSdkInstance = createMockSdkInstance(mockGooglePaySession);
+
+    mockPayPalContext({ sdkInstance: mockSdkInstance });
+
+    capturedOnPaymentAuthorized = null;
+    mockLoadPaymentData = jest.fn().mockResolvedValue(undefined);
+
+    defaultProps = {
+      googlePayConfig: mockGooglePayConfig,
+      transactionInfo: {
+        countryCode: "US",
+        currencyCode: "USD",
+        totalPriceStatus: "FINAL",
+        totalPrice: "100.00",
+      },
+      environment: "TEST",
+      createOrder: jest.fn().mockResolvedValue({ orderId: "ORDER-123" }),
+      onApprove: jest.fn(),
+      onCancel: jest.fn(),
+      onError: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    removeGooglePayGlobal();
+    jest.clearAllMocks();
+  });
+
+  describe("initialization", () => {
+    test("should not create session when no SDK instance is available", () => {
+      mockPayPalRejected();
+
+      const {
+        result: {
+          current: { error },
+        },
+      } = renderHook(() => useGooglePayOneTimePaymentSession(defaultProps));
+
+      expectCurrentErrorValue(error);
+
+      expect(error).toEqual(new Error("no sdk instance available"));
+      expect(
+        mockSdkInstance.createGooglePayOneTimePaymentSession,
+      ).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      {
+        description: "Error object",
+        thrownError: new Error("Required components not loaded in SDK"),
+      },
+      {
+        description: "non-Error string",
+        thrownError: "String error message",
+      },
+    ])(
+      "should handle $description thrown by createGooglePayOneTimePaymentSession",
+      ({ thrownError }) => {
+        const mockSdkInstanceWithError = {
+          createGooglePayOneTimePaymentSession: jest
+            .fn()
+            .mockImplementation(() => {
+              throw thrownError;
+            }),
+        };
+
+        mockPayPalContext({ sdkInstance: mockSdkInstanceWithError });
+
+        const {
+          result: {
+            current: { error },
+          },
+        } = renderHook(() => useGooglePayOneTimePaymentSession(defaultProps));
+
+        expectCurrentErrorValue(error);
+
+        expect(
+          mockSdkInstanceWithError.createGooglePayOneTimePaymentSession,
+        ).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    test("should create session successfully with valid SDK instance", () => {
+      const {
+        result: {
+          current: { error },
+        },
+      } = renderHook(() => useGooglePayOneTimePaymentSession(defaultProps));
+
+      expect(error).toBeNull();
+      expect(
+        mockSdkInstance.createGooglePayOneTimePaymentSession,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    test("should set isPending to true when SDK is loading", () => {
+      mockPayPalPending();
+
+      const {
+        result: {
+          current: { isPending, error },
+        },
+      } = renderHook(() => useGooglePayOneTimePaymentSession(defaultProps));
+
+      expect(isPending).toBe(true);
+      expect(error).toBeNull();
+    });
+
+    test("should set isPending to false when SDK is ready", () => {
+      const {
+        result: {
+          current: { isPending },
+        },
+      } = renderHook(() => useGooglePayOneTimePaymentSession(defaultProps));
+
+      expect(isPending).toBe(false);
+    });
+  });
+
+  describe("session setup", () => {
+    test("should call formatConfigForPaymentRequest with googlePayConfig", () => {
+      renderHook(() => useGooglePayOneTimePaymentSession(defaultProps));
+
+      expect(
+        mockGooglePaySession.formatConfigForPaymentRequest,
+      ).toHaveBeenCalledWith(mockGooglePayConfig);
+    });
+
+    test("should pass environment to PaymentsClient", async () => {
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession({
+          ...defaultProps,
+          environment: "PRODUCTION",
+        }),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      // The PaymentsClient was constructed (verified via capturedOnPaymentAuthorized being set)
+      expect(capturedOnPaymentAuthorized).not.toBeNull();
+    });
+  });
+
+  describe("createGooglePayButton", () => {
+    test("should check readiness and create button", async () => {
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      const options = {
+        onClick: jest.fn(),
+        buttonType: "pay" as const,
+      };
+
+      let button: HTMLElement | null = null;
+      await act(async () => {
+        button = await result.current.createGooglePayButton(options);
+      });
+
+      expect(result.current.paymentsClient).not.toBeNull();
+      expect(result.current.paymentsClient?.isReadyToPay).toHaveBeenCalledWith({
+        allowedPaymentMethods:
+          result.current.formattedConfig?.allowedPaymentMethods,
+        apiVersion: result.current.formattedConfig?.apiVersion,
+        apiVersionMinor: result.current.formattedConfig?.apiVersionMinor,
+      });
+      expect(result.current.paymentsClient?.createButton).toHaveBeenCalledWith(
+        options,
+      );
+      expect(button).toBeInstanceOf(HTMLElement);
+    });
+
+    test("should return null when Google Pay is not ready", async () => {
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      (
+        result.current.paymentsClient?.isReadyToPay as jest.Mock
+      ).mockResolvedValue({
+        result: false,
+      });
+
+      let button: HTMLElement | null = null;
+      await act(async () => {
+        button = await result.current.createGooglePayButton({
+          onClick: jest.fn(),
+        });
+      });
+
+      expect(button).toBeNull();
+      expect(
+        result.current.paymentsClient?.createButton,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("should set error and call onError when setup fails", async () => {
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      (
+        result.current.paymentsClient?.isReadyToPay as jest.Mock
+      ).mockRejectedValue(new Error("isReadyToPay failed"));
+
+      await act(async () => {
+        await result.current.createGooglePayButton({ onClick: jest.fn() });
+      });
+
+      expect(result.current.error?.message).toBe("isReadyToPay failed");
+      expect(defaultProps.onError).toHaveBeenCalled();
+    });
+  });
+
+  describe("handleClick - payment flow", () => {
+    test("should handle payment authorization, confirm order, and call onApprove", async () => {
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(capturedOnPaymentAuthorized).not.toBeNull();
+
+      let authResult: unknown;
+      await act(async () => {
+        authResult = await capturedOnPaymentAuthorized!(mockPaymentData);
+      });
+
+      expect(defaultProps.createOrder).toHaveBeenCalled();
+      expect(mockGooglePaySession.confirmOrder).toHaveBeenCalledWith({
+        orderId: "ORDER-123",
+        paymentMethodData: mockPaymentData.paymentMethodData,
+      });
+      expect(defaultProps.onApprove).toHaveBeenCalled();
+      expect(authResult).toEqual({ transactionState: "SUCCESS" });
+    });
+
+    test("should handle 3DS PAYER_ACTION_REQUIRED response", async () => {
+      (mockGooglePaySession.confirmOrder as jest.Mock).mockResolvedValue({
+        id: "test-order-id",
+        status: "PAYER_ACTION_REQUIRED",
+        payment_source: {
+          google_pay: {
+            name: "Test User",
+            card: {
+              last_digits: "1234",
+              type: "CREDIT",
+              brand: "VISA",
+            },
+          },
+        },
+        links: [
+          {
+            href: "https://example.com/3ds",
+            rel: "payer-action",
+            method: "GET",
+          },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(capturedOnPaymentAuthorized).not.toBeNull();
+
+      let authResult: unknown;
+      await act(async () => {
+        authResult = await capturedOnPaymentAuthorized!(mockPaymentData);
+      });
+
+      expect(mockGooglePaySession.initiatePayerAction).toHaveBeenCalled();
+      expect(defaultProps.onApprove).toHaveBeenCalled();
+      expect(authResult).toEqual({ transactionState: "SUCCESS" });
+    });
+
+    test("should error when Google Pay SDK is not available", async () => {
+      removeGooglePayGlobal();
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(result.current.error?.message).toBe(
+        "Google Pay client is not available",
+      );
+    });
+
+    test("should error when session is not available", async () => {
+      mockPayPalRejected();
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(result.current.error?.message).toBe(
+        "Google Pay session not available",
+      );
+    });
+  });
+
+  describe("handleClick - error handling", () => {
+    test.each([
+      {
+        description: "Error object",
+        rejectedValue: new Error("Confirmation failed"),
+        expectedMessage: "Confirmation failed",
+      },
+      {
+        description: "non-Error string (normalized via toError)",
+        rejectedValue: "string error",
+        expectedMessage: "string error",
+      },
+    ])(
+      "should handle order confirmation $description and return ERROR",
+      async ({ rejectedValue, expectedMessage }) => {
+        (mockGooglePaySession.confirmOrder as jest.Mock).mockRejectedValue(
+          rejectedValue,
+        );
+
+        const { result } = renderHook(() =>
+          useGooglePayOneTimePaymentSession(defaultProps),
+        );
+
+        await act(async () => {
+          await result.current.handleClick();
+        });
+
+        expect(capturedOnPaymentAuthorized).not.toBeNull();
+
+        let authResult: unknown;
+        await act(async () => {
+          authResult = await capturedOnPaymentAuthorized!(mockPaymentData);
+        });
+
+        expect(result.current.error).toBeInstanceOf(Error);
+        expect(result.current.error?.message).toBe(expectedMessage);
+        expect(defaultProps.onError).toHaveBeenCalled();
+        expect(authResult).toEqual(
+          expect.objectContaining({
+            transactionState: "ERROR",
+          }),
+        );
+      },
+    );
+
+    test("should handle createOrder failure", async () => {
+      (defaultProps.createOrder as jest.Mock).mockRejectedValue(
+        new Error("Order creation failed"),
+      );
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(capturedOnPaymentAuthorized).not.toBeNull();
+
+      let authResult: unknown;
+      await act(async () => {
+        authResult = await capturedOnPaymentAuthorized!(mockPaymentData);
+      });
+
+      expect(result.current.error?.message).toBe("Order creation failed");
+      expect(defaultProps.onError).toHaveBeenCalled();
+      expect(authResult).toEqual(
+        expect.objectContaining({
+          transactionState: "ERROR",
+        }),
+      );
+    });
+
+    test("should call onCancel when user dismisses Google Pay sheet", async () => {
+      // Simulate the MockPaymentsClient rejecting with CANCELED statusCode
+      mockLoadPaymentData = jest
+        .fn()
+        .mockRejectedValue({ statusCode: "CANCELED" });
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(defaultProps.onCancel).toHaveBeenCalled();
+      expect(result.current.error).toBeNull();
+    });
+
+    test("should set error when loadPaymentData fails with non-cancel error", async () => {
+      mockLoadPaymentData = jest
+        .fn()
+        .mockRejectedValue(new Error("Payment data load failed"));
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(result.current.error?.message).toBe("Payment data load failed");
+      expect(defaultProps.onError).toHaveBeenCalled();
+    });
+
+    test("should clear error when SDK instance becomes available", () => {
+      const { rerender, result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      // Initially has SDK
+      expect(result.current.error).toBeNull();
+
+      // Simulate SDK becoming unavailable
+      mockPayPalRejected();
+      rerender();
+
+      expect(result.current.error).not.toBeNull();
+
+      // SDK becomes available again
+      mockPayPalContext({ sdkInstance: mockSdkInstance });
+      rerender();
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("handleDestroy", () => {
+    test("should nullify session and prevent further clicks after handleDestroy", async () => {
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      // Verify session works initially
+      expect(result.current.error).toBeNull();
+
+      act(() => {
+        result.current.handleDestroy();
+      });
+
+      // After destroy, handleClick should error because sessionRef is null
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(result.current.error?.message).toBe(
+        "Google Pay session not available",
+      );
+    });
+  });
+
+  describe("cleanup", () => {
+    test("should not retry session creation after SDK error", () => {
+      const mockSdkInstanceWithError = {
+        createGooglePayOneTimePaymentSession: jest
+          .fn()
+          .mockImplementation(() => {
+            throw new Error("SDK error");
+          }),
+      };
+
+      mockPayPalContext({ sdkInstance: mockSdkInstanceWithError });
+
+      const { rerender } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      // First attempt
+      expect(
+        mockSdkInstanceWithError.createGooglePayOneTimePaymentSession,
+      ).toHaveBeenCalledTimes(1);
+
+      // Rerender should not trigger another attempt with same failed SDK
+      rerender();
+
+      expect(
+        mockSdkInstanceWithError.createGooglePayOneTimePaymentSession,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    test("should retry session creation when SDK instance changes", () => {
+      const mockSdkInstanceWithError = {
+        createGooglePayOneTimePaymentSession: jest
+          .fn()
+          .mockImplementation(() => {
+            throw new Error("SDK error");
+          }),
+      };
+
+      mockPayPalContext({ sdkInstance: mockSdkInstanceWithError });
+
+      const { rerender } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      expect(
+        mockSdkInstanceWithError.createGooglePayOneTimePaymentSession,
+      ).toHaveBeenCalledTimes(1);
+
+      // New SDK instance should trigger retry
+      const newMockSdkInstance = createMockSdkInstance();
+      mockPayPalContext({ sdkInstance: newMockSdkInstance });
+      rerender();
+
+      expect(
+        newMockSdkInstance.createGooglePayOneTimePaymentSession,
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.test.ts
@@ -613,7 +613,7 @@ describe("useGooglePayOneTimePaymentSession", () => {
       expect(result.current.error).toBeNull();
     });
 
-    test("should set error when loadPaymentData fails with non-cancel error", async () => {
+    test("should ignore non-cancel loadPaymentData rejection", async () => {
       mockLoadPaymentData = jest
         .fn()
         .mockRejectedValue(new Error("Payment data load failed"));
@@ -626,8 +626,33 @@ describe("useGooglePayOneTimePaymentSession", () => {
         await result.current.handleClick();
       });
 
-      expect(result.current.error?.message).toBe("Payment data load failed");
-      expect(defaultProps.onError).toHaveBeenCalled();
+      expect(result.current.error).toBeNull();
+      expect(defaultProps.onError).not.toHaveBeenCalled();
+    });
+
+    test("should not call onError twice when authorization fails and sheet closes", async () => {
+      (mockGooglePaySession.confirmOrder as jest.Mock).mockRejectedValue(
+        new Error("Confirmation failed"),
+      );
+
+      mockLoadPaymentData = jest.fn().mockImplementation(async () => {
+        if (capturedOnPaymentAuthorized) {
+          await capturedOnPaymentAuthorized(mockPaymentData);
+        }
+
+        throw new Error("Payment sheet closed after authorization error");
+      });
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(result.current.error?.message).toBe("Confirmation failed");
+      expect(defaultProps.onError).toHaveBeenCalledTimes(1);
     });
 
     test("should clear error when SDK instance becomes available", () => {

--- a/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
@@ -1,0 +1,379 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { usePayPal } from "./usePayPal";
+import { useIsMountedRef } from "./useIsMounted";
+import { useError } from "./useError";
+import { useProxyProps, createPaymentSession, toError } from "../utils";
+import { INSTANCE_LOADING_STATE } from "../types/ProviderEnums";
+
+import type {
+  GooglePayOneTimePaymentSession,
+  GooglePayConfig,
+  GooglePayConfigFromFindEligibleMethods,
+  GooglePayPaymentMethodData,
+  GooglePayButtonOptions,
+  GooglePayApprovePaymentResponse,
+  GooglePayTransactionInfo,
+  BasePaymentSessionReturn,
+} from "../types";
+
+export type UseGooglePayOneTimePaymentSessionProps = {
+  /**
+   * Google Pay configuration from findEligibleMethods.
+   * Used to format the payment request with allowed payment methods and merchant info.
+   */
+  googlePayConfig: GooglePayConfigFromFindEligibleMethods;
+  /**
+   * Transaction info for the Google Pay payment request.
+   */
+  transactionInfo: GooglePayTransactionInfo;
+  /**
+   * Google Pay environment. Use "TEST" for sandbox and "PRODUCTION" for live.
+   * @default "TEST"
+   */
+  environment?: "TEST" | "PRODUCTION";
+  /**
+   * Callback function to create an order.
+   * Should return a promise that resolves to an object with orderId.
+   */
+  createOrder: () => Promise<{ orderId: string }>;
+  /**
+   * Callback invoked when the payment is successfully approved.
+   */
+  onApprove: (data: GooglePayApprovePaymentResponse) => void | Promise<void>;
+  /**
+   * Optional callback invoked when the payment is cancelled.
+   */
+  onCancel?: () => void;
+  /**
+   * Optional callback invoked when an error occurs.
+   */
+  onError?: (error: Error) => void;
+};
+
+export type UseGooglePayOneTimePaymentSessionReturn =
+  BasePaymentSessionReturn & {
+    /**
+     * The Google Pay PaymentsClient instance.
+     * Used internally to check readiness and create the payment button.
+     * Advanced users may interact with this directly if needed.
+     * @default null (until session is fully initialized)
+     */
+    paymentsClient: google.payments.api.PaymentsClient | null;
+    /**
+     * The formatted Google Pay configuration for the payment request.
+     * Includes allowed payment methods, merchant info, and API versions.
+     * @default null (until session is fully initialized)
+     */
+    formattedConfig: GooglePayConfig | null;
+    /**
+     * Creates the native Google Pay button after checking eligibility via isReadyToPay.
+     * Setup errors are captured in hook state and forwarded to onError.
+     */
+    createGooglePayButton: (
+      options: GooglePayButtonOptions,
+    ) => Promise<HTMLElement | null>;
+  };
+
+/**
+ * Hook for managing Google Pay one-time payment sessions.
+ *
+ * This hook creates and manages a complete Google Pay payment session, handling the entire
+ * flow from button click through payment authorization to order confirmation.
+ *
+ * Unlike Apple Pay and Venmo (which use web components), Google Pay uses Google's PaymentsClient
+ * to drive the payment UI. This hook returns the PaymentsClient and formatted config so the
+ * GooglePayOneTimePaymentButton component can:
+ * 1. Check device/browser readiness with `isReadyToPay()`
+ * 2. Create the native Google Pay button before user interaction
+ * 3. Load payment data and handle payment callbacks
+ *
+ * The hook manages the entire session lifecycle including order creation, payment confirmation,
+ * 3DS (PAYER_ACTION_REQUIRED) handling, and error management.
+ *
+ * @example
+ * ```typescript
+ * function GooglePayCheckoutButton() {
+ *   const { sdkInstance } = usePayPal();
+ *   const [googlePayConfig, setGooglePayConfig] = useState(null);
+ *
+ *   useEffect(() => {
+ *     const fetchConfig = async () => {
+ *       const methods = await sdkInstance?.findEligibleMethods({ currencyCode: "USD" });
+ *       if (methods?.isEligible("googlepay")) {
+ *         setGooglePayConfig(methods.getDetails("googlepay").config);
+ *       }
+ *     };
+ *     fetchConfig();
+ *   }, [sdkInstance]);
+ *
+ *   const { isPending, error, handleClick } = useGooglePayOneTimePaymentSession({
+ *     googlePayConfig,
+ *     transactionInfo: {
+ *       countryCode: "US",
+ *       currencyCode: "USD",
+ *       totalPriceStatus: "FINAL",
+ *       totalPrice: "100.00",
+ *     },
+ *     createOrder: async () => {
+ *       const response = await fetch("/api/orders", { method: "POST" });
+ *       const data = await response.json();
+ *       return { orderId: data.id };
+ *     },
+ *     onApprove: (data) => console.log("Payment approved:", data),
+ *     onError: (err) => console.error("Payment error:", err),
+ *   });
+ *
+ *   if (isPending || !googlePayConfig) return null;
+ *   if (error) return <div>Error: {error.message}</div>;
+ *
+ *   return <button onClick={handleClick}>Pay with Google Pay</button>;
+ * }
+ * ```
+ */
+export function useGooglePayOneTimePaymentSession({
+  googlePayConfig,
+  transactionInfo,
+  environment = "TEST",
+  createOrder,
+  ...callbacks
+}: UseGooglePayOneTimePaymentSessionProps): UseGooglePayOneTimePaymentSessionReturn {
+  const { sdkInstance, loadingStatus } = usePayPal();
+  const isMountedRef = useIsMountedRef();
+  const sessionRef = useRef<GooglePayOneTimePaymentSession | null>(null);
+  const paymentsClientRef = useRef<google.payments.api.PaymentsClient | null>(
+    null,
+  );
+  const createOrderRef = useRef(createOrder);
+  createOrderRef.current = createOrder;
+  const proxyCallbacks = useProxyProps(callbacks);
+  const [error, setError] = useError();
+  const [paymentsClient, setPaymentsClient] =
+    useState<google.payments.api.PaymentsClient | null>(null);
+  const [formattedConfig, setFormattedConfig] =
+    useState<GooglePayConfig | null>(null);
+
+  // Prevents retrying session creation with a failed SDK instance
+  const failedSdkRef = useRef<unknown>(null);
+
+  const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
+
+  const handleCancel = useCallback(() => {
+    // Google Pay doesn't have a persistent session to cancel;
+    // the payment sheet is managed by Google's PaymentsClient.
+  }, []);
+
+  const handleDestroy = useCallback(() => {
+    sessionRef.current = null;
+    paymentsClientRef.current = null;
+    setPaymentsClient(null);
+    setFormattedConfig(null);
+  }, []);
+
+  // Handle SDK availability
+  useEffect(() => {
+    // Reset failed SDK tracking when SDK instance changes
+    if (failedSdkRef.current !== sdkInstance) {
+      failedSdkRef.current = null;
+    }
+
+    if (sdkInstance) {
+      setError(null);
+    } else if (loadingStatus !== INSTANCE_LOADING_STATE.PENDING) {
+      setError(new Error("no sdk instance available"));
+    }
+  }, [sdkInstance, setError, loadingStatus]);
+
+  // Create and manage session lifecycle
+  useEffect(() => {
+    if (!sdkInstance) {
+      return;
+    }
+
+    const newSession = createPaymentSession({
+      sessionCreator: () => sdkInstance.createGooglePayOneTimePaymentSession(),
+      failedSdkRef,
+      sdkInstance,
+      setError,
+      errorMessage:
+        'Failed to create payment session. This may occur if the required component "googlepay-payments" is not included in the SDK components array.',
+    });
+
+    if (!newSession) {
+      return;
+    }
+
+    sessionRef.current = newSession;
+
+    return () => {
+      sessionRef.current = null;
+    };
+  }, [sdkInstance, setError]);
+
+  // Create a reusable PaymentsClient and formatted config so the component can
+  // run isReadyToPay and mount the native Google Pay button before user click.
+  useEffect(() => {
+    if (!sessionRef.current) {
+      paymentsClientRef.current = null;
+      setPaymentsClient(null);
+      setFormattedConfig(null);
+      return;
+    }
+
+    if (
+      typeof window === "undefined" ||
+      !window.google?.payments?.api?.PaymentsClient
+    ) {
+      paymentsClientRef.current = null;
+      setPaymentsClient(null);
+      setFormattedConfig(null);
+      return;
+    }
+
+    try {
+      const paypalSession = sessionRef.current;
+      const nextFormattedConfig =
+        paypalSession.formatConfigForPaymentRequest(googlePayConfig);
+
+      const nextPaymentsClient = new window.google.payments.api.PaymentsClient({
+        environment,
+        paymentDataCallbacks: {
+          onPaymentAuthorized: async (
+            paymentData: google.payments.api.PaymentData,
+          ) => {
+            try {
+              const order = await createOrderRef.current();
+
+              const confirmResult = await paypalSession.confirmOrder({
+                orderId: order.orderId,
+                paymentMethodData:
+                  paymentData.paymentMethodData as unknown as GooglePayPaymentMethodData,
+              });
+
+              // Handle 3DS (3-D Secure) authentication if required
+              // When confirmOrder returns PAYER_ACTION_REQUIRED status, initiate payer action
+              if (confirmResult.status === "PAYER_ACTION_REQUIRED") {
+                paypalSession.initiatePayerAction();
+              }
+
+              await proxyCallbacks.onApprove(confirmResult);
+
+              return { transactionState: "SUCCESS" as const };
+            } catch (err) {
+              const paymentError = toError(err);
+              setError(paymentError);
+              proxyCallbacks.onError?.(paymentError);
+
+              return {
+                transactionState: "ERROR" as const,
+                error: {
+                  intent: "PAYMENT_AUTHORIZATION",
+                  message: paymentError.message,
+                  reason: "OTHER_ERROR",
+                },
+              };
+            }
+          },
+        },
+      });
+
+      paymentsClientRef.current = nextPaymentsClient;
+      setPaymentsClient(nextPaymentsClient);
+      setFormattedConfig(nextFormattedConfig);
+    } catch (err) {
+      paymentsClientRef.current = null;
+      setPaymentsClient(null);
+      setFormattedConfig(null);
+      const setupError = toError(err);
+      setError(setupError);
+      proxyCallbacks.onError?.(setupError);
+    }
+  }, [googlePayConfig, environment, proxyCallbacks, sdkInstance, setError]);
+
+  const createGooglePayButton = useCallback(
+    async (options: GooglePayButtonOptions): Promise<HTMLElement | null> => {
+      if (!paymentsClientRef.current || !formattedConfig) {
+        return null;
+      }
+
+      try {
+        const isReadyToPay = await paymentsClientRef.current.isReadyToPay({
+          allowedPaymentMethods: formattedConfig.allowedPaymentMethods,
+          apiVersion: formattedConfig.apiVersion,
+          apiVersionMinor: formattedConfig.apiVersionMinor,
+        });
+
+        if (!isReadyToPay.result) {
+          return null;
+        }
+
+        return paymentsClientRef.current.createButton(options);
+      } catch (err) {
+        const setupError = toError(err);
+        setError(setupError);
+        proxyCallbacks.onError?.(setupError);
+        return null;
+      }
+    },
+    [formattedConfig, proxyCallbacks, setError],
+  );
+
+  const handleClick = useCallback(async () => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    // Clear any error from a previous attempt so the user can retry
+    setError(null);
+
+    if (!sessionRef.current) {
+      setError(new Error("Google Pay session not available"));
+      return;
+    }
+
+    if (!paymentsClientRef.current || !formattedConfig) {
+      setError(new Error("Google Pay client is not available"));
+      return;
+    }
+
+    try {
+      const paymentDataRequest = {
+        apiVersion: formattedConfig.apiVersion,
+        apiVersionMinor: formattedConfig.apiVersionMinor,
+        allowedPaymentMethods: formattedConfig.allowedPaymentMethods,
+        merchantInfo: formattedConfig.merchantInfo,
+        transactionInfo,
+        callbackIntents: ["PAYMENT_AUTHORIZATION"] as const,
+      };
+
+      await paymentsClientRef.current.loadPaymentData(paymentDataRequest);
+    } catch (err) {
+      const sessionError = toError(err);
+
+      if ((err as { statusCode?: string })?.statusCode === "CANCELED") {
+        proxyCallbacks.onCancel?.();
+        return;
+      }
+
+      setError(sessionError);
+      proxyCallbacks.onError?.(sessionError);
+    }
+  }, [
+    isMountedRef,
+    transactionInfo,
+    formattedConfig,
+    proxyCallbacks,
+    setError,
+  ]);
+
+  return {
+    error,
+    isPending,
+    paymentsClient,
+    formattedConfig,
+    createGooglePayButton,
+    handleClick,
+    handleCancel,
+    handleDestroy,
+  };
+}

--- a/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
@@ -348,15 +348,13 @@ export function useGooglePayOneTimePaymentSession({
 
       await paymentsClientRef.current.loadPaymentData(paymentDataRequest);
     } catch (err) {
-      const sessionError = toError(err);
-
       if ((err as { statusCode?: string })?.statusCode === "CANCELED") {
         proxyCallbacks.onCancel?.();
         return;
       }
-
-      setError(sessionError);
-      proxyCallbacks.onError?.(sessionError);
+      // Authorization errors are already reported in onPaymentAuthorized.
+      // Other rejections (e.g. DEVELOPER_ERROR) are configuration issues
+      // that surface during development, not runtime payment failures.
     }
   }, [
     isMountedRef,

--- a/packages/react-paypal-js/src/v6/index.ts
+++ b/packages/react-paypal-js/src/v6/index.ts
@@ -50,6 +50,10 @@ export {
   ApplePayOneTimePaymentButton,
   type ApplePayOneTimePaymentButtonProps,
 } from "./components/ApplePayOneTimePaymentButton";
+export {
+  GooglePayOneTimePaymentButton,
+  type GooglePayOneTimePaymentButtonProps,
+} from "./components/GooglePayOneTimePaymentButton";
 export { PayPalCardNumberField } from "./components/PayPalCardNumberField";
 export { PayPalCardExpiryField } from "./components/PayPalCardExpiryField";
 export { PayPalCardCvvField } from "./components/PayPalCardCvvField";
@@ -124,6 +128,10 @@ export {
   useApplePayOneTimePaymentSession,
   type UseApplePayOneTimePaymentSessionProps,
 } from "./hooks/useApplePayOneTimePaymentSession";
+export {
+  useGooglePayOneTimePaymentSession,
+  type UseGooglePayOneTimePaymentSessionProps,
+} from "./hooks/useGooglePayOneTimePaymentSession";
 
 // React 19+ JSX SDK Web Components type declaration
 declare global {

--- a/packages/react-paypal-js/src/v6/types/googlePay.ts
+++ b/packages/react-paypal-js/src/v6/types/googlePay.ts
@@ -1,49 +1,9 @@
 import type {
-  GooglePayConfig,
+  GooglePayButtonOptions,
+  GooglePayIsReadyToPayRequest,
+  GooglePayPaymentDataRequest,
   GooglePayPaymentMethodData,
 } from "@paypal/paypal-js/sdk-v6";
-
-export interface GooglePayTransactionInfo {
-  countryCode: string;
-  currencyCode: string;
-  totalPriceStatus: "FINAL" | "ESTIMATED" | "NOT_CURRENTLY_KNOWN";
-  totalPrice: string;
-  totalPriceLabel?: string;
-  displayItems?: Array<{
-    label: string;
-    type: string;
-    price: string;
-  }>;
-  [key: string]: unknown;
-}
-
-export interface GooglePayIsReadyToPayRequest {
-  allowedPaymentMethods: GooglePayConfig["allowedPaymentMethods"];
-  apiVersion: GooglePayConfig["apiVersion"];
-  apiVersionMinor: GooglePayConfig["apiVersionMinor"];
-}
-
-export interface GooglePayPaymentDataRequest extends GooglePayIsReadyToPayRequest {
-  merchantInfo: GooglePayConfig["merchantInfo"];
-  transactionInfo: GooglePayTransactionInfo;
-  callbackIntents: ReadonlyArray<"PAYMENT_AUTHORIZATION">;
-}
-
-export interface GooglePayButtonOptions {
-  onClick: () => void;
-  buttonType?:
-    | "book"
-    | "buy"
-    | "checkout"
-    | "donate"
-    | "order"
-    | "pay"
-    | "plain"
-    | "subscribe";
-  buttonColor?: "default" | "black" | "white";
-  buttonSizeMode?: "static" | "fill";
-  buttonLocale?: string;
-}
 
 declare global {
   interface Window {

--- a/packages/react-paypal-js/src/v6/types/googlePay.ts
+++ b/packages/react-paypal-js/src/v6/types/googlePay.ts
@@ -1,0 +1,89 @@
+import type {
+  GooglePayConfig,
+  GooglePayPaymentMethodData,
+} from "@paypal/paypal-js/sdk-v6";
+
+export interface GooglePayTransactionInfo {
+  countryCode: string;
+  currencyCode: string;
+  totalPriceStatus: "FINAL" | "ESTIMATED" | "NOT_CURRENTLY_KNOWN";
+  totalPrice: string;
+  totalPriceLabel?: string;
+  displayItems?: Array<{
+    label: string;
+    type: string;
+    price: string;
+  }>;
+  [key: string]: unknown;
+}
+
+export interface GooglePayIsReadyToPayRequest {
+  allowedPaymentMethods: GooglePayConfig["allowedPaymentMethods"];
+  apiVersion: GooglePayConfig["apiVersion"];
+  apiVersionMinor: GooglePayConfig["apiVersionMinor"];
+}
+
+export interface GooglePayPaymentDataRequest extends GooglePayIsReadyToPayRequest {
+  merchantInfo: GooglePayConfig["merchantInfo"];
+  transactionInfo: GooglePayTransactionInfo;
+  callbackIntents: ReadonlyArray<"PAYMENT_AUTHORIZATION">;
+}
+
+export interface GooglePayButtonOptions {
+  onClick: () => void;
+  buttonType?:
+    | "book"
+    | "buy"
+    | "checkout"
+    | "donate"
+    | "order"
+    | "pay"
+    | "plain"
+    | "subscribe";
+  buttonColor?: "default" | "black" | "white";
+  buttonSizeMode?: "static" | "fill";
+  buttonLocale?: string;
+}
+
+declare global {
+  interface Window {
+    google?: {
+      payments: {
+        api: {
+          PaymentsClient: new (config: {
+            environment: string;
+            paymentDataCallbacks?: {
+              onPaymentAuthorized?: (
+                paymentData: google.payments.api.PaymentData,
+              ) => Promise<google.payments.api.PaymentAuthorizationResult>;
+            };
+          }) => google.payments.api.PaymentsClient;
+        };
+      };
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace google.payments.api {
+    interface PaymentData {
+      paymentMethodData: GooglePayPaymentMethodData;
+    }
+
+    interface PaymentAuthorizationResult {
+      transactionState: "SUCCESS" | "ERROR";
+      error?: {
+        intent: string;
+        message: string;
+        reason: string;
+      };
+    }
+
+    interface PaymentsClient {
+      loadPaymentData(request: GooglePayPaymentDataRequest): Promise<void>;
+      isReadyToPay(
+        request: GooglePayIsReadyToPayRequest,
+      ): Promise<{ result: boolean }>;
+      createButton(options: GooglePayButtonOptions): HTMLElement;
+    }
+  }
+}

--- a/packages/react-paypal-js/src/v6/types/index.ts
+++ b/packages/react-paypal-js/src/v6/types/index.ts
@@ -1,5 +1,6 @@
 export * from "./ProviderEnums";
 export * from "./braintree";
+export * from "./googlePay";
 
 export type * from "@paypal/paypal-js/sdk-v6";
 export type * from "./sdkWebComponents";


### PR DESCRIPTION
This PR adds GooglePay one-time payment hook and a reusable GooglePay button component in v6 React SDK. 

Google Pay demo: https://github.com/paypal-examples/v6-web-sdk-sample-integration/pull/238
