### PR TITLE
Fix to prevent ApplePaySession completePayment from being called twice

### DIFF
--- a/.changeset/witty-pants-wash.md
+++ b/.changeset/witty-pants-wash.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Fix to prevent ApplePaySession completePayment twice

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.test.ts
@@ -511,6 +511,36 @@ describe("useApplePayOneTimePaymentSession", () => {
       });
     });
 
+    test("should complete with STATUS_FAILURE when onApprove throws", async () => {
+      const onApproveError = new Error("Capture failed");
+      defaultProps.onApprove = jest.fn().mockRejectedValue(onApproveError);
+
+      const { result } = renderHook(() =>
+        useApplePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(capturedApplePaySession).not.toBeNull();
+      await act(async () => {
+        await capturedApplePaySession!.onpaymentauthorized?.({
+          payment: {
+            token: {},
+            billingContact: {},
+          },
+        });
+      });
+
+      expect(result.current.error).toEqual(onApproveError);
+      expect(defaultProps.onError).toHaveBeenCalledWith(onApproveError);
+      expect(capturedApplePaySession!.completePayment).toHaveBeenCalledTimes(1);
+      expect(capturedApplePaySession!.completePayment).toHaveBeenCalledWith({
+        status: MockApplePaySession.STATUS_FAILURE,
+      });
+    });
+
     test("should clear error when SDK instance becomes available", () => {
       const { rerender, result } = renderHook(() =>
         useApplePayOneTimePaymentSession(defaultProps),

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.test.ts
@@ -311,6 +311,43 @@ describe("useApplePayOneTimePaymentSession", () => {
       expect(defaultProps.onApprove).toHaveBeenCalled();
     });
 
+    test("should call onApproveCompleted after successful completion", async () => {
+      defaultProps.onApproveCompleted = jest.fn();
+
+      const { result } = renderHook(() =>
+        useApplePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(capturedApplePaySession).not.toBeNull();
+      await act(async () => {
+        await capturedApplePaySession!.onpaymentauthorized?.({
+          payment: {
+            token: {},
+            billingContact: {},
+          },
+        });
+      });
+
+      expect(capturedApplePaySession!.completePayment).toHaveBeenCalledWith({
+        status: MockApplePaySession.STATUS_SUCCESS,
+      });
+      expect(defaultProps.onApproveCompleted).toHaveBeenCalledTimes(1);
+
+      const completePaymentCallOrder =
+        capturedApplePaySession!.completePayment.mock.invocationCallOrder[0];
+      const onApproveCompletedCallOrder = (
+        defaultProps.onApproveCompleted as jest.Mock
+      ).mock.invocationCallOrder[0];
+
+      expect(completePaymentCallOrder).toBeLessThan(
+        onApproveCompletedCallOrder,
+      );
+    });
+
     test("should handle payment method selection", async () => {
       const { result } = renderHook(() =>
         useApplePayOneTimePaymentSession(defaultProps),
@@ -539,6 +576,74 @@ describe("useApplePayOneTimePaymentSession", () => {
       expect(capturedApplePaySession!.completePayment).toHaveBeenCalledWith({
         status: MockApplePaySession.STATUS_FAILURE,
       });
+    });
+
+    test("should call onError when completePayment throws after successful onApprove", async () => {
+      const completePaymentError = new Error("InvalidAccessError");
+
+      const { result } = renderHook(() =>
+        useApplePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(capturedApplePaySession).not.toBeNull();
+      capturedApplePaySession!.completePayment.mockImplementation(() => {
+        throw completePaymentError;
+      });
+
+      await act(async () => {
+        await capturedApplePaySession!.onpaymentauthorized?.({
+          payment: {
+            token: {},
+            billingContact: {},
+          },
+        });
+      });
+
+      expect(defaultProps.onApprove).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onError).toHaveBeenCalledWith(completePaymentError);
+      expect(result.current.error).toEqual(completePaymentError);
+      expect(capturedApplePaySession!.completePayment).toHaveBeenCalledTimes(1);
+      expect(capturedApplePaySession!.completePayment).toHaveBeenCalledWith({
+        status: MockApplePaySession.STATUS_SUCCESS,
+      });
+    });
+
+    test("should call onError when onApproveCompleted throws", async () => {
+      const onApproveCompletedError = new Error("Post-approve failed");
+      defaultProps.onApproveCompleted = jest
+        .fn()
+        .mockRejectedValue(onApproveCompletedError);
+
+      const { result } = renderHook(() =>
+        useApplePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(capturedApplePaySession).not.toBeNull();
+      await act(async () => {
+        await capturedApplePaySession!.onpaymentauthorized?.({
+          payment: {
+            token: {},
+            billingContact: {},
+          },
+        });
+      });
+
+      expect(capturedApplePaySession!.completePayment).toHaveBeenCalledWith({
+        status: MockApplePaySession.STATUS_SUCCESS,
+      });
+      expect(defaultProps.onError).toHaveBeenCalledWith(
+        onApproveCompletedError,
+      );
+      expect(result.current.error).toEqual(onApproveCompletedError);
+      expect(capturedApplePaySession!.completePayment).toHaveBeenCalledTimes(1);
     });
 
     test("should clear error when SDK instance becomes available", () => {

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
@@ -294,6 +294,25 @@ export function useApplePayOneTimePaymentSession({
           shippingContact?: ApplePayContact;
         };
       }) => {
+        let didCompletePayment = false;
+
+        // Call completePayment only once per ApplePaySession.
+        const completePaymentOnce = (status: number) => {
+          if (didCompletePayment) {
+            return;
+          }
+
+          didCompletePayment = true;
+
+          try {
+            applePaySession.completePayment({ status });
+          } catch (err) {
+            const completePaymentError = toError(err);
+            setError(completePaymentError);
+            proxyCallbacks.onError?.(completePaymentError);
+          }
+        };
+
         try {
           // Create the order
           const order = await createOrder();
@@ -306,20 +325,16 @@ export function useApplePayOneTimePaymentSession({
             shippingContact: event.payment.shippingContact,
           });
 
-          // Complete the Apple Pay session successfully
-          applePaySession.completePayment({
-            status: ApplePaySessionConstructor.STATUS_SUCCESS,
-          });
-
           // Call onApprove callback
           await proxyCallbacks.onApprove(confirmResult);
+
+          // Complete the Apple Pay session successfully
+          completePaymentOnce(ApplePaySessionConstructor.STATUS_SUCCESS);
         } catch (err) {
           const paymentError = toError(err);
           setError(paymentError);
           proxyCallbacks.onError?.(paymentError);
-          applePaySession.completePayment({
-            status: ApplePaySessionConstructor.STATUS_FAILURE,
-          });
+          completePaymentOnce(ApplePaySessionConstructor.STATUS_FAILURE);
         }
       };
 

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
@@ -62,8 +62,16 @@ export type UseApplePayOneTimePaymentSessionProps = {
   createOrder: () => Promise<{ orderId: string }>;
   /**
    * Callback invoked when the payment is successfully approved.
+   * Keep this callback fast — it runs before Apple Pay session completion,
+   * which has a strict timeout window (commonly around 30 seconds).
+   * Move non-critical follow-up work to onApproveCompleted instead.
    */
   onApprove: (data: ConfirmOrderResponse) => void | Promise<void>;
+  /**
+   * Optional callback invoked after Apple Pay session completion succeeds.
+   * Use this for non-critical follow-up work that should not block completion.
+   */
+  onApproveCompleted?: (data: ConfirmOrderResponse) => void | Promise<void>;
   /**
    * Optional callback invoked when the payment is cancelled.
    */
@@ -330,6 +338,15 @@ export function useApplePayOneTimePaymentSession({
 
           // Complete the Apple Pay session successfully
           completePaymentOnce(ApplePaySessionConstructor.STATUS_SUCCESS);
+
+          // Run non-critical post-completion logic without affecting payment status.
+          try {
+            await proxyCallbacks.onApproveCompleted?.(confirmResult);
+          } catch (err) {
+            const postApproveError = toError(err);
+            setError(postApproveError);
+            proxyCallbacks.onError?.(postApproveError);
+          }
         } catch (err) {
           const paymentError = toError(err);
           setError(paymentError);


### PR DESCRIPTION
The fix prevents ApplePay Session `completePayment` from being called twice.

Previously, the hook completed the Apple Pay session with `STATUS_SUCCESS` before `onApprove` finished. If `onApprove` later threw, the error path attempted to call `completePayment` again with `STATUS_FAILURE` on the same `ApplePaySession` which can throw `InvalidAccessError`.

This change updates the hook to call `onApprove` before marking Apple Pay session successful and guards `completePayment` so it can only run once per session.