### PR TITLE
fix: example shows a type error for missing prop

### DIFF
--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -103,6 +103,7 @@ function CheckoutPage() {
         });
         console.log("Payment captured!");
       }}
+      presentationMode: "auto"
     />
   );
 }


### PR DESCRIPTION
fixes #933

> The documentation examples for PayPalOneTimePaymentButton imply presentationMode is optional (or defaulted to auto), but the published TypeScript types require presentationMode to be explicitly provided. As a result, the official example fails type-checking in strict TypeScript projects.

The first doc example in the README does not work and is missing a required prop for `presentationMode`. However, later in the documentation it is shown as an optional prop with a default `How to present the payment session (default: "auto")`.

Temporarily solution, updated doc example to include `presentationMode` to remove type error.

Let me know if you require further changes.
