### PR TITLE
Feature: BT-PayPal Pay Later hook

### DIFF
--- a/.changeset/nasty-rockets-cut.md
+++ b/.changeset/nasty-rockets-cut.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+Adds the Braintree PayPal Pay Later session hook.

--- a/.changeset/nasty-rockets-cut.md
+++ b/.changeset/nasty-rockets-cut.md
@@ -2,4 +2,10 @@
 "@paypal/react-paypal-js": minor
 ---
 
-Adds the Braintree PayPal Pay Later session hook.
+Add Braintree PayPal Pay Later (BNPL) support and a companion eligibility hook for v6.
+
+- `useBraintreePayPalPayLaterSession` — manages a Pay Later session (`error`, `isPending`, `handleClick`), consistent with the existing one-time-payment, billing-agreement, and checkout-with-vault hooks.
+- `useBraintreeEligibleMethods` — fetches eligibility via `findEligibleMethods` and caches it on the provider, deduplicating by checkout instance + options and refetching when either changes.
+- Provider-level failures are now surfaced separately and labeled (`Braintree provider error: …`, with the original error as `cause`), distinct from "checkout instance not available", so consumers can tell which layer failed.
+- Add `shippingCallbackUrl`, `shippingAddressOverride` (now typed as `BraintreeShippingAddressOverride` instead of `Record<string, unknown>`), and `contactPreference` options to the one-time, Pay Later, and checkout-with-vault session types.
+- `BraintreeEligibilityResult.getDetails` is now strongly typed per funding source.

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.test.tsx
@@ -69,6 +69,8 @@ function setupTestComponent() {
   const state: BraintreePayPalState = {
     loadingStatus: INSTANCE_LOADING_STATE.PENDING,
     braintreePayPalCheckoutInstance: null,
+    eligibleMethods: null,
+    eligibleMethodsPayload: null,
     isHydrated: false,
     error: null,
   };

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.test.tsx
@@ -69,8 +69,8 @@ function setupTestComponent() {
   const state: BraintreePayPalState = {
     loadingStatus: INSTANCE_LOADING_STATE.PENDING,
     braintreePayPalCheckoutInstance: null,
-    eligibleMethods: null,
-    eligibleMethodsPayload: null,
+    eligiblePaymentMethods: null,
+    eligiblePaymentMethodsPayload: null,
     isHydrated: false,
     error: null,
   };

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.test.tsx
@@ -40,7 +40,7 @@ function createMockBraintreeNamespace() {
       paypal: true,
       paylater: false,
       credit: false,
-      getDetails: jest.fn().mockReturnValue(null),
+      getDetails: jest.fn().mockReturnValue({ canBeVaulted: false }),
     }),
     getClientId: jest.fn().mockResolvedValue("client-id"),
     updatePayment: jest.fn().mockResolvedValue(undefined),

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.tsx
@@ -189,16 +189,16 @@ export const BraintreePayPalProvider: React.FC<
   const contextValue: BraintreePayPalState = useMemo(
     () => ({
       braintreePayPalCheckoutInstance: state.braintreePayPalCheckoutInstance,
-      eligibleMethods: state.eligibleMethods,
-      eligibleMethodsPayload: state.eligibleMethodsPayload,
+      eligiblePaymentMethods: state.eligiblePaymentMethods,
+      eligiblePaymentMethodsPayload: state.eligiblePaymentMethodsPayload,
       loadingStatus: state.loadingStatus,
       error: state.error,
       isHydrated,
     }),
     [
       state.braintreePayPalCheckoutInstance,
-      state.eligibleMethods,
-      state.eligibleMethodsPayload,
+      state.eligiblePaymentMethods,
+      state.eligiblePaymentMethodsPayload,
       state.loadingStatus,
       state.error,
       isHydrated,

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.tsx
@@ -5,6 +5,7 @@ import {
   braintreeInitialState,
   braintreeReducer,
 } from "../../context/BraintreePayPalContext";
+import { BraintreeDispatchContext } from "../../context/BraintreeDispatchContext";
 import {
   BRAINTREE_DISPATCH_ACTION,
   INSTANCE_LOADING_STATE,
@@ -188,12 +189,16 @@ export const BraintreePayPalProvider: React.FC<
   const contextValue: BraintreePayPalState = useMemo(
     () => ({
       braintreePayPalCheckoutInstance: state.braintreePayPalCheckoutInstance,
+      eligibleMethods: state.eligibleMethods,
+      eligibleMethodsPayload: state.eligibleMethodsPayload,
       loadingStatus: state.loadingStatus,
       error: state.error,
       isHydrated,
     }),
     [
       state.braintreePayPalCheckoutInstance,
+      state.eligibleMethods,
+      state.eligibleMethodsPayload,
       state.loadingStatus,
       state.error,
       isHydrated,
@@ -201,8 +206,10 @@ export const BraintreePayPalProvider: React.FC<
   );
 
   return (
-    <BraintreePayPalContext.Provider value={contextValue}>
-      {children}
-    </BraintreePayPalContext.Provider>
+    <BraintreeDispatchContext.Provider value={dispatch}>
+      <BraintreePayPalContext.Provider value={contextValue}>
+        {children}
+      </BraintreePayPalContext.Provider>
+    </BraintreeDispatchContext.Provider>
   );
 };

--- a/packages/react-paypal-js/src/v6/context/BraintreeDispatchContext.tsx
+++ b/packages/react-paypal-js/src/v6/context/BraintreeDispatchContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, Dispatch } from "react";
+
+import type { BraintreeAction } from "./BraintreePayPalContext";
+
+/**
+ * Internal context for dispatching Braintree PayPal state updates.
+ * This is NOT exported to external consumers.
+ * Only hooks like useBraintreeEligibleMethods can access this internally.
+ *
+ * @internal
+ */
+export const BraintreeDispatchContext =
+  createContext<Dispatch<BraintreeAction> | null>(null);

--- a/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.test.ts
+++ b/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.test.ts
@@ -42,7 +42,7 @@ function createMockCheckoutInstance(): BraintreePayPalCheckoutInstance {
       paypal: true,
       paylater: false,
       credit: false,
-      getDetails: jest.fn().mockReturnValue(null),
+      getDetails: jest.fn().mockReturnValue({ canBeVaulted: false }),
     }),
     getClientId: jest.fn().mockResolvedValue("client-id"),
     updatePayment: jest.fn().mockResolvedValue(undefined),
@@ -66,7 +66,7 @@ function createMockEligibility(): BraintreeEligibilityResult {
     paypal: true,
     paylater: true,
     credit: false,
-    getDetails: jest.fn().mockReturnValue(null),
+    getDetails: jest.fn().mockReturnValue({ canBeVaulted: false }),
   };
 }
 

--- a/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.test.ts
+++ b/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.test.ts
@@ -10,7 +10,7 @@ import type {
 } from "./BraintreePayPalContext";
 import type { BraintreePayPalCheckoutInstance } from "../types";
 import type {
-  BraintreeEligiblePaymentMethodsOutput,
+  BraintreeEligibilityResult,
   BraintreeFindEligibleMethodsOptions,
 } from "../types/braintree";
 
@@ -61,7 +61,7 @@ function createInitialState(): BraintreePayPalState {
   };
 }
 
-function createMockEligibility(): BraintreeEligiblePaymentMethodsOutput {
+function createMockEligibility(): BraintreeEligibilityResult {
   return {
     paypal: true,
     paylater: true,

--- a/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.test.ts
+++ b/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.test.ts
@@ -10,7 +10,7 @@ import type {
 } from "./BraintreePayPalContext";
 import type { BraintreePayPalCheckoutInstance } from "../types";
 import type {
-  BraintreeEligibilityResult,
+  BraintreeEligiblePaymentMethodsOutput,
   BraintreeFindEligibleMethodsOptions,
 } from "../types/braintree";
 
@@ -53,15 +53,15 @@ function createMockCheckoutInstance(): BraintreePayPalCheckoutInstance {
 function createInitialState(): BraintreePayPalState {
   return {
     braintreePayPalCheckoutInstance: null,
-    eligibleMethods: null,
-    eligibleMethodsPayload: null,
+    eligiblePaymentMethods: null,
+    eligiblePaymentMethodsPayload: null,
     loadingStatus: INSTANCE_LOADING_STATE.PENDING,
     error: null,
     isHydrated: false,
   };
 }
 
-function createMockEligibility(): BraintreeEligibilityResult {
+function createMockEligibility(): BraintreeEligiblePaymentMethodsOutput {
   return {
     paypal: true,
     paylater: true,
@@ -145,15 +145,15 @@ describe("braintreeReducer", () => {
       const action: BraintreeAction = {
         type: BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY,
         value: {
-          eligibleMethods: eligibility,
+          eligiblePaymentMethods: eligibility,
           payload: SAMPLE_PAYLOAD,
         },
       };
 
       const result = braintreeReducer(initialState, action);
 
-      expect(result.eligibleMethods).toBe(eligibility);
-      expect(result.eligibleMethodsPayload).toBe(SAMPLE_PAYLOAD);
+      expect(result.eligiblePaymentMethods).toBe(eligibility);
+      expect(result.eligiblePaymentMethodsPayload).toBe(SAMPLE_PAYLOAD);
       expect(result.loadingStatus).toBe(initialState.loadingStatus);
       expect(result).not.toBe(initialState);
     });
@@ -161,17 +161,17 @@ describe("braintreeReducer", () => {
     test("should accept null eligibility (e.g. when clearing the cache)", () => {
       const stateWithEligibility: BraintreePayPalState = {
         ...initialState,
-        eligibleMethods: createMockEligibility(),
-        eligibleMethodsPayload: SAMPLE_PAYLOAD,
+        eligiblePaymentMethods: createMockEligibility(),
+        eligiblePaymentMethodsPayload: SAMPLE_PAYLOAD,
       };
 
       const result = braintreeReducer(stateWithEligibility, {
         type: BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY,
-        value: { eligibleMethods: null, payload: null },
+        value: { eligiblePaymentMethods: null, payload: null },
       });
 
-      expect(result.eligibleMethods).toBe(null);
-      expect(result.eligibleMethodsPayload).toBe(null);
+      expect(result.eligiblePaymentMethods).toBe(null);
+      expect(result.eligiblePaymentMethodsPayload).toBe(null);
     });
   });
 
@@ -179,8 +179,8 @@ describe("braintreeReducer", () => {
     test("should reset state to initial values", () => {
       const stateWithData: BraintreePayPalState = {
         braintreePayPalCheckoutInstance: createMockCheckoutInstance(),
-        eligibleMethods: createMockEligibility(),
-        eligibleMethodsPayload: SAMPLE_PAYLOAD,
+        eligiblePaymentMethods: createMockEligibility(),
+        eligiblePaymentMethodsPayload: SAMPLE_PAYLOAD,
         error: new Error("previous error"),
         loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
         isHydrated: false,
@@ -193,8 +193,8 @@ describe("braintreeReducer", () => {
       const result = braintreeReducer(stateWithData, action);
 
       expect(result.braintreePayPalCheckoutInstance).toBe(null);
-      expect(result.eligibleMethods).toBe(null);
-      expect(result.eligibleMethodsPayload).toBe(null);
+      expect(result.eligiblePaymentMethods).toBe(null);
+      expect(result.eligiblePaymentMethodsPayload).toBe(null);
       expect(result.error).toBe(null);
       expect(result.loadingStatus).toBe(INSTANCE_LOADING_STATE.PENDING);
       expect(result.isHydrated).toBe(false);
@@ -246,8 +246,8 @@ describe("braintreeReducer", () => {
       const eligibility = createMockEligibility();
       const stateWithInstance: BraintreePayPalState = {
         braintreePayPalCheckoutInstance: mockInstance,
-        eligibleMethods: eligibility,
-        eligibleMethodsPayload: SAMPLE_PAYLOAD,
+        eligiblePaymentMethods: eligibility,
+        eligiblePaymentMethodsPayload: SAMPLE_PAYLOAD,
         loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
         error: null,
         isHydrated: false,
@@ -261,8 +261,8 @@ describe("braintreeReducer", () => {
       const result = braintreeReducer(stateWithInstance, action);
 
       expect(result.braintreePayPalCheckoutInstance).toBe(mockInstance);
-      expect(result.eligibleMethods).toBe(eligibility);
-      expect(result.eligibleMethodsPayload).toBe(SAMPLE_PAYLOAD);
+      expect(result.eligiblePaymentMethods).toBe(eligibility);
+      expect(result.eligiblePaymentMethodsPayload).toBe(SAMPLE_PAYLOAD);
     });
   });
 });

--- a/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.test.ts
+++ b/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.test.ts
@@ -9,6 +9,10 @@ import type {
   BraintreeAction,
 } from "./BraintreePayPalContext";
 import type { BraintreePayPalCheckoutInstance } from "../types";
+import type {
+  BraintreeEligibilityResult,
+  BraintreeFindEligibleMethodsOptions,
+} from "../types/braintree";
 
 function createMockCheckoutInstance(): BraintreePayPalCheckoutInstance {
   return {
@@ -49,11 +53,29 @@ function createMockCheckoutInstance(): BraintreePayPalCheckoutInstance {
 function createInitialState(): BraintreePayPalState {
   return {
     braintreePayPalCheckoutInstance: null,
+    eligibleMethods: null,
+    eligibleMethodsPayload: null,
     loadingStatus: INSTANCE_LOADING_STATE.PENDING,
     error: null,
     isHydrated: false,
   };
 }
+
+function createMockEligibility(): BraintreeEligibilityResult {
+  return {
+    paypal: true,
+    paylater: true,
+    credit: false,
+    getDetails: jest.fn().mockReturnValue(null),
+  };
+}
+
+const SAMPLE_PAYLOAD: BraintreeFindEligibleMethodsOptions = {
+  amount: "10.00",
+  currency: "USD",
+  countryCode: "US",
+  paymentFlow: "ONE_TIME_PAYMENT",
+};
 
 describe("braintreeReducer", () => {
   let initialState: BraintreePayPalState;
@@ -117,10 +139,48 @@ describe("braintreeReducer", () => {
     );
   });
 
+  describe("SET_ELIGIBILITY action", () => {
+    test("should store eligibility result and the payload it was fetched with", () => {
+      const eligibility = createMockEligibility();
+      const action: BraintreeAction = {
+        type: BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY,
+        value: {
+          eligibleMethods: eligibility,
+          payload: SAMPLE_PAYLOAD,
+        },
+      };
+
+      const result = braintreeReducer(initialState, action);
+
+      expect(result.eligibleMethods).toBe(eligibility);
+      expect(result.eligibleMethodsPayload).toBe(SAMPLE_PAYLOAD);
+      expect(result.loadingStatus).toBe(initialState.loadingStatus);
+      expect(result).not.toBe(initialState);
+    });
+
+    test("should accept null eligibility (e.g. when clearing the cache)", () => {
+      const stateWithEligibility: BraintreePayPalState = {
+        ...initialState,
+        eligibleMethods: createMockEligibility(),
+        eligibleMethodsPayload: SAMPLE_PAYLOAD,
+      };
+
+      const result = braintreeReducer(stateWithEligibility, {
+        type: BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY,
+        value: { eligibleMethods: null, payload: null },
+      });
+
+      expect(result.eligibleMethods).toBe(null);
+      expect(result.eligibleMethodsPayload).toBe(null);
+    });
+  });
+
   describe("RESET_STATE action", () => {
     test("should reset state to initial values", () => {
       const stateWithData: BraintreePayPalState = {
         braintreePayPalCheckoutInstance: createMockCheckoutInstance(),
+        eligibleMethods: createMockEligibility(),
+        eligibleMethodsPayload: SAMPLE_PAYLOAD,
         error: new Error("previous error"),
         loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
         isHydrated: false,
@@ -133,6 +193,8 @@ describe("braintreeReducer", () => {
       const result = braintreeReducer(stateWithData, action);
 
       expect(result.braintreePayPalCheckoutInstance).toBe(null);
+      expect(result.eligibleMethods).toBe(null);
+      expect(result.eligibleMethodsPayload).toBe(null);
       expect(result.error).toBe(null);
       expect(result.loadingStatus).toBe(INSTANCE_LOADING_STATE.PENDING);
       expect(result.isHydrated).toBe(false);
@@ -181,8 +243,11 @@ describe("braintreeReducer", () => {
 
     test("should preserve unmodified properties", () => {
       const mockInstance = createMockCheckoutInstance();
+      const eligibility = createMockEligibility();
       const stateWithInstance: BraintreePayPalState = {
         braintreePayPalCheckoutInstance: mockInstance,
+        eligibleMethods: eligibility,
+        eligibleMethodsPayload: SAMPLE_PAYLOAD,
         loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
         error: null,
         isHydrated: false,
@@ -196,6 +261,8 @@ describe("braintreeReducer", () => {
       const result = braintreeReducer(stateWithInstance, action);
 
       expect(result.braintreePayPalCheckoutInstance).toBe(mockInstance);
+      expect(result.eligibleMethods).toBe(eligibility);
+      expect(result.eligibleMethodsPayload).toBe(SAMPLE_PAYLOAD);
     });
   });
 });

--- a/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.tsx
+++ b/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.tsx
@@ -7,14 +7,14 @@ import {
 
 import type { BraintreePayPalCheckoutInstance } from "../types";
 import type {
-  BraintreeEligibilityResult,
+  BraintreeEligiblePaymentMethodsOutput,
   BraintreeFindEligibleMethodsOptions,
 } from "../types/braintree";
 
 export interface BraintreePayPalState {
   braintreePayPalCheckoutInstance: BraintreePayPalCheckoutInstance | null;
-  eligibleMethods: BraintreeEligibilityResult | null;
-  eligibleMethodsPayload?: BraintreeFindEligibleMethodsOptions | null;
+  eligiblePaymentMethods: BraintreeEligiblePaymentMethodsOutput | null;
+  eligiblePaymentMethodsPayload?: BraintreeFindEligibleMethodsOptions | null;
   loadingStatus: INSTANCE_LOADING_STATE;
   error: Error | null;
   isHydrated: boolean;
@@ -32,7 +32,7 @@ export type BraintreeAction =
   | {
       type: BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY;
       value: {
-        eligibleMethods: BraintreeEligibilityResult | null;
+        eligiblePaymentMethods: BraintreeEligiblePaymentMethodsOutput | null;
         payload?: BraintreeFindEligibleMethodsOptions | null;
       };
     }
@@ -41,8 +41,8 @@ export type BraintreeAction =
 
 export const braintreeInitialState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
-  eligibleMethods: null,
-  eligibleMethodsPayload: null,
+  eligiblePaymentMethods: null,
+  eligiblePaymentMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.PENDING,
   error: null,
   isHydrated: false,
@@ -64,8 +64,8 @@ export function braintreeReducer(
     case BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY:
       return {
         ...state,
-        eligibleMethods: action.value.eligibleMethods,
-        eligibleMethodsPayload: action.value.payload,
+        eligiblePaymentMethods: action.value.eligiblePaymentMethods,
+        eligiblePaymentMethodsPayload: action.value.payload,
       };
     case BRAINTREE_DISPATCH_ACTION.SET_ERROR:
       return {

--- a/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.tsx
+++ b/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.tsx
@@ -6,9 +6,15 @@ import {
 } from "../types/ProviderEnums";
 
 import type { BraintreePayPalCheckoutInstance } from "../types";
+import type {
+  BraintreeEligibilityResult,
+  BraintreeFindEligibleMethodsOptions,
+} from "../types/braintree";
 
 export interface BraintreePayPalState {
   braintreePayPalCheckoutInstance: BraintreePayPalCheckoutInstance | null;
+  eligibleMethods: BraintreeEligibilityResult | null;
+  eligibleMethodsPayload?: BraintreeFindEligibleMethodsOptions | null;
   loadingStatus: INSTANCE_LOADING_STATE;
   error: Error | null;
   isHydrated: boolean;
@@ -23,11 +29,20 @@ export type BraintreeAction =
       type: BRAINTREE_DISPATCH_ACTION.SET_INSTANCE;
       value: BraintreePayPalCheckoutInstance;
     }
+  | {
+      type: BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY;
+      value: {
+        eligibleMethods: BraintreeEligibilityResult | null;
+        payload?: BraintreeFindEligibleMethodsOptions | null;
+      };
+    }
   | { type: BRAINTREE_DISPATCH_ACTION.SET_ERROR; value: Error }
   | { type: BRAINTREE_DISPATCH_ACTION.RESET_STATE };
 
 export const braintreeInitialState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
+  eligibleMethods: null,
+  eligibleMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.PENDING,
   error: null,
   isHydrated: false,
@@ -45,6 +60,12 @@ export function braintreeReducer(
         ...state,
         braintreePayPalCheckoutInstance: action.value,
         loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
+      };
+    case BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY:
+      return {
+        ...state,
+        eligibleMethods: action.value.eligibleMethods,
+        eligibleMethodsPayload: action.value.payload,
       };
     case BRAINTREE_DISPATCH_ACTION.SET_ERROR:
       return {

--- a/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.tsx
+++ b/packages/react-paypal-js/src/v6/context/BraintreePayPalContext.tsx
@@ -7,13 +7,13 @@ import {
 
 import type { BraintreePayPalCheckoutInstance } from "../types";
 import type {
-  BraintreeEligiblePaymentMethodsOutput,
+  BraintreeEligibilityResult,
   BraintreeFindEligibleMethodsOptions,
 } from "../types/braintree";
 
 export interface BraintreePayPalState {
   braintreePayPalCheckoutInstance: BraintreePayPalCheckoutInstance | null;
-  eligiblePaymentMethods: BraintreeEligiblePaymentMethodsOutput | null;
+  eligiblePaymentMethods: BraintreeEligibilityResult | null;
   eligiblePaymentMethodsPayload?: BraintreeFindEligibleMethodsOptions | null;
   loadingStatus: INSTANCE_LOADING_STATE;
   error: Error | null;
@@ -32,7 +32,7 @@ export type BraintreeAction =
   | {
       type: BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY;
       value: {
-        eligiblePaymentMethods: BraintreeEligiblePaymentMethodsOutput | null;
+        eligiblePaymentMethods: BraintreeEligibilityResult | null;
         payload?: BraintreeFindEligibleMethodsOptions | null;
       };
     }

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
@@ -1,8 +1,12 @@
 import React, { useReducer } from "react";
 import { renderHook, act } from "@testing-library/react-hooks";
+import { render, waitFor } from "@testing-library/react";
 
 import { expectCurrentErrorValue } from "../useErrorTestUtil";
-import { useBraintreeEligibleMethods } from "./useBraintreeEligibleMethods";
+import {
+  useBraintreeEligibleMethods,
+  UseBraintreeEligibleMethodsReturn,
+} from "./useBraintreeEligibleMethods";
 import {
   BraintreePayPalContext,
   braintreeInitialState,
@@ -79,10 +83,11 @@ interface ProviderHandle {
 function makeProvider(
   initialOverrides: Partial<BraintreePayPalState> = {},
 ): ProviderHandle {
-  const handle: ProviderHandle = {
-    Wrapper: () => null,
-    dispatch: () => {},
-  };
+  // `currentDispatch` is rebound on every Wrapper render. The returned
+  // `dispatch` forwards to it so callers can destructure `dispatch` from the
+  // handle BEFORE the Wrapper has mounted (when the real reducer dispatch is
+  // not yet known) and still hit the live dispatch at call time.
+  let currentDispatch: (action: BraintreeAction) => void = () => {};
 
   const Wrapper: TestWrapper = ({ children }) => {
     const [state, dispatch] = useReducer(braintreeReducer, {
@@ -91,7 +96,7 @@ function makeProvider(
       isHydrated: true,
       ...initialOverrides,
     });
-    handle.dispatch = dispatch;
+    currentDispatch = dispatch;
     return React.createElement(
       BraintreeDispatchContext.Provider,
       { value: dispatch },
@@ -103,8 +108,10 @@ function makeProvider(
     );
   };
 
-  handle.Wrapper = Wrapper;
-  return handle;
+  return {
+    Wrapper,
+    dispatch: (action) => currentDispatch(action),
+  };
 }
 
 describe("useBraintreeEligibleMethods", () => {
@@ -257,7 +264,7 @@ describe("useBraintreeEligibleMethods", () => {
       expect(firstInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
 
       const secondInstance = createMockCheckoutInstance();
-      act(() => {
+      await act(async () => {
         dispatch({
           type: BRAINTREE_DISPATCH_ACTION.SET_INSTANCE,
           value: secondInstance as unknown as BraintreePayPalCheckoutInstance,
@@ -342,28 +349,52 @@ describe("useBraintreeEligibleMethods", () => {
           checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
       });
 
-      const first = renderHook(
-        () => useBraintreeEligibleMethods(defaultProps),
-        { wrapper: Wrapper },
+      // Each renderHook() call mounts an independent React tree, so the two
+      // consumers cannot share context via separate renderHook invocations.
+      // To exercise the cross-mount cache contract, render both consumers as
+      // siblings under one Wrapper instance and capture their hook returns
+      // through component refs.
+      const firstReturn: {
+        current: UseBraintreeEligibleMethodsReturn | null;
+      } = { current: null };
+      const secondReturn: {
+        current: UseBraintreeEligibleMethodsReturn | null;
+      } = { current: null };
+
+      function First() {
+        firstReturn.current = useBraintreeEligibleMethods(defaultProps);
+        return null;
+      }
+      function Second() {
+        secondReturn.current = useBraintreeEligibleMethods(defaultProps);
+        return null;
+      }
+
+      const { rerender } = render(
+        React.createElement(Wrapper, null, React.createElement(First)),
       );
 
-      await first.waitForNextUpdate();
-
+      await waitFor(() =>
+        expect(firstReturn.current?.eligibleMethods).toBe(eligibility),
+      );
       expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
-      expect(first.result.current.eligibleMethods).toBe(eligibility);
 
       // Mount a second consumer with the same options under the same provider.
       // The cached eligibility on context should be returned immediately and no
       // additional findEligibleMethods call should fire.
-      const second = renderHook(
-        () => useBraintreeEligibleMethods(defaultProps),
-        { wrapper: Wrapper },
+      rerender(
+        React.createElement(
+          Wrapper,
+          null,
+          React.createElement(First),
+          React.createElement(Second),
+        ),
       );
 
       // Hook is brand-new — its lastFetchRef is null — but a deep-equal payload
       // is already cached on context, so it should still skip the network call.
       expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
-      expect(second.result.current.eligibleMethods).toBe(eligibility);
+      expect(secondReturn.current?.eligibleMethods).toBe(eligibility);
     });
   });
 

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
@@ -120,7 +120,7 @@ describe("useBraintreeEligibleMethods", () => {
   });
 
   describe("initialization", () => {
-    test("should return isPending=true while provider instance is pending", () => {
+    test("should return isLoading=true while provider instance is pending", () => {
       const { Wrapper } = makeProvider({
         loadingStatus: INSTANCE_LOADING_STATE.PENDING,
       });
@@ -130,7 +130,7 @@ describe("useBraintreeEligibleMethods", () => {
         { wrapper: Wrapper },
       );
 
-      expect(result.current.isPending).toBe(true);
+      expect(result.current.isLoading).toBe(true);
       expect(result.current.eligibleMethods).toBeNull();
       expect(result.current.error).toBeNull();
     });
@@ -168,7 +168,7 @@ describe("useBraintreeEligibleMethods", () => {
       await waitForNextUpdate();
 
       expect(result.current.eligibleMethods).toBe(eligibility);
-      expect(result.current.isPending).toBe(false);
+      expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBeNull();
     });
 
@@ -192,7 +192,62 @@ describe("useBraintreeEligibleMethods", () => {
       expectCurrentErrorValue(result.current.error);
       expect(result.current.error).toBe(thrownError);
       expect(result.current.eligibleMethods).toBeNull();
-      expect(result.current.isPending).toBe(false);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    test("should forward option fields beyond the known four to findEligibleMethods", async () => {
+      const checkoutInstance = createMockCheckoutInstance();
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
+      });
+
+      // Simulates a field added to BraintreeFindEligibleMethodsOptions later.
+      // The hook must forward the whole options object, not a fixed subset of
+      // keys, otherwise newly added options are silently dropped.
+      const optionsWithExtraField = {
+        ...defaultProps,
+        futureField: "forward-me",
+      } as unknown as BraintreeFindEligibleMethodsOptions;
+
+      const { waitForNextUpdate } = renderHook(
+        () => useBraintreeEligibleMethods(optionsWithExtraField),
+        { wrapper: Wrapper },
+      );
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledWith(
+        expect.objectContaining({ futureField: "forward-me" }),
+      );
+
+      await waitForNextUpdate();
+    });
+  });
+
+  describe("provider errors", () => {
+    test("should surface a labeled provider-level error and stop loading", () => {
+      const providerError = new Error("checkout instance failed to initialize");
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance: null,
+        loadingStatus: INSTANCE_LOADING_STATE.REJECTED,
+        error: providerError,
+      });
+
+      const { result } = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
+      );
+
+      // Provider/context errors are surfaced separately from fetch errors and
+      // labeled so the developer can tell which layer failed.
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toContain(
+        "Braintree PayPal context error",
+      );
+      expect(result.current.error?.message).toContain(
+        "checkout instance failed to initialize",
+      );
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.eligibleMethods).toBeNull();
     });
   });
 
@@ -399,7 +454,7 @@ describe("useBraintreeEligibleMethods", () => {
   });
 
   describe("StrictMode", () => {
-    test("should resolve isPending under React 18 StrictMode double-mount", async () => {
+    test("should resolve isLoading under React 18 StrictMode double-mount", async () => {
       const eligibility = createMockEligibility();
       const checkoutInstance = createMockCheckoutInstance(eligibility);
       const { Wrapper } = makeProvider({
@@ -419,7 +474,7 @@ describe("useBraintreeEligibleMethods", () => {
       // StrictMode mounts effects twice (mount -> cleanup -> mount). The first
       // mount starts a fetch and is immediately aborted by its cleanup; the
       // dedup marker must be rolled back so the second mount re-fetches.
-      // Without the rollback, the hook stays stuck at isPending=true.
+      // Without the rollback, the hook stays stuck at isLoading=true.
       render(
         React.createElement(
           React.StrictMode,
@@ -428,7 +483,7 @@ describe("useBraintreeEligibleMethods", () => {
         ),
       );
 
-      await waitFor(() => expect(hookReturn.current?.isPending).toBe(false));
+      await waitFor(() => expect(hookReturn.current?.isLoading).toBe(false));
 
       expect(hookReturn.current?.eligibleMethods).toBe(eligibility);
       expect(hookReturn.current?.error).toBeNull();

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../../types/ProviderEnums";
 
 import type {
-  BraintreeEligiblePaymentMethodsOutput,
+  BraintreeEligibilityResult,
   BraintreeFindEligibleMethodsOptions,
 } from "../../types/braintree";
 import type {
@@ -29,8 +29,8 @@ import type {
 import type { BraintreePayPalCheckoutInstance } from "../../types";
 
 const createMockEligibility = (
-  overrides: Partial<BraintreeEligiblePaymentMethodsOutput> = {},
-): BraintreeEligiblePaymentMethodsOutput => ({
+  overrides: Partial<BraintreeEligibilityResult> = {},
+): BraintreeEligibilityResult => ({
   paypal: true,
   paylater: true,
   credit: false,
@@ -45,8 +45,8 @@ type MockCheckoutInstance = Pick<
 
 const createMockCheckoutInstance = (
   result:
-    | BraintreeEligiblePaymentMethodsOutput
-    | Promise<BraintreeEligiblePaymentMethodsOutput> = createMockEligibility(),
+    | BraintreeEligibilityResult
+    | Promise<BraintreeEligibilityResult> = createMockEligibility(),
 ): MockCheckoutInstance => ({
   findEligibleMethods: jest
     .fn()
@@ -495,14 +495,10 @@ describe("useBraintreeEligibleMethods", () => {
 
   describe("unmount", () => {
     test("should not update state after unmount", async () => {
-      let resolveFetch: (
-        value: BraintreeEligiblePaymentMethodsOutput,
-      ) => void = () => {};
-      const pending = new Promise<BraintreeEligiblePaymentMethodsOutput>(
-        (resolve) => {
-          resolveFetch = resolve;
-        },
-      );
+      let resolveFetch: (value: BraintreeEligibilityResult) => void = () => {};
+      const pending = new Promise<BraintreeEligibilityResult>((resolve) => {
+        resolveFetch = resolve;
+      });
 
       const checkoutInstance = {
         findEligibleMethods: jest.fn().mockReturnValue(pending),

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
@@ -1,21 +1,28 @@
+import React, { useReducer } from "react";
 import { renderHook, act } from "@testing-library/react-hooks";
 
 import { expectCurrentErrorValue } from "../useErrorTestUtil";
 import { useBraintreeEligibleMethods } from "./useBraintreeEligibleMethods";
-import { useBraintreePayPal } from "./useBraintreePayPal";
-import { INSTANCE_LOADING_STATE } from "../../types/ProviderEnums";
+import {
+  BraintreePayPalContext,
+  braintreeInitialState,
+  braintreeReducer,
+} from "../../context/BraintreePayPalContext";
+import { BraintreeDispatchContext } from "../../context/BraintreeDispatchContext";
+import {
+  BRAINTREE_DISPATCH_ACTION,
+  INSTANCE_LOADING_STATE,
+} from "../../types/ProviderEnums";
 
 import type {
   BraintreeEligibilityResult,
   BraintreeFindEligibleMethodsOptions,
 } from "../../types/braintree";
-import type { BraintreePayPalState } from "../../context/BraintreePayPalContext";
-
-jest.mock("./useBraintreePayPal");
-
-const mockUseBraintreePayPal = useBraintreePayPal as jest.MockedFunction<
-  typeof useBraintreePayPal
->;
+import type {
+  BraintreeAction,
+  BraintreePayPalState,
+} from "../../context/BraintreePayPalContext";
+import type { BraintreePayPalCheckoutInstance } from "../../types";
 
 const createMockEligibility = (
   overrides: Partial<BraintreeEligibilityResult> = {},
@@ -27,38 +34,22 @@ const createMockEligibility = (
   ...overrides,
 });
 
+type MockCheckoutInstance = Pick<
+  BraintreePayPalCheckoutInstance,
+  "findEligibleMethods"
+>;
+
 const createMockCheckoutInstance = (
   result:
     | BraintreeEligibilityResult
     | Promise<BraintreeEligibilityResult> = createMockEligibility(),
-) => ({
+): MockCheckoutInstance => ({
   findEligibleMethods: jest
     .fn()
     .mockReturnValue(
       result instanceof Promise ? result : Promise.resolve(result),
     ),
 });
-
-const defaultBraintreeState: BraintreePayPalState = {
-  braintreePayPalCheckoutInstance: null,
-  loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
-  error: null,
-  isHydrated: true,
-};
-
-function mockBraintreeContext(
-  overrides: Partial<
-    Omit<BraintreePayPalState, "braintreePayPalCheckoutInstance"> & {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      braintreePayPalCheckoutInstance?: any;
-    }
-  > = {},
-): void {
-  mockUseBraintreePayPal.mockReturnValue({
-    ...defaultBraintreeState,
-    ...overrides,
-  } as BraintreePayPalState);
-}
 
 const defaultProps: BraintreeFindEligibleMethodsOptions = {
   amount: "10.00",
@@ -67,6 +58,55 @@ const defaultProps: BraintreeFindEligibleMethodsOptions = {
   paymentFlow: "ONE_TIME_PAYMENT",
 };
 
+// Wrapper accepts arbitrary props because @testing-library/react-hooks types
+// the wrapper to match the hook's initialProps shape.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TestWrapper = React.ComponentType<any>;
+
+interface ProviderHandle {
+  Wrapper: TestWrapper;
+  dispatch: (action: BraintreeAction) => void;
+}
+
+/**
+ * Creates a reducer-backed test provider that exposes the real
+ * BraintreeDispatchContext so that dispatched SET_ELIGIBILITY actions actually
+ * update the BraintreePayPalContext state observed by the hook.
+ *
+ * Returns a `dispatch` handle for tests that want to mutate state externally
+ * (e.g. swapping the checkout instance).
+ */
+function makeProvider(
+  initialOverrides: Partial<BraintreePayPalState> = {},
+): ProviderHandle {
+  const handle: ProviderHandle = {
+    Wrapper: () => null,
+    dispatch: () => {},
+  };
+
+  const Wrapper: TestWrapper = ({ children }) => {
+    const [state, dispatch] = useReducer(braintreeReducer, {
+      ...braintreeInitialState,
+      loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
+      isHydrated: true,
+      ...initialOverrides,
+    });
+    handle.dispatch = dispatch;
+    return React.createElement(
+      BraintreeDispatchContext.Provider,
+      { value: dispatch },
+      React.createElement(
+        BraintreePayPalContext.Provider,
+        { value: state },
+        children,
+      ),
+    );
+  };
+
+  handle.Wrapper = Wrapper;
+  return handle;
+}
+
 describe("useBraintreeEligibleMethods", () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -74,37 +114,44 @@ describe("useBraintreeEligibleMethods", () => {
 
   describe("initialization", () => {
     test("should return isPending=true while provider instance is pending", () => {
-      mockBraintreeContext({ loadingStatus: INSTANCE_LOADING_STATE.PENDING });
+      const { Wrapper } = makeProvider({
+        loadingStatus: INSTANCE_LOADING_STATE.PENDING,
+      });
 
-      const { result } = renderHook(() =>
-        useBraintreeEligibleMethods(defaultProps),
+      const { result } = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.isPending).toBe(true);
-      expect(result.current.eligibility).toBeNull();
+      expect(result.current.eligibleMethods).toBeNull();
       expect(result.current.error).toBeNull();
     });
 
-    test("should not call findEligibleMethods when no checkout instance is available", () => {
-      mockBraintreeContext({
+    test("should not crash when no checkout instance is available", () => {
+      const { Wrapper } = makeProvider({
         loadingStatus: INSTANCE_LOADING_STATE.REJECTED,
       });
 
-      renderHook(() => useBraintreeEligibleMethods(defaultProps));
+      const { result } = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
+      );
 
-      // Nothing to assert on the instance — it's null. Just confirm no crash and no eligibility.
+      expect(result.current.eligibleMethods).toBeNull();
     });
 
     test("should call findEligibleMethods with the supplied options when instance is available", async () => {
       const eligibility = createMockEligibility();
       const checkoutInstance = createMockCheckoutInstance(eligibility);
-
-      mockBraintreeContext({
-        braintreePayPalCheckoutInstance: checkoutInstance,
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useBraintreeEligibleMethods(defaultProps),
+      const { result, waitForNextUpdate } = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
       );
 
       expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledWith(
@@ -113,7 +160,7 @@ describe("useBraintreeEligibleMethods", () => {
 
       await waitForNextUpdate();
 
-      expect(result.current.eligibility).toBe(eligibility);
+      expect(result.current.eligibleMethods).toBe(eligibility);
       expect(result.current.isPending).toBe(false);
       expect(result.current.error).toBeNull();
     });
@@ -123,20 +170,21 @@ describe("useBraintreeEligibleMethods", () => {
       const checkoutInstance = {
         findEligibleMethods: jest.fn().mockRejectedValue(thrownError),
       };
-
-      mockBraintreeContext({
-        braintreePayPalCheckoutInstance: checkoutInstance,
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
       });
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useBraintreeEligibleMethods(defaultProps),
+      const { result, waitForNextUpdate } = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
       );
 
       await waitForNextUpdate();
 
       expectCurrentErrorValue(result.current.error);
       expect(result.current.error).toBe(thrownError);
-      expect(result.current.eligibility).toBeNull();
+      expect(result.current.eligibleMethods).toBeNull();
       expect(result.current.isPending).toBe(false);
     });
   });
@@ -144,15 +192,15 @@ describe("useBraintreeEligibleMethods", () => {
   describe("refetch behavior", () => {
     test("should refetch when options change", async () => {
       const checkoutInstance = createMockCheckoutInstance();
-
-      mockBraintreeContext({
-        braintreePayPalCheckoutInstance: checkoutInstance,
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
       });
 
       const { rerender, waitForNextUpdate } = renderHook(
         ({ amount }) =>
           useBraintreeEligibleMethods({ ...defaultProps, amount }),
-        { initialProps: { amount: "10.00" } },
+        { initialProps: { amount: "10.00" }, wrapper: Wrapper },
       );
 
       await waitForNextUpdate();
@@ -171,15 +219,15 @@ describe("useBraintreeEligibleMethods", () => {
 
     test("should not refetch when options are deep-equal but referentially different", async () => {
       const checkoutInstance = createMockCheckoutInstance();
-
-      mockBraintreeContext({
-        braintreePayPalCheckoutInstance: checkoutInstance,
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
       });
 
       const { rerender, waitForNextUpdate } = renderHook(
         (props: BraintreeFindEligibleMethodsOptions) =>
           useBraintreeEligibleMethods(props),
-        { initialProps: { ...defaultProps } },
+        { initialProps: { ...defaultProps }, wrapper: Wrapper },
       );
 
       await waitForNextUpdate();
@@ -194,13 +242,14 @@ describe("useBraintreeEligibleMethods", () => {
 
     test("should refetch when checkout instance changes", async () => {
       const firstInstance = createMockCheckoutInstance();
-
-      mockBraintreeContext({
-        braintreePayPalCheckoutInstance: firstInstance,
+      const { Wrapper, dispatch } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          firstInstance as unknown as BraintreePayPalCheckoutInstance,
       });
 
-      const { rerender, waitForNextUpdate } = renderHook(() =>
-        useBraintreeEligibleMethods(defaultProps),
+      const { waitForNextUpdate } = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
       );
 
       await waitForNextUpdate();
@@ -208,11 +257,12 @@ describe("useBraintreeEligibleMethods", () => {
       expect(firstInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
 
       const secondInstance = createMockCheckoutInstance();
-      mockBraintreeContext({
-        braintreePayPalCheckoutInstance: secondInstance,
+      act(() => {
+        dispatch({
+          type: BRAINTREE_DISPATCH_ACTION.SET_INSTANCE,
+          value: secondInstance as unknown as BraintreePayPalCheckoutInstance,
+        });
       });
-
-      rerender();
 
       expect(secondInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
     });
@@ -223,23 +273,58 @@ describe("useBraintreeEligibleMethods", () => {
           .fn()
           .mockRejectedValue(new Error("init failure")),
       };
-
-      mockBraintreeContext({
-        braintreePayPalCheckoutInstance: checkoutInstance,
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
       });
 
-      const { rerender, waitForNextUpdate } = renderHook(() =>
-        useBraintreeEligibleMethods(defaultProps),
+      const { rerender, waitForNextUpdate } = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
       );
 
       await waitForNextUpdate();
 
       expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
 
-      jest.clearAllMocks();
+      checkoutInstance.findEligibleMethods.mockClear();
       rerender();
 
       expect(checkoutInstance.findEligibleMethods).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("context caching", () => {
+    test("should reuse cached eligibility for a second hook mount with the same options", async () => {
+      const eligibility = createMockEligibility();
+      const checkoutInstance = createMockCheckoutInstance(eligibility);
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
+      });
+
+      const first = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
+      );
+
+      await first.waitForNextUpdate();
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
+      expect(first.result.current.eligibleMethods).toBe(eligibility);
+
+      // Mount a second consumer with the same options under the same provider.
+      // The cached eligibility on context should be returned immediately and no
+      // additional findEligibleMethods call should fire.
+      const second = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
+      );
+
+      // Hook is brand-new — its lastFetchRef is null — but a deep-equal payload
+      // is already cached on context, so it should still skip the network call.
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
+      expect(second.result.current.eligibleMethods).toBe(eligibility);
     });
   });
 
@@ -253,13 +338,14 @@ describe("useBraintreeEligibleMethods", () => {
       const checkoutInstance = {
         findEligibleMethods: jest.fn().mockReturnValue(pending),
       };
-
-      mockBraintreeContext({
-        braintreePayPalCheckoutInstance: checkoutInstance,
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
       });
 
-      const { result, unmount } = renderHook(() =>
-        useBraintreeEligibleMethods(defaultProps),
+      const { result, unmount } = renderHook(
+        () => useBraintreeEligibleMethods(defaultProps),
+        { wrapper: Wrapper },
       );
 
       unmount();
@@ -270,7 +356,7 @@ describe("useBraintreeEligibleMethods", () => {
       });
 
       // Eligibility should remain null because the post-unmount update was skipped
-      expect(result.current.eligibility).toBeNull();
+      expect(result.current.eligibleMethods).toBeNull();
     });
   });
 });

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
@@ -1,0 +1,276 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+
+import { expectCurrentErrorValue } from "../useErrorTestUtil";
+import { useBraintreeEligibleMethods } from "./useBraintreeEligibleMethods";
+import { useBraintreePayPal } from "./useBraintreePayPal";
+import { INSTANCE_LOADING_STATE } from "../../types/ProviderEnums";
+
+import type {
+  BraintreeEligibilityResult,
+  BraintreeFindEligibleMethodsOptions,
+} from "../../types/braintree";
+import type { BraintreePayPalState } from "../../context/BraintreePayPalContext";
+
+jest.mock("./useBraintreePayPal");
+
+const mockUseBraintreePayPal = useBraintreePayPal as jest.MockedFunction<
+  typeof useBraintreePayPal
+>;
+
+const createMockEligibility = (
+  overrides: Partial<BraintreeEligibilityResult> = {},
+): BraintreeEligibilityResult => ({
+  paypal: true,
+  paylater: true,
+  credit: false,
+  getDetails: jest.fn().mockReturnValue(null),
+  ...overrides,
+});
+
+const createMockCheckoutInstance = (
+  result:
+    | BraintreeEligibilityResult
+    | Promise<BraintreeEligibilityResult> = createMockEligibility(),
+) => ({
+  findEligibleMethods: jest
+    .fn()
+    .mockReturnValue(
+      result instanceof Promise ? result : Promise.resolve(result),
+    ),
+});
+
+const defaultBraintreeState: BraintreePayPalState = {
+  braintreePayPalCheckoutInstance: null,
+  loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
+  error: null,
+  isHydrated: true,
+};
+
+function mockBraintreeContext(
+  overrides: Partial<
+    Omit<BraintreePayPalState, "braintreePayPalCheckoutInstance"> & {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      braintreePayPalCheckoutInstance?: any;
+    }
+  > = {},
+): void {
+  mockUseBraintreePayPal.mockReturnValue({
+    ...defaultBraintreeState,
+    ...overrides,
+  } as BraintreePayPalState);
+}
+
+const defaultProps: BraintreeFindEligibleMethodsOptions = {
+  amount: "10.00",
+  currency: "USD",
+  countryCode: "US",
+  paymentFlow: "ONE_TIME_PAYMENT",
+};
+
+describe("useBraintreeEligibleMethods", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("initialization", () => {
+    test("should return isPending=true while provider instance is pending", () => {
+      mockBraintreeContext({ loadingStatus: INSTANCE_LOADING_STATE.PENDING });
+
+      const { result } = renderHook(() =>
+        useBraintreeEligibleMethods(defaultProps),
+      );
+
+      expect(result.current.isPending).toBe(true);
+      expect(result.current.eligibility).toBeNull();
+      expect(result.current.error).toBeNull();
+    });
+
+    test("should not call findEligibleMethods when no checkout instance is available", () => {
+      mockBraintreeContext({
+        loadingStatus: INSTANCE_LOADING_STATE.REJECTED,
+      });
+
+      renderHook(() => useBraintreeEligibleMethods(defaultProps));
+
+      // Nothing to assert on the instance — it's null. Just confirm no crash and no eligibility.
+    });
+
+    test("should call findEligibleMethods with the supplied options when instance is available", async () => {
+      const eligibility = createMockEligibility();
+      const checkoutInstance = createMockCheckoutInstance(eligibility);
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: checkoutInstance,
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useBraintreeEligibleMethods(defaultProps),
+      );
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledWith(
+        defaultProps,
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current.eligibility).toBe(eligibility);
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    test("should set error and leave eligibility null when findEligibleMethods rejects", async () => {
+      const thrownError = new Error("findEligibleMethods failed");
+      const checkoutInstance = {
+        findEligibleMethods: jest.fn().mockRejectedValue(thrownError),
+      };
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: checkoutInstance,
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useBraintreeEligibleMethods(defaultProps),
+      );
+
+      await waitForNextUpdate();
+
+      expectCurrentErrorValue(result.current.error);
+      expect(result.current.error).toBe(thrownError);
+      expect(result.current.eligibility).toBeNull();
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  describe("refetch behavior", () => {
+    test("should refetch when options change", async () => {
+      const checkoutInstance = createMockCheckoutInstance();
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: checkoutInstance,
+      });
+
+      const { rerender, waitForNextUpdate } = renderHook(
+        ({ amount }) =>
+          useBraintreeEligibleMethods({ ...defaultProps, amount }),
+        { initialProps: { amount: "10.00" } },
+      );
+
+      await waitForNextUpdate();
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
+
+      rerender({ amount: "20.00" });
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(2);
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenLastCalledWith(
+        expect.objectContaining({ amount: "20.00" }),
+      );
+
+      await waitForNextUpdate();
+    });
+
+    test("should not refetch when options are deep-equal but referentially different", async () => {
+      const checkoutInstance = createMockCheckoutInstance();
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: checkoutInstance,
+      });
+
+      const { rerender, waitForNextUpdate } = renderHook(
+        (props: BraintreeFindEligibleMethodsOptions) =>
+          useBraintreeEligibleMethods(props),
+        { initialProps: { ...defaultProps } },
+      );
+
+      await waitForNextUpdate();
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
+
+      // New reference, same values
+      rerender({ ...defaultProps });
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
+    });
+
+    test("should refetch when checkout instance changes", async () => {
+      const firstInstance = createMockCheckoutInstance();
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: firstInstance,
+      });
+
+      const { rerender, waitForNextUpdate } = renderHook(() =>
+        useBraintreeEligibleMethods(defaultProps),
+      );
+
+      await waitForNextUpdate();
+
+      expect(firstInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
+
+      const secondInstance = createMockCheckoutInstance();
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: secondInstance,
+      });
+
+      rerender();
+
+      expect(secondInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
+    });
+
+    test("should not retry on the same failed checkout instance", async () => {
+      const checkoutInstance = {
+        findEligibleMethods: jest
+          .fn()
+          .mockRejectedValue(new Error("init failure")),
+      };
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: checkoutInstance,
+      });
+
+      const { rerender, waitForNextUpdate } = renderHook(() =>
+        useBraintreeEligibleMethods(defaultProps),
+      );
+
+      await waitForNextUpdate();
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
+
+      jest.clearAllMocks();
+      rerender();
+
+      expect(checkoutInstance.findEligibleMethods).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unmount", () => {
+    test("should not update state after unmount", async () => {
+      let resolveFetch: (value: BraintreeEligibilityResult) => void = () => {};
+      const pending = new Promise<BraintreeEligibilityResult>((resolve) => {
+        resolveFetch = resolve;
+      });
+
+      const checkoutInstance = {
+        findEligibleMethods: jest.fn().mockReturnValue(pending),
+      };
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: checkoutInstance,
+      });
+
+      const { result, unmount } = renderHook(() =>
+        useBraintreeEligibleMethods(defaultProps),
+      );
+
+      unmount();
+
+      await act(async () => {
+        resolveFetch(createMockEligibility());
+        await pending;
+      });
+
+      // Eligibility should remain null because the post-unmount update was skipped
+      expect(result.current.eligibility).toBeNull();
+    });
+  });
+});

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
@@ -34,7 +34,7 @@ const createMockEligibility = (
   paypal: true,
   paylater: true,
   credit: false,
-  getDetails: jest.fn().mockReturnValue(null),
+  getDetails: jest.fn().mockReturnValue({ canBeVaulted: false }),
   ...overrides,
 });
 
@@ -395,6 +395,46 @@ describe("useBraintreeEligibleMethods", () => {
       // is already cached on context, so it should still skip the network call.
       expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
       expect(secondReturn.current?.eligibleMethods).toBe(eligibility);
+    });
+  });
+
+  describe("StrictMode", () => {
+    test("should resolve isPending under React 18 StrictMode double-mount", async () => {
+      const eligibility = createMockEligibility();
+      const checkoutInstance = createMockCheckoutInstance(eligibility);
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
+      });
+
+      const hookReturn: {
+        current: UseBraintreeEligibleMethodsReturn | null;
+      } = { current: null };
+
+      function Consumer() {
+        hookReturn.current = useBraintreeEligibleMethods(defaultProps);
+        return null;
+      }
+
+      // StrictMode mounts effects twice (mount -> cleanup -> mount). The first
+      // mount starts a fetch and is immediately aborted by its cleanup; the
+      // dedup marker must be rolled back so the second mount re-fetches.
+      // Without the rollback, the hook stays stuck at isPending=true.
+      render(
+        React.createElement(
+          React.StrictMode,
+          null,
+          React.createElement(Wrapper, null, React.createElement(Consumer)),
+        ),
+      );
+
+      await waitFor(() => expect(hookReturn.current?.isPending).toBe(false));
+
+      expect(hookReturn.current?.eligibleMethods).toBe(eligibility);
+      expect(hookReturn.current?.error).toBeNull();
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledWith(
+        defaultProps,
+      );
     });
   });
 

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../../types/ProviderEnums";
 
 import type {
-  BraintreeEligibilityResult,
+  BraintreeEligiblePaymentMethodsOutput,
   BraintreeFindEligibleMethodsOptions,
 } from "../../types/braintree";
 import type {
@@ -29,8 +29,8 @@ import type {
 import type { BraintreePayPalCheckoutInstance } from "../../types";
 
 const createMockEligibility = (
-  overrides: Partial<BraintreeEligibilityResult> = {},
-): BraintreeEligibilityResult => ({
+  overrides: Partial<BraintreeEligiblePaymentMethodsOutput> = {},
+): BraintreeEligiblePaymentMethodsOutput => ({
   paypal: true,
   paylater: true,
   credit: false,
@@ -45,8 +45,8 @@ type MockCheckoutInstance = Pick<
 
 const createMockCheckoutInstance = (
   result:
-    | BraintreeEligibilityResult
-    | Promise<BraintreeEligibilityResult> = createMockEligibility(),
+    | BraintreeEligiblePaymentMethodsOutput
+    | Promise<BraintreeEligiblePaymentMethodsOutput> = createMockEligibility(),
 ): MockCheckoutInstance => ({
   findEligibleMethods: jest
     .fn()
@@ -131,7 +131,7 @@ describe("useBraintreeEligibleMethods", () => {
       );
 
       expect(result.current.isLoading).toBe(true);
-      expect(result.current.eligibleMethods).toBeNull();
+      expect(result.current.eligiblePaymentMethods).toBeNull();
       expect(result.current.error).toBeNull();
     });
 
@@ -145,7 +145,7 @@ describe("useBraintreeEligibleMethods", () => {
         { wrapper: Wrapper },
       );
 
-      expect(result.current.eligibleMethods).toBeNull();
+      expect(result.current.eligiblePaymentMethods).toBeNull();
     });
 
     test("should call findEligibleMethods with the supplied options when instance is available", async () => {
@@ -167,7 +167,7 @@ describe("useBraintreeEligibleMethods", () => {
 
       await waitForNextUpdate();
 
-      expect(result.current.eligibleMethods).toBe(eligibility);
+      expect(result.current.eligiblePaymentMethods).toBe(eligibility);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBeNull();
     });
@@ -191,7 +191,7 @@ describe("useBraintreeEligibleMethods", () => {
 
       expectCurrentErrorValue(result.current.error);
       expect(result.current.error).toBe(thrownError);
-      expect(result.current.eligibleMethods).toBeNull();
+      expect(result.current.eligiblePaymentMethods).toBeNull();
       expect(result.current.isLoading).toBe(false);
     });
 
@@ -247,7 +247,7 @@ describe("useBraintreeEligibleMethods", () => {
         "checkout instance failed to initialize",
       );
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.eligibleMethods).toBeNull();
+      expect(result.current.eligiblePaymentMethods).toBeNull();
     });
   });
 
@@ -352,7 +352,7 @@ describe("useBraintreeEligibleMethods", () => {
 
       expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
       expect(result.current.error).not.toBeNull();
-      expect(result.current.eligibleMethods).toBeNull();
+      expect(result.current.eligiblePaymentMethods).toBeNull();
 
       // Consumer corrects an option on the SAME (now-failed) instance.
       // The hook must retry rather than stay pinned to the prior failure.
@@ -364,7 +364,7 @@ describe("useBraintreeEligibleMethods", () => {
       expect(checkoutInstance.findEligibleMethods).toHaveBeenLastCalledWith(
         expect.objectContaining({ amount: "20.00" }),
       );
-      expect(result.current.eligibleMethods).toBe(successResult);
+      expect(result.current.eligiblePaymentMethods).toBe(successResult);
       expect(result.current.error).toBeNull();
     });
 
@@ -430,7 +430,7 @@ describe("useBraintreeEligibleMethods", () => {
       );
 
       await waitFor(() =>
-        expect(firstReturn.current?.eligibleMethods).toBe(eligibility),
+        expect(firstReturn.current?.eligiblePaymentMethods).toBe(eligibility),
       );
       expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
 
@@ -449,7 +449,7 @@ describe("useBraintreeEligibleMethods", () => {
       // Hook is brand-new — its lastFetchRef is null — but a deep-equal payload
       // is already cached on context, so it should still skip the network call.
       expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
-      expect(secondReturn.current?.eligibleMethods).toBe(eligibility);
+      expect(secondReturn.current?.eligiblePaymentMethods).toBe(eligibility);
     });
   });
 
@@ -485,7 +485,7 @@ describe("useBraintreeEligibleMethods", () => {
 
       await waitFor(() => expect(hookReturn.current?.isLoading).toBe(false));
 
-      expect(hookReturn.current?.eligibleMethods).toBe(eligibility);
+      expect(hookReturn.current?.eligiblePaymentMethods).toBe(eligibility);
       expect(hookReturn.current?.error).toBeNull();
       expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledWith(
         defaultProps,
@@ -495,10 +495,14 @@ describe("useBraintreeEligibleMethods", () => {
 
   describe("unmount", () => {
     test("should not update state after unmount", async () => {
-      let resolveFetch: (value: BraintreeEligibilityResult) => void = () => {};
-      const pending = new Promise<BraintreeEligibilityResult>((resolve) => {
-        resolveFetch = resolve;
-      });
+      let resolveFetch: (
+        value: BraintreeEligiblePaymentMethodsOutput,
+      ) => void = () => {};
+      const pending = new Promise<BraintreeEligiblePaymentMethodsOutput>(
+        (resolve) => {
+          resolveFetch = resolve;
+        },
+      );
 
       const checkoutInstance = {
         findEligibleMethods: jest.fn().mockReturnValue(pending),
@@ -521,7 +525,7 @@ describe("useBraintreeEligibleMethods", () => {
       });
 
       // Eligibility should remain null because the post-unmount update was skipped
-      expect(result.current.eligibleMethods).toBeNull();
+      expect(result.current.eligiblePaymentMethods).toBeNull();
     });
   });
 });

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.test.ts
@@ -267,6 +267,45 @@ describe("useBraintreeEligibleMethods", () => {
       expect(secondInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
     });
 
+    test("should retry with new options after a failure (transient errors must recover)", async () => {
+      const successResult = createMockEligibility();
+      const checkoutInstance = {
+        findEligibleMethods: jest
+          .fn()
+          .mockRejectedValueOnce(new Error("network blip"))
+          .mockResolvedValueOnce(successResult),
+      };
+      const { Wrapper } = makeProvider({
+        braintreePayPalCheckoutInstance:
+          checkoutInstance as unknown as BraintreePayPalCheckoutInstance,
+      });
+
+      const { result, rerender, waitForNextUpdate } = renderHook(
+        ({ amount }) =>
+          useBraintreeEligibleMethods({ ...defaultProps, amount }),
+        { initialProps: { amount: "10.00" }, wrapper: Wrapper },
+      );
+
+      await waitForNextUpdate();
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(1);
+      expect(result.current.error).not.toBeNull();
+      expect(result.current.eligibleMethods).toBeNull();
+
+      // Consumer corrects an option on the SAME (now-failed) instance.
+      // The hook must retry rather than stay pinned to the prior failure.
+      rerender({ amount: "20.00" });
+
+      await waitForNextUpdate();
+
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenCalledTimes(2);
+      expect(checkoutInstance.findEligibleMethods).toHaveBeenLastCalledWith(
+        expect.objectContaining({ amount: "20.00" }),
+      );
+      expect(result.current.eligibleMethods).toBe(successResult);
+      expect(result.current.error).toBeNull();
+    });
+
     test("should not retry on the same failed checkout instance", async () => {
       const checkoutInstance = {
         findEligibleMethods: jest

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -11,7 +11,7 @@ import {
 } from "../../types/ProviderEnums";
 
 import type {
-  BraintreeEligibilityResult,
+  BraintreeEligiblePaymentMethodsOutput,
   BraintreeFindEligibleMethodsOptions,
 } from "../../types/braintree";
 
@@ -19,7 +19,7 @@ export type UseBraintreeEligibleMethodsProps =
   BraintreeFindEligibleMethodsOptions;
 
 export interface UseBraintreeEligibleMethodsReturn {
-  eligibleMethods: BraintreeEligibilityResult | null;
+  eligiblePaymentMethods: BraintreeEligiblePaymentMethodsOutput | null;
   isLoading: boolean;
   error: Error | null;
 }
@@ -41,7 +41,7 @@ export interface UseBraintreeEligibleMethodsReturn {
  *
  * @example
  * function Checkout() {
- *   const { eligibleMethods, isLoading, error } = useBraintreeEligibleMethods({
+ *   const { eligiblePaymentMethods, isLoading, error } = useBraintreeEligibleMethods({
  *     amount: "10.00",
  *     currency: "USD",
  *     countryCode: "US",
@@ -53,8 +53,8 @@ export interface UseBraintreeEligibleMethodsReturn {
  *
  *   return (
  *     <>
- *       {eligibleMethods?.paypal && <BraintreePayPalOneTimePaymentButton ... />}
- *       {eligibleMethods?.paylater && <PayPalPayLaterButton ... />}
+ *       {eligiblePaymentMethods?.paypal && <BraintreePayPalOneTimePaymentButton ... />}
+ *       {eligiblePaymentMethods?.paylater && <PayPalPayLaterButton ... />}
  *     </>
  *   );
  * }
@@ -64,8 +64,8 @@ export function useBraintreeEligibleMethods(
 ): UseBraintreeEligibleMethodsReturn {
   const {
     braintreePayPalCheckoutInstance,
-    eligibleMethods,
-    eligibleMethodsPayload,
+    eligiblePaymentMethods,
+    eligiblePaymentMethodsPayload,
     loadingStatus,
     error: contextError,
   } = useBraintreePayPal();
@@ -77,10 +77,12 @@ export function useBraintreeEligibleMethods(
   // Refs let the effect see the latest context-cached eligibility without
   // adding it to the dep array (which would re-run the effect every time
   // *we* dispatch SET_ELIGIBILITY and re-trigger the fetch).
-  const eligibleMethodsRef = useRef(eligibleMethods);
-  const eligibleMethodsPayloadRef = useRef(eligibleMethodsPayload);
-  eligibleMethodsRef.current = eligibleMethods;
-  eligibleMethodsPayloadRef.current = eligibleMethodsPayload;
+  const eligiblePaymentMethodsRef = useRef(eligiblePaymentMethods);
+  const eligiblePaymentMethodsPayloadRef = useRef(
+    eligiblePaymentMethodsPayload,
+  );
+  eligiblePaymentMethodsRef.current = eligiblePaymentMethods;
+  eligiblePaymentMethodsPayloadRef.current = eligiblePaymentMethodsPayload;
 
   // Memoize the whole options object so every field the caller passes is
   // forwarded to findEligibleMethods. Don't destructure-and-rebuild a fixed
@@ -133,9 +135,9 @@ export function useBraintreeEligibleMethods(
     // separate hook mounts will memoize different references for the same
     // option values.
     if (
-      eligibleMethodsRef.current &&
+      eligiblePaymentMethodsRef.current &&
       lastFetchRef.current === null &&
-      deepEqual(eligibleMethodsPayloadRef.current, memoizedOptions)
+      deepEqual(eligiblePaymentMethodsPayloadRef.current, memoizedOptions)
     ) {
       lastFetchRef.current = {
         instance: braintreePayPalCheckoutInstance,
@@ -163,7 +165,7 @@ export function useBraintreeEligibleMethods(
         dispatch({
           type: BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY,
           value: {
-            eligibleMethods: result,
+            eligiblePaymentMethods: result,
             payload: memoizedOptions,
           },
         });
@@ -216,9 +218,9 @@ export function useBraintreeEligibleMethods(
   // the one currently requested. Normalize null/undefined so the deepEqual
   // doesn't treat "no stored payload" as different from "no provided payload".
   const isStaleData =
-    !!eligibleMethods &&
+    !!eligiblePaymentMethods &&
     !deepEqual(
-      eligibleMethodsPayload ?? undefined,
+      eligiblePaymentMethodsPayload ?? undefined,
       memoizedOptions ?? undefined,
     );
 
@@ -226,7 +228,7 @@ export function useBraintreeEligibleMethods(
     !error &&
     (loadingStatus === INSTANCE_LOADING_STATE.PENDING ||
       isFetching ||
-      !eligibleMethods ||
+      !eligiblePaymentMethods ||
       isStaleData);
 
   // Provider-level failures (e.g. the checkout instance failed to initialize)
@@ -235,14 +237,14 @@ export function useBraintreeEligibleMethods(
   // both into a single error. Mirrors useEligibleMethods.
   if (contextError) {
     return {
-      eligibleMethods,
+      eligiblePaymentMethods,
       isLoading: false,
       error: new Error(`Braintree PayPal context error: ${contextError}`),
     };
   }
 
   return {
-    eligibleMethods,
+    eligiblePaymentMethods,
     isLoading,
     error,
   };

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -20,7 +20,7 @@ export type UseBraintreeEligibleMethodsProps =
 
 export interface UseBraintreeEligibleMethodsReturn {
   eligibleMethods: BraintreeEligibilityResult | null;
-  isPending: boolean;
+  isLoading: boolean;
   error: Error | null;
 }
 
@@ -152,6 +152,7 @@ export function useBraintreeEligibleMethods({
     };
 
     let isSubscribed = true;
+    let didSettle = false;
     setIsFetching(true);
     setError(null);
 
@@ -180,6 +181,10 @@ export function useBraintreeEligibleMethods({
         setError(err);
       })
       .finally(() => {
+        // Mark the request as settled regardless of subscription so the
+        // cleanup below knows it completed and should not roll back the dedup
+        // marker.
+        didSettle = true;
         if (!isSubscribed || !isMountedRef.current) {
           return;
         }
@@ -188,6 +193,18 @@ export function useBraintreeEligibleMethods({
 
     return () => {
       isSubscribed = false;
+      // If this fetch was torn down before it settled (e.g. a React 18
+      // StrictMode mount/cleanup/mount cycle), clear the dedup marker so the
+      // remount re-fetches. Without this, the remount sees lastFetchRef already
+      // matching (instance, payload) and skips, while the only in-flight fetch
+      // was just aborted — leaving the hook stuck with isPending=true forever.
+      if (
+        !didSettle &&
+        lastFetchRef.current?.instance === braintreePayPalCheckoutInstance &&
+        lastFetchRef.current?.payload === memoizedOptions
+      ) {
+        lastFetchRef.current = null;
+      }
     };
   }, [
     braintreePayPalCheckoutInstance,
@@ -207,7 +224,7 @@ export function useBraintreeEligibleMethods({
       memoizedOptions ?? undefined,
     );
 
-  const isPending =
+  const isLoading =
     loadingStatus === INSTANCE_LOADING_STATE.PENDING ||
     isFetching ||
     (!eligibleMethods && !error) ||
@@ -215,7 +232,7 @@ export function useBraintreeEligibleMethods({
 
   return {
     eligibleMethods,
-    isPending,
+    isLoading,
     error,
   };
 }

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -231,6 +231,7 @@ export function useBraintreeEligibleMethods(
       !eligiblePaymentMethods ||
       isStaleData);
 
+  // dropping in a placeholder commit
   // Provider-level failures (e.g. the checkout instance failed to initialize)
   // are surfaced in their own return and labeled, distinct from fetch-level
   // errors, so the developer can tell which layer failed — rather than merging

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -234,7 +234,7 @@ export function useBraintreeEligibleMethods(
   // Provider-level failures (e.g. the checkout instance failed to initialize)
   // are surfaced in their own return and labeled, distinct from fetch-level
   // errors, so the developer can tell which layer failed — rather than merging
-  // both into a single error. Mirrors useEligibleMethods.
+  // both into a single error.
   if (contextError) {
     return {
       eligiblePaymentMethods,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -1,10 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 
 import { useBraintreePayPal } from "./useBraintreePayPal";
+import { useBraintreePayPalDispatch } from "./useBraintreePayPalDispatch";
 import { useIsMountedRef } from "../useIsMounted";
 import { useError } from "../useError";
-import { useDeepCompareMemoize } from "../../utils";
-import { INSTANCE_LOADING_STATE } from "../../types/ProviderEnums";
+import { deepEqual, useDeepCompareMemoize } from "../../utils";
+import {
+  BRAINTREE_DISPATCH_ACTION,
+  INSTANCE_LOADING_STATE,
+} from "../../types/ProviderEnums";
 
 import type {
   BraintreeEligibilityResult,
@@ -24,15 +28,19 @@ export interface UseBraintreeEligibleMethodsReturn {
  * Hook for fetching Braintree PayPal eligibility for given checkout options.
  *
  * Calls {@link https://braintree.github.io/braintree-web/current/PayPalCheckoutV6.html#findEligibleMethods | BraintreePayPalCheckoutInstance.findEligibleMethods}
- * on the shared instance from {@link useBraintreePayPal} and re-fetches when the
- * options change. Use to gate rendering of buttons (e.g. Pay Later) on eligibility.
+ * on the shared instance from {@link useBraintreePayPal} and stores the result
+ * in the `BraintreePayPalProvider` context. The fetch is deduplicated by
+ * `(instance, options)` so that mounting this hook in multiple components, or
+ * re-mounting it with the same options, will reuse the cached result instead
+ * of firing a new request. The hook re-fetches when the options change.
  *
  * `isPending` is true while the provider's checkout instance is initializing
- * OR while eligibility is being fetched.
+ * OR while eligibility is being fetched OR while the cached eligibility was
+ * fetched with different options than the ones currently requested.
  *
  * @example
  * function Checkout() {
- *   const { eligibility, isPending, error } = useBraintreeEligibleMethods({
+ *   const { eligibleMethods, isPending, error } = useBraintreeEligibleMethods({
  *     amount: "10.00",
  *     currency: "USD",
  *     countryCode: "US",
@@ -44,8 +52,8 @@ export interface UseBraintreeEligibleMethodsReturn {
  *
  *   return (
  *     <>
- *       {eligibility?.paypal && <BraintreePayPalOneTimePaymentButton ... />}
- *       {eligibility?.paylater && <PayPalPayLaterButton ... />}
+ *       {eligibleMethods?.paypal && <BraintreePayPalOneTimePaymentButton ... />}
+ *       {eligibleMethods?.paylater && <PayPalPayLaterButton ... />}
  *     </>
  *   );
  * }
@@ -56,13 +64,24 @@ export function useBraintreeEligibleMethods({
   countryCode,
   paymentFlow,
 }: UseBraintreeEligibleMethodsProps): UseBraintreeEligibleMethodsReturn {
-  const { braintreePayPalCheckoutInstance, loadingStatus } =
-    useBraintreePayPal();
+  const {
+    braintreePayPalCheckoutInstance,
+    eligibleMethods,
+    eligibleMethodsPayload,
+    loadingStatus,
+  } = useBraintreePayPal();
+  const dispatch = useBraintreePayPalDispatch();
   const isMountedRef = useIsMountedRef();
   const [error, setError] = useError();
-  const [eligibleMethods, setEligibleMethods] =
-    useState<BraintreeEligibilityResult | null>(null);
   const [isFetching, setIsFetching] = useState(false);
+
+  // Refs let the effect see the latest context-cached eligibility without
+  // adding it to the dep array (which would re-run the effect every time
+  // *we* dispatch SET_ELIGIBILITY and re-trigger the fetch).
+  const eligibleMethodsRef = useRef(eligibleMethods);
+  const eligibleMethodsPayloadRef = useRef(eligibleMethodsPayload);
+  eligibleMethodsRef.current = eligibleMethods;
+  eligibleMethodsPayloadRef.current = eligibleMethodsPayload;
 
   const memoizedOptions = useDeepCompareMemoize({
     amount,
@@ -70,6 +89,12 @@ export function useBraintreeEligibleMethods({
     countryCode,
     paymentFlow,
   });
+
+  // Track what we've fetched (instance + payload combo) to prevent duplicate fetches
+  const lastFetchRef = useRef<{
+    instance: typeof braintreePayPalCheckoutInstance;
+    payload: typeof memoizedOptions;
+  } | null>(null);
 
   // Prevents retrying with a checkout instance whose findEligibleMethods has already failed
   const failedInstanceRef = useRef<unknown>(null);
@@ -87,9 +112,38 @@ export function useBraintreeEligibleMethods({
       return;
     }
 
+    const hasFetchedThisConfig =
+      lastFetchRef.current?.instance === braintreePayPalCheckoutInstance &&
+      lastFetchRef.current?.payload === memoizedOptions;
+
+    if (hasFetchedThisConfig) {
+      return;
+    }
+
+    // Another hook instance (or earlier mount) may have already populated
+    // eligibility on context with a deep-equal payload. If so, claim it as
+    // ours and skip the network call. Use deepEqual instead of === because
+    // separate hook mounts will memoize different references for the same
+    // option values.
+    if (
+      eligibleMethodsRef.current &&
+      lastFetchRef.current === null &&
+      deepEqual(eligibleMethodsPayloadRef.current, memoizedOptions)
+    ) {
+      lastFetchRef.current = {
+        instance: braintreePayPalCheckoutInstance,
+        payload: memoizedOptions,
+      };
+      return;
+    }
+
+    lastFetchRef.current = {
+      instance: braintreePayPalCheckoutInstance,
+      payload: memoizedOptions,
+    };
+
     let isSubscribed = true;
     setIsFetching(true);
-    setEligibleMethods(null);
     setError(null);
 
     braintreePayPalCheckoutInstance
@@ -98,7 +152,13 @@ export function useBraintreeEligibleMethods({
         if (!isSubscribed || !isMountedRef.current) {
           return;
         }
-        setEligibleMethods(result);
+        dispatch({
+          type: BRAINTREE_DISPATCH_ACTION.SET_ELIGIBILITY,
+          value: {
+            eligibleMethods: result,
+            payload: memoizedOptions,
+          },
+        });
       })
       .catch((err: unknown) => {
         if (!isSubscribed || !isMountedRef.current) {
@@ -120,12 +180,26 @@ export function useBraintreeEligibleMethods({
   }, [
     braintreePayPalCheckoutInstance,
     memoizedOptions,
+    dispatch,
     setError,
     isMountedRef,
   ]);
 
+  // Cached eligibility is stale if it was fetched with a different payload than
+  // the one currently requested. Normalize null/undefined so the deepEqual
+  // doesn't treat "no stored payload" as different from "no provided payload".
+  const isStaleData =
+    !!eligibleMethods &&
+    !deepEqual(
+      eligibleMethodsPayload ?? undefined,
+      memoizedOptions ?? undefined,
+    );
+
   const isPending =
-    loadingStatus === INSTANCE_LOADING_STATE.PENDING || isFetching;
+    loadingStatus === INSTANCE_LOADING_STATE.PENDING ||
+    isFetching ||
+    (!eligibleMethods && !error) ||
+    isStaleData;
 
   return {
     eligibleMethods,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -231,7 +231,6 @@ export function useBraintreeEligibleMethods(
       !eligiblePaymentMethods ||
       isStaleData);
 
-  // dropping in a placeholder commit
   // Provider-level failures (e.g. the checkout instance failed to initialize)
   // are surfaced in their own return and labeled, distinct from fetch-level
   // errors, so the developer can tell which layer failed — rather than merging

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -96,19 +96,28 @@ export function useBraintreeEligibleMethods({
     payload: typeof memoizedOptions;
   } | null>(null);
 
-  // Prevents retrying with a checkout instance whose findEligibleMethods has already failed
-  const failedInstanceRef = useRef<unknown>(null);
+  // Prevents auto-retrying the exact (instance, payload) call that just failed.
+  // Keyed on payload too so that changing options on the same failed instance
+  // is still allowed to retry — a failed request shouldn't pin the hook in an
+  // error state forever when the consumer corrects the input.
+  const failedFetchRef = useRef<{
+    instance: typeof braintreePayPalCheckoutInstance;
+    payload: typeof memoizedOptions;
+  } | null>(null);
 
   useEffect(() => {
-    if (failedInstanceRef.current !== braintreePayPalCheckoutInstance) {
-      failedInstanceRef.current = null;
+    if (failedFetchRef.current?.instance !== braintreePayPalCheckoutInstance) {
+      failedFetchRef.current = null;
     }
 
     if (!braintreePayPalCheckoutInstance) {
       return;
     }
 
-    if (failedInstanceRef.current === braintreePayPalCheckoutInstance) {
+    if (
+      failedFetchRef.current?.instance === braintreePayPalCheckoutInstance &&
+      failedFetchRef.current?.payload === memoizedOptions
+    ) {
       return;
     }
 
@@ -164,7 +173,10 @@ export function useBraintreeEligibleMethods({
         if (!isSubscribed || !isMountedRef.current) {
           return;
         }
-        failedInstanceRef.current = braintreePayPalCheckoutInstance;
+        failedFetchRef.current = {
+          instance: braintreePayPalCheckoutInstance,
+          payload: memoizedOptions,
+        };
         setError(err);
       })
       .finally(() => {

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -34,20 +34,21 @@ export interface UseBraintreeEligibleMethodsReturn {
  * re-mounting it with the same options, will reuse the cached result instead
  * of firing a new request. The hook re-fetches when the options change.
  *
- * `isPending` is true while the provider's checkout instance is initializing
+ * `isLoading` is true while the provider's checkout instance is initializing
  * OR while eligibility is being fetched OR while the cached eligibility was
- * fetched with different options than the ones currently requested.
+ * fetched with different options than the ones currently requested. It is
+ * forced false whenever an error (fetch- or provider-level) is present.
  *
  * @example
  * function Checkout() {
- *   const { eligibleMethods, isPending, error } = useBraintreeEligibleMethods({
+ *   const { eligibleMethods, isLoading, error } = useBraintreeEligibleMethods({
  *     amount: "10.00",
  *     currency: "USD",
  *     countryCode: "US",
  *     paymentFlow: "ONE_TIME_PAYMENT",
  *   });
  *
- *   if (isPending) return <Spinner />;
+ *   if (isLoading) return <Spinner />;
  *   if (error) return <ErrorMessage error={error} />;
  *
  *   return (
@@ -58,17 +59,15 @@ export interface UseBraintreeEligibleMethodsReturn {
  *   );
  * }
  */
-export function useBraintreeEligibleMethods({
-  amount,
-  currency,
-  countryCode,
-  paymentFlow,
-}: UseBraintreeEligibleMethodsProps): UseBraintreeEligibleMethodsReturn {
+export function useBraintreeEligibleMethods(
+  options: UseBraintreeEligibleMethodsProps,
+): UseBraintreeEligibleMethodsReturn {
   const {
     braintreePayPalCheckoutInstance,
     eligibleMethods,
     eligibleMethodsPayload,
     loadingStatus,
+    error: contextError,
   } = useBraintreePayPal();
   const dispatch = useBraintreePayPalDispatch();
   const isMountedRef = useIsMountedRef();
@@ -83,12 +82,11 @@ export function useBraintreeEligibleMethods({
   eligibleMethodsRef.current = eligibleMethods;
   eligibleMethodsPayloadRef.current = eligibleMethodsPayload;
 
-  const memoizedOptions = useDeepCompareMemoize({
-    amount,
-    currency,
-    countryCode,
-    paymentFlow,
-  });
+  // Memoize the whole options object so every field the caller passes is
+  // forwarded to findEligibleMethods. Don't destructure-and-rebuild a fixed
+  // set of keys here — that would silently drop any field later added to
+  // BraintreeFindEligibleMethodsOptions.
+  const memoizedOptions = useDeepCompareMemoize(options);
 
   // Track what we've fetched (instance + payload combo) to prevent duplicate fetches
   const lastFetchRef = useRef<{
@@ -197,7 +195,7 @@ export function useBraintreeEligibleMethods({
       // StrictMode mount/cleanup/mount cycle), clear the dedup marker so the
       // remount re-fetches. Without this, the remount sees lastFetchRef already
       // matching (instance, payload) and skips, while the only in-flight fetch
-      // was just aborted — leaving the hook stuck with isPending=true forever.
+      // was just aborted — leaving the hook stuck with isLoading=true forever.
       if (
         !didSettle &&
         lastFetchRef.current?.instance === braintreePayPalCheckoutInstance &&
@@ -225,10 +223,23 @@ export function useBraintreeEligibleMethods({
     );
 
   const isLoading =
-    loadingStatus === INSTANCE_LOADING_STATE.PENDING ||
-    isFetching ||
-    (!eligibleMethods && !error) ||
-    isStaleData;
+    !error &&
+    (loadingStatus === INSTANCE_LOADING_STATE.PENDING ||
+      isFetching ||
+      !eligibleMethods ||
+      isStaleData);
+
+  // Provider-level failures (e.g. the checkout instance failed to initialize)
+  // are surfaced in their own return and labeled, distinct from fetch-level
+  // errors, so the developer can tell which layer failed — rather than merging
+  // both into a single error. Mirrors useEligibleMethods.
+  if (contextError) {
+    return {
+      eligibleMethods,
+      isLoading: false,
+      error: new Error(`Braintree PayPal context error: ${contextError}`),
+    };
+  }
 
   return {
     eligibleMethods,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from "react";
+
+import { useBraintreePayPal } from "./useBraintreePayPal";
+import { useIsMountedRef } from "../useIsMounted";
+import { useError } from "../useError";
+import { useDeepCompareMemoize } from "../../utils";
+import { INSTANCE_LOADING_STATE } from "../../types/ProviderEnums";
+
+import type {
+  BraintreeEligibilityResult,
+  BraintreeFindEligibleMethodsOptions,
+} from "../../types/braintree";
+
+export type UseBraintreeEligibleMethodsProps =
+  BraintreeFindEligibleMethodsOptions;
+
+export interface UseBraintreeEligibleMethodsReturn {
+  eligibleMethods: BraintreeEligibilityResult | null;
+  isPending: boolean;
+  error: Error | null;
+}
+
+/**
+ * Hook for fetching Braintree PayPal eligibility for given checkout options.
+ *
+ * Calls {@link https://braintree.github.io/braintree-web/current/PayPalCheckoutV6.html#findEligibleMethods | BraintreePayPalCheckoutInstance.findEligibleMethods}
+ * on the shared instance from {@link useBraintreePayPal} and re-fetches when the
+ * options change. Use to gate rendering of buttons (e.g. Pay Later) on eligibility.
+ *
+ * `isPending` is true while the provider's checkout instance is initializing
+ * OR while eligibility is being fetched.
+ *
+ * @example
+ * function Checkout() {
+ *   const { eligibility, isPending, error } = useBraintreeEligibleMethods({
+ *     amount: "10.00",
+ *     currency: "USD",
+ *     countryCode: "US",
+ *     paymentFlow: "ONE_TIME_PAYMENT",
+ *   });
+ *
+ *   if (isPending) return <Spinner />;
+ *   if (error) return <ErrorMessage error={error} />;
+ *
+ *   return (
+ *     <>
+ *       {eligibility?.paypal && <BraintreePayPalOneTimePaymentButton ... />}
+ *       {eligibility?.paylater && <PayPalPayLaterButton ... />}
+ *     </>
+ *   );
+ * }
+ */
+export function useBraintreeEligibleMethods({
+  amount,
+  currency,
+  countryCode,
+  paymentFlow,
+}: UseBraintreeEligibleMethodsProps): UseBraintreeEligibleMethodsReturn {
+  const { braintreePayPalCheckoutInstance, loadingStatus } =
+    useBraintreePayPal();
+  const isMountedRef = useIsMountedRef();
+  const [error, setError] = useError();
+  const [eligibleMethods, setEligibleMethods] =
+    useState<BraintreeEligibilityResult | null>(null);
+  const [isFetching, setIsFetching] = useState(false);
+
+  const memoizedOptions = useDeepCompareMemoize({
+    amount,
+    currency,
+    countryCode,
+    paymentFlow,
+  });
+
+  // Prevents retrying with a checkout instance whose findEligibleMethods has already failed
+  const failedInstanceRef = useRef<unknown>(null);
+
+  useEffect(() => {
+    if (failedInstanceRef.current !== braintreePayPalCheckoutInstance) {
+      failedInstanceRef.current = null;
+    }
+
+    if (!braintreePayPalCheckoutInstance) {
+      return;
+    }
+
+    if (failedInstanceRef.current === braintreePayPalCheckoutInstance) {
+      return;
+    }
+
+    let isSubscribed = true;
+    setIsFetching(true);
+    setEligibleMethods(null);
+    setError(null);
+
+    braintreePayPalCheckoutInstance
+      .findEligibleMethods(memoizedOptions)
+      .then((result) => {
+        if (!isSubscribed || !isMountedRef.current) {
+          return;
+        }
+        setEligibleMethods(result);
+      })
+      .catch((err: unknown) => {
+        if (!isSubscribed || !isMountedRef.current) {
+          return;
+        }
+        failedInstanceRef.current = braintreePayPalCheckoutInstance;
+        setError(err);
+      })
+      .finally(() => {
+        if (!isSubscribed || !isMountedRef.current) {
+          return;
+        }
+        setIsFetching(false);
+      });
+
+    return () => {
+      isSubscribed = false;
+    };
+  }, [
+    braintreePayPalCheckoutInstance,
+    memoizedOptions,
+    setError,
+    isMountedRef,
+  ]);
+
+  const isPending =
+    loadingStatus === INSTANCE_LOADING_STATE.PENDING || isFetching;
+
+  return {
+    eligibleMethods,
+    isPending,
+    error,
+  };
+}

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreeEligibleMethods.ts
@@ -11,7 +11,7 @@ import {
 } from "../../types/ProviderEnums";
 
 import type {
-  BraintreeEligiblePaymentMethodsOutput,
+  BraintreeEligibilityResult,
   BraintreeFindEligibleMethodsOptions,
 } from "../../types/braintree";
 
@@ -19,7 +19,7 @@ export type UseBraintreeEligibleMethodsProps =
   BraintreeFindEligibleMethodsOptions;
 
 export interface UseBraintreeEligibleMethodsReturn {
-  eligiblePaymentMethods: BraintreeEligiblePaymentMethodsOutput | null;
+  eligiblePaymentMethods: BraintreeEligibilityResult | null;
   isLoading: boolean;
   error: Error | null;
 }

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPal.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPal.ts
@@ -11,9 +11,9 @@ import type { BraintreePayPalProvider } from "../../components/Braintree/Braintr
  * The returned state includes:
  * - `braintreePayPalCheckoutInstance` — the Braintree PayPal Checkout V6 instance
  *   used for `tokenizePayment()`, `findEligibleMethods()`, and `updatePayment()`
- * - `eligibleMethods` — eligibility result cached by `useBraintreeEligibleMethods`,
+ * - `eligiblePaymentMethods` — eligibility result cached by `useBraintreeEligibleMethods`,
  *   or `null` if it has not been fetched yet
- * - `eligibleMethodsPayload` — the options the cached `eligibleMethods` was
+ * - `eligiblePaymentMethodsPayload` — the options the cached `eligiblePaymentMethods` was
  *   fetched with, used to detect stale data
  * - `loadingStatus` — `"pending"`, `"resolved"`, or `"rejected"`
  * - `error` — any initialization error

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPal.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPal.ts
@@ -11,6 +11,10 @@ import type { BraintreePayPalProvider } from "../../components/Braintree/Braintr
  * The returned state includes:
  * - `braintreePayPalCheckoutInstance` — the Braintree PayPal Checkout V6 instance
  *   used for `tokenizePayment()`, `findEligibleMethods()`, and `updatePayment()`
+ * - `eligibleMethods` — eligibility result cached by `useBraintreeEligibleMethods`,
+ *   or `null` if it has not been fetched yet
+ * - `eligibleMethodsPayload` — the options the cached `eligibleMethods` was
+ *   fetched with, used to detect stale data
  * - `loadingStatus` — `"pending"`, `"resolved"`, or `"rejected"`
  * - `error` — any initialization error
  * - `isHydrated` — `false` during SSR, `true` after client hydration

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.test.ts
@@ -35,8 +35,8 @@ const createMockCheckoutInstance = (session = createMockSession()) => ({
 
 const defaultBraintreeState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
-  eligibleMethods: null,
-  eligibleMethodsPayload: null,
+  eligiblePaymentMethods: null,
+  eligiblePaymentMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
   error: null,
   isHydrated: true,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.test.ts
@@ -107,11 +107,33 @@ describe("useBraintreeBillingAgreementSession", () => {
       expectCurrentErrorValue(error);
 
       expect(error).toEqual(
-        new Error("Braintree checkout instance not available"),
+        new Error(
+          "Braintree Billing Agreement checkout instance not available",
+        ),
       );
       expect(
         mockCheckoutInstance.createBillingAgreementSession,
       ).not.toHaveBeenCalled();
+    });
+
+    test("should surface provider error as the cause when the provider failed to initialize", () => {
+      const providerError = new Error("init failed");
+      mockBraintreeContext({
+        loadingStatus: INSTANCE_LOADING_STATE.REJECTED,
+        error: providerError,
+      });
+
+      const {
+        result: {
+          current: { error },
+        },
+      } = renderHook(() =>
+        useBraintreePayPalBillingAgreementSession(defaultProps),
+      );
+
+      expectCurrentErrorValue(error);
+      expect(error?.message).toBe("Braintree provider error: init failed");
+      expect((error as Error & { cause?: unknown })?.cause).toBe(providerError);
     });
 
     test.each([
@@ -181,7 +203,9 @@ describe("useBraintreeBillingAgreementSession", () => {
 
       expectCurrentErrorValue(result.current.error);
       expect(result.current.error).toEqual(
-        new Error("Braintree checkout instance not available"),
+        new Error(
+          "Braintree Billing Agreement checkout instance not available",
+        ),
       );
 
       const newMockSession = createMockSession();

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.test.ts
@@ -35,6 +35,8 @@ const createMockCheckoutInstance = (session = createMockSession()) => ({
 
 const defaultBraintreeState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
+  eligibleMethods: null,
+  eligibleMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
   error: null,
   isHydrated: true,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.ts
@@ -34,7 +34,7 @@ export interface UseBraintreePayPalBillingAgreementSessionReturn {
  * instance is still being initialized. Buttons should wait to render until `isPending`
  * is false.
  *
- * For a ready-to-use component that wraps this hook, see {@link BraintreePayPalBillingAgreementButton}.
+ * For a ready-to-use component that wraps this hook, see `BraintreePayPalBillingAgreementButton`.
  *
  * @returns Object with: `error` (any session error), `isPending` (checkout instance loading), `handleClick` (starts session)
  *

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalBillingAgreementSession.ts
@@ -113,8 +113,11 @@ export function useBraintreePayPalBillingAgreementSession({
   planMetadata,
   shippingAddressOverride,
 }: UseBraintreePayPalBillingAgreementSessionProps): UseBraintreePayPalBillingAgreementSessionReturn {
-  const { braintreePayPalCheckoutInstance, loadingStatus } =
-    useBraintreePayPal();
+  const {
+    braintreePayPalCheckoutInstance,
+    loadingStatus,
+    error: contextError,
+  } = useBraintreePayPal();
   const isMountedRef = useIsMountedRef();
   const sessionRef = useRef<BraintreePaymentSession | null>(null);
   const [error, setError] = useError();
@@ -142,9 +145,17 @@ export function useBraintreePayPalBillingAgreementSession({
     if (braintreePayPalCheckoutInstance) {
       setError(null);
     } else if (loadingStatus !== INSTANCE_LOADING_STATE.PENDING) {
-      setError(new Error("Braintree checkout instance not available"));
+      setError(
+        contextError
+          ? new Error(`Braintree provider error: ${contextError.message}`, {
+              cause: contextError,
+            })
+          : new Error(
+              "Braintree Billing Agreement checkout instance not available",
+            ),
+      );
     }
-  }, [braintreePayPalCheckoutInstance, setError, loadingStatus]);
+  }, [braintreePayPalCheckoutInstance, setError, loadingStatus, contextError]);
 
   useEffect(() => {
     if (!braintreePayPalCheckoutInstance) {

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.test.ts
@@ -35,8 +35,8 @@ const createMockCheckoutInstance = (session = createMockSession()) => ({
 
 const defaultBraintreeState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
-  eligibleMethods: null,
-  eligibleMethodsPayload: null,
+  eligiblePaymentMethods: null,
+  eligiblePaymentMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
   error: null,
   isHydrated: true,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.test.ts
@@ -108,11 +108,33 @@ describe("useBraintreePayPalCheckoutWithVaultSession", () => {
       expectCurrentErrorValue(error);
 
       expect(error).toEqual(
-        new Error("Braintree checkout instance not available"),
+        new Error(
+          "Braintree Checkout With Vault checkout instance not available",
+        ),
       );
       expect(
         mockCheckoutInstance.createCheckoutWithVaultSession,
       ).not.toHaveBeenCalled();
+    });
+
+    test("should surface provider error as the cause when the provider failed to initialize", () => {
+      const providerError = new Error("init failed");
+      mockBraintreeContext({
+        loadingStatus: INSTANCE_LOADING_STATE.REJECTED,
+        error: providerError,
+      });
+
+      const {
+        result: {
+          current: { error },
+        },
+      } = renderHook(() =>
+        useBraintreePayPalCheckoutWithVaultSession(defaultProps),
+      );
+
+      expectCurrentErrorValue(error);
+      expect(error?.message).toBe("Braintree provider error: init failed");
+      expect((error as Error & { cause?: unknown })?.cause).toBe(providerError);
     });
 
     test.each([
@@ -182,7 +204,9 @@ describe("useBraintreePayPalCheckoutWithVaultSession", () => {
 
       expectCurrentErrorValue(result.current.error);
       expect(result.current.error).toEqual(
-        new Error("Braintree checkout instance not available"),
+        new Error(
+          "Braintree Checkout With Vault checkout instance not available",
+        ),
       );
 
       const newMockSession = createMockSession();

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.test.ts
@@ -35,6 +35,8 @@ const createMockCheckoutInstance = (session = createMockSession()) => ({
 
 const defaultBraintreeState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
+  eligibleMethods: null,
+  eligibleMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
   error: null,
   isHydrated: true,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.ts
@@ -75,6 +75,7 @@ export function useBraintreePayPalCheckoutWithVaultSession({
   cancelUrl,
   displayName,
   presentationMode,
+  shippingCallbackUrl,
   // Object/array data options (require deep comparison)
   billingAgreementDetails,
   lineItems,
@@ -148,6 +149,7 @@ export function useBraintreePayPalCheckoutWithVaultSession({
           cancelUrl,
           displayName,
           presentationMode,
+          shippingCallbackUrl,
           billingAgreementDetails: memoizedBillingAgreementDetails,
           lineItems: memoizedLineItems,
           shippingOptions: memoizedShippingOptions,
@@ -181,6 +183,7 @@ export function useBraintreePayPalCheckoutWithVaultSession({
     cancelUrl,
     displayName,
     presentationMode,
+    shippingCallbackUrl,
     memoizedBillingAgreementDetails,
     memoizedLineItems,
     memoizedShippingOptions,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession.ts
@@ -81,8 +81,11 @@ export function useBraintreePayPalCheckoutWithVaultSession({
   shippingOptions,
   amountBreakdown,
 }: UseBraintreePayPalCheckoutWithVaultSessionProps): UseBraintreePayPalCheckoutWithVaultSessionReturn {
-  const { braintreePayPalCheckoutInstance, loadingStatus } =
-    useBraintreePayPal();
+  const {
+    braintreePayPalCheckoutInstance,
+    loadingStatus,
+    error: contextError,
+  } = useBraintreePayPal();
   const isMountedRef = useIsMountedRef();
   const sessionRef = useRef<BraintreePaymentSession | null>(null);
   const [error, setError] = useError();
@@ -116,9 +119,17 @@ export function useBraintreePayPalCheckoutWithVaultSession({
     if (braintreePayPalCheckoutInstance) {
       setError(null);
     } else if (loadingStatus !== INSTANCE_LOADING_STATE.PENDING) {
-      setError(new Error("Braintree checkout instance not available"));
+      setError(
+        contextError
+          ? new Error(`Braintree provider error: ${contextError.message}`, {
+              cause: contextError,
+            })
+          : new Error(
+              "Braintree Checkout With Vault checkout instance not available",
+            ),
+      );
     }
-  }, [braintreePayPalCheckoutInstance, setError, loadingStatus]);
+  }, [braintreePayPalCheckoutInstance, setError, loadingStatus, contextError]);
 
   useEffect(() => {
     if (!braintreePayPalCheckoutInstance) {

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalDispatch.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalDispatch.ts
@@ -1,0 +1,29 @@
+import { useContext, Dispatch } from "react";
+
+import { BraintreeDispatchContext } from "../../context/BraintreeDispatchContext";
+
+import type { BraintreeAction } from "../../context/BraintreePayPalContext";
+
+/**
+ * Internal hook for dispatching Braintree PayPal state updates.
+ *
+ * @remarks
+ * This is an INTERNAL API and should not be used directly by external consumers.
+ * Only use this in internal hooks that need to update the Braintree PayPal
+ * context state.
+ *
+ * @internal
+ *
+ * @returns Dispatch function for Braintree PayPal actions
+ */
+export function useBraintreePayPalDispatch(): Dispatch<BraintreeAction> {
+  const dispatch = useContext(BraintreeDispatchContext);
+
+  if (dispatch === null) {
+    throw new Error(
+      "useBraintreePayPalDispatch must be used within a BraintreePayPalProvider",
+    );
+  }
+
+  return dispatch;
+}

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.test.ts
@@ -36,6 +36,8 @@ const createMockCheckoutInstance = (session = createMockSession()) => ({
 
 const defaultBraintreeState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
+  eligibleMethods: null,
+  eligibleMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
   error: null,
   isHydrated: true,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.test.ts
@@ -109,11 +109,33 @@ describe("useBraintreePayPalOneTimePaymentSession", () => {
       expectCurrentErrorValue(error);
 
       expect(error).toEqual(
-        new Error("Braintree checkout instance not available"),
+        new Error("Braintree One-Time Payment checkout instance not available"),
       );
       expect(
         mockCheckoutInstance.createOneTimePaymentSession,
       ).not.toHaveBeenCalled();
+    });
+
+    test("should surface provider error as the cause when the provider failed to initialize", () => {
+      const providerError = new Error("init failed");
+      mockBraintreeContext({
+        loadingStatus: INSTANCE_LOADING_STATE.REJECTED,
+        error: providerError,
+      });
+
+      const {
+        result: {
+          current: { error: hookError },
+        },
+      } = renderHook(() =>
+        useBraintreePayPalOneTimePaymentSession(defaultProps),
+      );
+
+      expectCurrentErrorValue(hookError);
+      expect(hookError?.message).toBe("Braintree provider error: init failed");
+      expect((hookError as Error & { cause?: unknown })?.cause).toBe(
+        providerError,
+      );
     });
 
     test.each([
@@ -184,7 +206,7 @@ describe("useBraintreePayPalOneTimePaymentSession", () => {
 
       expectCurrentErrorValue(result.current.error);
       expect(result.current.error).toEqual(
-        new Error("Braintree checkout instance not available"),
+        new Error("Braintree One-Time Payment checkout instance not available"),
       );
 
       // Second render: instance becomes available

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.test.ts
@@ -36,8 +36,8 @@ const createMockCheckoutInstance = (session = createMockSession()) => ({
 
 const defaultBraintreeState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
-  eligibleMethods: null,
-  eligibleMethodsPayload: null,
+  eligiblePaymentMethods: null,
+  eligiblePaymentMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
   error: null,
   isHydrated: true,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.ts
@@ -93,8 +93,11 @@ export function useBraintreePayPalOneTimePaymentSession({
   shippingOptions,
   amountBreakdown,
 }: UseBraintreePayPalOneTimePaymentSessionProps): UseBraintreePayPalOneTimePaymentSessionReturn {
-  const { braintreePayPalCheckoutInstance, loadingStatus } =
-    useBraintreePayPal();
+  const {
+    braintreePayPalCheckoutInstance,
+    loadingStatus,
+    error: contextError,
+  } = useBraintreePayPal();
   const isMountedRef = useIsMountedRef();
   const sessionRef = useRef<BraintreePaymentSession | null>(null);
   const [error, setError] = useError();
@@ -127,9 +130,17 @@ export function useBraintreePayPalOneTimePaymentSession({
     if (braintreePayPalCheckoutInstance) {
       setError(null);
     } else if (loadingStatus !== INSTANCE_LOADING_STATE.PENDING) {
-      setError(new Error("Braintree checkout instance not available"));
+      setError(
+        contextError
+          ? new Error(`Braintree provider error: ${contextError.message}`, {
+              cause: contextError,
+            })
+          : new Error(
+              "Braintree One-Time Payment checkout instance not available",
+            ),
+      );
     }
-  }, [braintreePayPalCheckoutInstance, setError, loadingStatus]);
+  }, [braintreePayPalCheckoutInstance, setError, loadingStatus, contextError]);
 
   // Create and manage session lifecycle
   useEffect(() => {

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.ts
@@ -88,10 +88,12 @@ export function useBraintreePayPalOneTimePaymentSession({
   cancelUrl,
   displayName,
   presentationMode,
+  shippingCallbackUrl,
   // Object/array data options (require deep comparison)
   lineItems,
   shippingOptions,
   amountBreakdown,
+  shippingAddressOverride,
 }: UseBraintreePayPalOneTimePaymentSessionProps): UseBraintreePayPalOneTimePaymentSessionReturn {
   const {
     braintreePayPalCheckoutInstance,
@@ -117,6 +119,9 @@ export function useBraintreePayPalOneTimePaymentSession({
   const memoizedLineItems = useDeepCompareMemoize(lineItems);
   const memoizedShippingOptions = useDeepCompareMemoize(shippingOptions);
   const memoizedAmountBreakdown = useDeepCompareMemoize(amountBreakdown);
+  const memoizedShippingAddressOverride = useDeepCompareMemoize(
+    shippingAddressOverride,
+  );
 
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
@@ -161,9 +166,11 @@ export function useBraintreePayPalOneTimePaymentSession({
           cancelUrl,
           displayName,
           presentationMode,
+          shippingCallbackUrl,
           lineItems: memoizedLineItems,
           shippingOptions: memoizedShippingOptions,
           amountBreakdown: memoizedAmountBreakdown,
+          shippingAddressOverride: memoizedShippingAddressOverride,
           ...proxyCallbacks,
         }),
       failedSdkRef: failedInstanceRef,
@@ -194,9 +201,11 @@ export function useBraintreePayPalOneTimePaymentSession({
     cancelUrl,
     displayName,
     presentationMode,
+    shippingCallbackUrl,
     memoizedLineItems,
     memoizedShippingOptions,
     memoizedAmountBreakdown,
+    memoizedShippingAddressOverride,
     proxyCallbacks,
     setError,
   ]);

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalOneTimePaymentSession.ts
@@ -31,7 +31,7 @@ export interface UseBraintreePayPalOneTimePaymentSessionReturn {
  * instance is still being initialized. Buttons should wait to render until `isPending`
  * is false.
  *
- * For a ready-to-use component that wraps this hook, see {@link BraintreePayPalOneTimePaymentButton}.
+ * For a ready-to-use component that wraps this hook, see `BraintreePayPalOneTimePaymentButton`.
  *
  * @returns Object with: `error` (any session error), `isPending` (checkout instance loading), `handleClick` (starts session)
  *

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.test.ts
@@ -1,0 +1,540 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+
+import { expectCurrentErrorValue } from "../useErrorTestUtil";
+import { useBraintreePayPalPayLaterSession } from "./useBraintreePayPalPayLaterSession";
+import { useBraintreePayPal } from "./useBraintreePayPal";
+import { useProxyProps } from "../../utils";
+import { INSTANCE_LOADING_STATE } from "../../types/ProviderEnums";
+
+import type { BraintreePaymentSession } from "../../types/braintree";
+import type { BraintreePayPalState } from "../../context/BraintreePayPalContext";
+import type { UseBraintreePayPalPayLaterSessionProps } from "./useBraintreePayPalPayLaterSession";
+
+// Must declare jest.mock at top level for hoisting
+jest.mock("./useBraintreePayPal");
+
+jest.mock("../../utils", () => ({
+  ...jest.requireActual("../../utils"),
+  useProxyProps: jest.fn(),
+}));
+
+const mockUseBraintreePayPal = useBraintreePayPal as jest.MockedFunction<
+  typeof useBraintreePayPal
+>;
+
+const mockUseProxyProps = useProxyProps as jest.MockedFunction<
+  typeof useProxyProps
+>;
+
+const createMockSession = (): BraintreePaymentSession => ({
+  start: jest.fn(),
+});
+
+const createMockCheckoutInstance = (session = createMockSession()) => ({
+  createPayLaterSession: jest.fn().mockReturnValue(session),
+});
+
+const defaultBraintreeState: BraintreePayPalState = {
+  braintreePayPalCheckoutInstance: null,
+  loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
+  error: null,
+  isHydrated: true,
+};
+
+function mockBraintreeContext(
+  overrides: Partial<
+    Omit<BraintreePayPalState, "braintreePayPalCheckoutInstance"> & {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      braintreePayPalCheckoutInstance?: any;
+    }
+  > = {},
+): void {
+  mockUseBraintreePayPal.mockReturnValue({
+    ...defaultBraintreeState,
+    ...overrides,
+  } as BraintreePayPalState);
+}
+
+function mockBraintreePending(): void {
+  mockBraintreeContext({
+    loadingStatus: INSTANCE_LOADING_STATE.PENDING,
+  });
+}
+
+function mockBraintreeRejected(): void {
+  mockBraintreeContext({
+    loadingStatus: INSTANCE_LOADING_STATE.REJECTED,
+  });
+}
+
+describe("useBraintreePayPalPayLaterSession", () => {
+  let mockSession: BraintreePaymentSession;
+  let mockCheckoutInstance: ReturnType<typeof createMockCheckoutInstance>;
+
+  const defaultProps: UseBraintreePayPalPayLaterSessionProps = {
+    amount: "10.00",
+    currency: "USD",
+    onApprove: jest.fn(),
+  };
+
+  beforeEach(() => {
+    mockUseProxyProps.mockImplementation((callbacks) => callbacks);
+
+    mockSession = createMockSession();
+    mockCheckoutInstance = createMockCheckoutInstance(mockSession);
+
+    mockBraintreeContext({
+      braintreePayPalCheckoutInstance: mockCheckoutInstance,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("initialization", () => {
+    test("should not create session when no checkout instance is available", () => {
+      mockBraintreeRejected();
+
+      const {
+        result: {
+          current: { error },
+        },
+      } = renderHook(() => useBraintreePayPalPayLaterSession(defaultProps));
+
+      expectCurrentErrorValue(error);
+
+      expect(error).toEqual(
+        new Error("Braintree checkout instance not available"),
+      );
+      expect(mockCheckoutInstance.createPayLaterSession).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      {
+        description: "Error object",
+        thrownError: new Error("Braintree initialization failed"),
+      },
+      {
+        description: "non-Error string",
+        thrownError: "String error message",
+      },
+    ])(
+      "should handle $description thrown by createPayLaterSession",
+      ({ thrownError }) => {
+        const mockCheckoutInstanceWithError = {
+          createPayLaterSession: jest.fn().mockImplementation(() => {
+            throw thrownError;
+          }),
+        };
+
+        mockBraintreeContext({
+          braintreePayPalCheckoutInstance: mockCheckoutInstanceWithError,
+        });
+
+        const {
+          result: {
+            current: { error },
+          },
+        } = renderHook(() => useBraintreePayPalPayLaterSession(defaultProps));
+
+        expectCurrentErrorValue(error);
+
+        expect(error?.message).toContain(
+          "Failed to create Braintree Pay Later session",
+        );
+        expect(error?.message).toContain(
+          "BraintreePayPalProvider is properly initialized",
+        );
+        expect((error as Error & { cause: typeof thrownError })?.cause).toBe(
+          thrownError,
+        );
+      },
+    );
+
+    test("should not error if there is no checkout instance but loading is still pending", () => {
+      mockBraintreePending();
+
+      const {
+        result: {
+          current: { error },
+        },
+      } = renderHook(() => useBraintreePayPalPayLaterSession(defaultProps));
+
+      expect(error).toBeNull();
+    });
+
+    test("should clear errors when checkout instance becomes available", () => {
+      // First render: no instance, REJECTED state
+      mockBraintreeRejected();
+
+      const { result, rerender } = renderHook(() =>
+        useBraintreePayPalPayLaterSession(defaultProps),
+      );
+
+      expectCurrentErrorValue(result.current.error);
+      expect(result.current.error).toEqual(
+        new Error("Braintree checkout instance not available"),
+      );
+
+      // Second render: instance becomes available
+      const newMockSession = createMockSession();
+      const newMockCheckoutInstance =
+        createMockCheckoutInstance(newMockSession);
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: newMockCheckoutInstance,
+      });
+
+      rerender();
+
+      expect(result.current.error).toBeNull();
+    });
+
+    test.each([
+      [INSTANCE_LOADING_STATE.PENDING, true],
+      [INSTANCE_LOADING_STATE.RESOLVED, false],
+      [INSTANCE_LOADING_STATE.REJECTED, false],
+    ])(
+      "should return isPending as %s when loadingStatus is %s",
+      (loadingStatus, expectedIsPending) => {
+        mockBraintreeContext({ loadingStatus });
+
+        const { result } = renderHook(() =>
+          useBraintreePayPalPayLaterSession(defaultProps),
+        );
+
+        expect(result.current.isPending).toBe(expectedIsPending);
+      },
+    );
+
+    test("should create a session with the correct options", () => {
+      const onApprove = jest.fn();
+      const onCancel = jest.fn();
+      const onComplete = jest.fn();
+      const onError = jest.fn();
+      const onShippingAddressChange = jest.fn();
+      const onShippingOptionsChange = jest.fn();
+
+      const props: UseBraintreePayPalPayLaterSessionProps = {
+        amount: "25.00",
+        currency: "EUR",
+        intent: "authorize",
+        userAuthenticationEmail: "test@example.com",
+        displayName: "Test Store",
+        presentationMode: "popup",
+        onApprove,
+        onCancel,
+        onComplete,
+        onError,
+        onShippingAddressChange,
+        onShippingOptionsChange,
+      };
+
+      renderHook(() => useBraintreePayPalPayLaterSession(props));
+
+      expect(mockCheckoutInstance.createPayLaterSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: "25.00",
+          currency: "EUR",
+          intent: "authorize",
+          userAuthenticationEmail: "test@example.com",
+          displayName: "Test Store",
+          presentationMode: "popup",
+          onApprove,
+          onCancel,
+          onComplete,
+          onError,
+          onShippingAddressChange,
+          onShippingOptionsChange,
+        }),
+      );
+    });
+
+    test("should forward callback invocations to the consumer", () => {
+      const onApprove = jest.fn();
+      const onCancel = jest.fn();
+      const onComplete = jest.fn();
+      const onError = jest.fn();
+
+      const props: UseBraintreePayPalPayLaterSessionProps = {
+        amount: "10.00",
+        currency: "USD",
+        onApprove,
+        onCancel,
+        onComplete,
+        onError,
+      };
+
+      renderHook(() => useBraintreePayPalPayLaterSession(props));
+
+      const createSessionCall =
+        mockCheckoutInstance.createPayLaterSession.mock.calls[0][0];
+
+      const mockApprovalData = {
+        payerId: "PAYER123",
+        orderId: "ORDER456",
+      };
+      createSessionCall.onApprove(mockApprovalData);
+      createSessionCall.onCancel();
+      createSessionCall.onComplete();
+      createSessionCall.onError(new Error("test error"));
+
+      expect(onApprove).toHaveBeenCalledWith(mockApprovalData);
+      expect(onCancel).toHaveBeenCalledWith();
+      expect(onComplete).toHaveBeenCalledWith();
+      expect(onError).toHaveBeenCalledWith(new Error("test error"));
+    });
+  });
+
+  describe("session lifecycle", () => {
+    test("should nullify session on unmount", () => {
+      const { result, unmount } = renderHook(() =>
+        useBraintreePayPalPayLaterSession(defaultProps),
+      );
+
+      unmount();
+
+      // After unmount, handleClick should not call start
+      act(() => {
+        result.current.handleClick();
+      });
+
+      expect(mockSession.start).not.toHaveBeenCalled();
+    });
+
+    test("should recreate session when data options change", () => {
+      const onApprove = jest.fn();
+
+      const { rerender } = renderHook(
+        ({ amount }) =>
+          useBraintreePayPalPayLaterSession({
+            amount,
+            currency: "USD",
+            onApprove,
+          }),
+        { initialProps: { amount: "10.00" } },
+      );
+
+      expect(mockCheckoutInstance.createPayLaterSession).toHaveBeenCalledTimes(
+        1,
+      );
+
+      jest.clearAllMocks();
+
+      rerender({ amount: "20.00" });
+
+      expect(mockCheckoutInstance.createPayLaterSession).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockCheckoutInstance.createPayLaterSession).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: "20.00" }),
+      );
+    });
+
+    test("should recreate session when checkout instance changes", () => {
+      const { rerender } = renderHook(() =>
+        useBraintreePayPalPayLaterSession(defaultProps),
+      );
+
+      jest.clearAllMocks();
+
+      const newMockSession = createMockSession();
+      const newMockCheckoutInstance =
+        createMockCheckoutInstance(newMockSession);
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: newMockCheckoutInstance,
+      });
+
+      rerender();
+
+      expect(newMockCheckoutInstance.createPayLaterSession).toHaveBeenCalled();
+    });
+
+    test("should not recreate session when only callbacks change", () => {
+      mockUseProxyProps.mockImplementation(
+        jest.requireActual("../../utils").useProxyProps,
+      );
+
+      const initialOnApprove = jest.fn();
+      const newOnApprove = jest.fn();
+
+      const { rerender } = renderHook(
+        ({ onApprove }) =>
+          useBraintreePayPalPayLaterSession({
+            amount: "10.00",
+            currency: "USD",
+            onApprove,
+          }),
+        { initialProps: { onApprove: initialOnApprove } },
+      );
+
+      jest.clearAllMocks();
+
+      rerender({ onApprove: newOnApprove });
+
+      expect(mockCheckoutInstance.createPayLaterSession).not.toHaveBeenCalled();
+    });
+
+    test("should not recreate session when inline object options have the same values", () => {
+      mockUseProxyProps.mockImplementation(
+        jest.requireActual("../../utils").useProxyProps,
+      );
+
+      const { rerender } = renderHook(
+        ({ lineItems }) =>
+          useBraintreePayPalPayLaterSession({
+            amount: "10.00",
+            currency: "USD",
+            onApprove: jest.fn(),
+            lineItems,
+          }),
+        {
+          initialProps: {
+            lineItems: [
+              {
+                quantity: "1",
+                unitAmount: "10.00",
+                name: "Item",
+                kind: "debit" as const,
+              },
+            ],
+          },
+        },
+      );
+
+      jest.clearAllMocks();
+
+      // Pass a new array reference with the same values
+      rerender({
+        lineItems: [
+          {
+            quantity: "1",
+            unitAmount: "10.00",
+            name: "Item",
+            kind: "debit" as const,
+          },
+        ],
+      });
+
+      expect(mockCheckoutInstance.createPayLaterSession).not.toHaveBeenCalled();
+    });
+
+    test("should not retry session creation on a failed checkout instance", () => {
+      const mockCheckoutInstanceWithError = {
+        createPayLaterSession: jest.fn().mockImplementation(() => {
+          throw new Error("init failure");
+        }),
+      };
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: mockCheckoutInstanceWithError,
+      });
+
+      const { rerender } = renderHook(() =>
+        useBraintreePayPalPayLaterSession(defaultProps),
+      );
+
+      expect(
+        mockCheckoutInstanceWithError.createPayLaterSession,
+      ).toHaveBeenCalledTimes(1);
+
+      jest.clearAllMocks();
+
+      // Rerender with same failed instance — should not retry
+      rerender();
+
+      expect(
+        mockCheckoutInstanceWithError.createPayLaterSession,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("should retry session creation when a new checkout instance replaces a failed one", () => {
+      mockUseProxyProps.mockImplementation(
+        jest.requireActual("../../utils").useProxyProps,
+      );
+
+      const mockCheckoutInstanceWithError = {
+        createPayLaterSession: jest.fn().mockImplementation(() => {
+          throw new Error("init failure");
+        }),
+      };
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: mockCheckoutInstanceWithError,
+      });
+
+      const { rerender } = renderHook(() =>
+        useBraintreePayPalPayLaterSession(defaultProps),
+      );
+
+      expect(
+        mockCheckoutInstanceWithError.createPayLaterSession,
+      ).toHaveBeenCalledTimes(1);
+
+      // Replace with a working instance
+      const newMockSession = createMockSession();
+      const newMockCheckoutInstance =
+        createMockCheckoutInstance(newMockSession);
+
+      mockBraintreeContext({
+        braintreePayPalCheckoutInstance: newMockCheckoutInstance,
+      });
+
+      rerender();
+
+      expect(
+        newMockCheckoutInstance.createPayLaterSession,
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("handleClick", () => {
+    test("should call session.start() when session is available", () => {
+      const { result } = renderHook(() =>
+        useBraintreePayPalPayLaterSession(defaultProps),
+      );
+
+      act(() => {
+        result.current.handleClick();
+      });
+
+      expect(mockSession.start).toHaveBeenCalled();
+    });
+
+    test("should set error when session is not available", () => {
+      mockBraintreeRejected();
+
+      const { result } = renderHook(() =>
+        useBraintreePayPalPayLaterSession(defaultProps),
+      );
+
+      act(() => {
+        result.current.handleClick();
+      });
+
+      const { error } = result.current;
+
+      expectCurrentErrorValue(error);
+
+      expect(error).toEqual(
+        new Error("Braintree payment session not available"),
+      );
+    });
+
+    test("should not call start after component is unmounted", () => {
+      const { result, unmount } = renderHook(() =>
+        useBraintreePayPalPayLaterSession(defaultProps),
+      );
+
+      unmount();
+
+      act(() => {
+        result.current.handleClick();
+      });
+
+      expect(mockSession.start).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.test.ts
@@ -36,6 +36,8 @@ const createMockCheckoutInstance = (session = createMockSession()) => ({
 
 const defaultBraintreeState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
+  eligibleMethods: null,
+  eligibleMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
   error: null,
   isHydrated: true,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.test.ts
@@ -107,9 +107,27 @@ describe("useBraintreePayPalPayLaterSession", () => {
       expectCurrentErrorValue(error);
 
       expect(error).toEqual(
-        new Error("Braintree checkout instance not available"),
+        new Error("Braintree Pay Later checkout instance not available"),
       );
       expect(mockCheckoutInstance.createPayLaterSession).not.toHaveBeenCalled();
+    });
+
+    test("should surface provider error as the cause when the provider failed to initialize", () => {
+      const providerError = new Error("init failed");
+      mockBraintreeContext({
+        loadingStatus: INSTANCE_LOADING_STATE.REJECTED,
+        error: providerError,
+      });
+
+      const {
+        result: {
+          current: { error },
+        },
+      } = renderHook(() => useBraintreePayPalPayLaterSession(defaultProps));
+
+      expectCurrentErrorValue(error);
+      expect(error?.message).toBe("Braintree provider error: init failed");
+      expect((error as Error & { cause?: unknown })?.cause).toBe(providerError);
     });
 
     test.each([
@@ -176,7 +194,7 @@ describe("useBraintreePayPalPayLaterSession", () => {
 
       expectCurrentErrorValue(result.current.error);
       expect(result.current.error).toEqual(
-        new Error("Braintree checkout instance not available"),
+        new Error("Braintree Pay Later checkout instance not available"),
       );
 
       // Second render: instance becomes available

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.test.ts
@@ -36,8 +36,8 @@ const createMockCheckoutInstance = (session = createMockSession()) => ({
 
 const defaultBraintreeState: BraintreePayPalState = {
   braintreePayPalCheckoutInstance: null,
-  eligibleMethods: null,
-  eligibleMethodsPayload: null,
+  eligiblePaymentMethods: null,
+  eligiblePaymentMethodsPayload: null,
   loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
   error: null,
   isHydrated: true,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
@@ -91,8 +91,11 @@ export function useBraintreePayPalPayLaterSession({
   shippingOptions,
   amountBreakdown,
 }: UseBraintreePayPalPayLaterSessionProps): UseBraintreePayPalPayLaterSessionReturn {
-  const { braintreePayPalCheckoutInstance, loadingStatus } =
-    useBraintreePayPal();
+  const {
+    braintreePayPalCheckoutInstance,
+    loadingStatus,
+    error: contextError,
+  } = useBraintreePayPal();
   const isMountedRef = useIsMountedRef();
   const sessionRef = useRef<BraintreePaymentSession | null>(null);
   const [error, setError] = useError();
@@ -126,9 +129,15 @@ export function useBraintreePayPalPayLaterSession({
     if (braintreePayPalCheckoutInstance) {
       setError(null);
     } else if (loadingStatus !== INSTANCE_LOADING_STATE.PENDING) {
-      setError(new Error("Braintree checkout instance not available"));
+      setError(
+        contextError
+          ? new Error(`Braintree provider error: ${contextError.message}`, {
+              cause: contextError,
+            })
+          : new Error("Braintree Pay Later checkout instance not available"),
+      );
     }
-  }, [braintreePayPalCheckoutInstance, setError, loadingStatus]);
+  }, [braintreePayPalCheckoutInstance, setError, loadingStatus, contextError]);
 
   // Create and manage session lifecycle
   useEffect(() => {

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import { useBraintreePayPal } from "./useBraintreePayPal";
+import { useIsMountedRef } from "../useIsMounted";
+import { useError } from "../useError";
+import {
+  createPaymentSession,
+  useProxyProps,
+  useDeepCompareMemoize,
+} from "../../utils";
+import { INSTANCE_LOADING_STATE } from "../../types/ProviderEnums";
+
+import type {
+  BraintreePayLaterSessionOptions,
+  BraintreePaymentSession,
+} from "../../types/braintree";
+
+export type UseBraintreePayPalPayLaterSessionProps =
+  BraintreePayLaterSessionOptions;
+
+export interface UseBraintreePayPalPayLaterSessionReturn {
+  error: Error | null;
+  isPending: boolean;
+  handleClick: () => void;
+}
+
+/**
+ * Hook for managing Pay Later (Buy Now, Pay Later) sessions with Braintree PayPal.
+ *
+ * The hook returns an `isPending` flag that indicates whether the Braintree checkout
+ * instance is still being initialized. Buttons should wait to render until `isPending`
+ * is false.
+ *
+ * @returns Object with: `error` (any session error), `isPending` (checkout instance loading), `handleClick` (starts session)
+ *
+ * @example
+ * // Custom button using the hook directly with a <paypal-button> web component
+ * function PayPalPayLaterButton(props: UseBraintreePayPalPayLaterSessionProps) {
+ *   const { isPending, handleClick } = useBraintreePayPalPayLaterSession(props);
+ *
+ *   return (
+ *     <paypal-button
+ *       type="pay"
+ *       fundingSource="paylater"
+ *       onClick={() => handleClick()}
+ *       disabled={isPending}
+ *     />
+ *   );
+ * }
+ *
+ * // Usage with tokenization in onApprove:
+ * function Checkout() {
+ *   const { braintreePayPalCheckoutInstance } = useBraintreePayPal();
+ *
+ *   const handleOnApprove = async (data) => {
+ *     const { nonce } = await braintreePayPalCheckoutInstance.tokenizePayment({
+ *       orderID: data.orderId,
+ *       payerID: data.payerId,
+ *     });
+ *     // Send nonce to your server to complete the transaction
+ *   };
+ *
+ *   return (
+ *     <PayPalPayLaterButton
+ *       amount="100.00"
+ *       currency="USD"
+ *       onApprove={handleOnApprove}
+ *     />
+ *   );
+ * }
+ */
+export function useBraintreePayPalPayLaterSession({
+  // Callbacks
+  onApprove,
+  onCancel,
+  onComplete,
+  onError: onErrorCallback,
+  onShippingAddressChange,
+  onShippingOptionsChange,
+  // Primitive data options
+  amount,
+  currency,
+  intent,
+  userAuthenticationEmail,
+  returnUrl,
+  cancelUrl,
+  displayName,
+  presentationMode,
+  // Object/array data options (require deep comparison)
+  lineItems,
+  shippingOptions,
+  amountBreakdown,
+}: UseBraintreePayPalPayLaterSessionProps): UseBraintreePayPalPayLaterSessionReturn {
+  const { braintreePayPalCheckoutInstance, loadingStatus } =
+    useBraintreePayPal();
+  const isMountedRef = useIsMountedRef();
+  const sessionRef = useRef<BraintreePaymentSession | null>(null);
+  const [error, setError] = useError();
+
+  // Prevents retrying session creation with a failed checkout instance
+  const failedInstanceRef = useRef<unknown>(null);
+
+  const proxyCallbacks = useProxyProps({
+    onApprove,
+    onCancel,
+    onComplete,
+    onError: onErrorCallback,
+    onShippingAddressChange,
+    onShippingOptionsChange,
+  });
+
+  // Deep-memoize only object/array options that consumers may pass inline
+  const memoizedLineItems = useDeepCompareMemoize(lineItems);
+  const memoizedShippingOptions = useDeepCompareMemoize(shippingOptions);
+  const memoizedAmountBreakdown = useDeepCompareMemoize(amountBreakdown);
+
+  const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
+
+  // Handle checkout instance availability
+  useEffect(() => {
+    // Reset failed instance tracking when checkout instance changes
+    if (failedInstanceRef.current !== braintreePayPalCheckoutInstance) {
+      failedInstanceRef.current = null;
+    }
+
+    if (braintreePayPalCheckoutInstance) {
+      setError(null);
+    } else if (loadingStatus !== INSTANCE_LOADING_STATE.PENDING) {
+      setError(new Error("Braintree checkout instance not available"));
+    }
+  }, [braintreePayPalCheckoutInstance, setError, loadingStatus]);
+
+  // Create and manage session lifecycle
+  useEffect(() => {
+    if (!braintreePayPalCheckoutInstance) {
+      return;
+    }
+
+    const newSession = createPaymentSession({
+      sessionCreator: () =>
+        braintreePayPalCheckoutInstance.createPayLaterSession({
+          amount,
+          currency,
+          intent,
+          userAuthenticationEmail,
+          returnUrl,
+          cancelUrl,
+          displayName,
+          presentationMode,
+          lineItems: memoizedLineItems,
+          shippingOptions: memoizedShippingOptions,
+          amountBreakdown: memoizedAmountBreakdown,
+          ...proxyCallbacks,
+        }),
+      failedSdkRef: failedInstanceRef,
+      sdkInstance: braintreePayPalCheckoutInstance,
+      setError,
+      errorMessage:
+        "Failed to create Braintree Pay Later session. Ensure the BraintreePayPalProvider is properly initialized with a valid client token and namespace.",
+    });
+
+    if (!newSession) {
+      return;
+    }
+
+    sessionRef.current = newSession;
+
+    return () => {
+      sessionRef.current = null;
+    };
+  }, [
+    braintreePayPalCheckoutInstance,
+    amount,
+    currency,
+    intent,
+    userAuthenticationEmail,
+    returnUrl,
+    cancelUrl,
+    displayName,
+    presentationMode,
+    memoizedLineItems,
+    memoizedShippingOptions,
+    memoizedAmountBreakdown,
+    proxyCallbacks,
+    setError,
+  ]);
+
+  const handleClick = useCallback(() => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    if (!sessionRef.current) {
+      setError(new Error("Braintree payment session not available"));
+      return;
+    }
+
+    sessionRef.current.start();
+  }, [isMountedRef, setError]);
+
+  return {
+    error,
+    isPending,
+    handleClick,
+  };
+}

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
@@ -86,10 +86,12 @@ export function useBraintreePayPalPayLaterSession({
   cancelUrl,
   displayName,
   presentationMode,
+  shippingCallbackUrl,
   // Object/array data options (require deep comparison)
   lineItems,
   shippingOptions,
   amountBreakdown,
+  shippingAddressOverride,
 }: UseBraintreePayPalPayLaterSessionProps): UseBraintreePayPalPayLaterSessionReturn {
   const {
     braintreePayPalCheckoutInstance,
@@ -116,6 +118,9 @@ export function useBraintreePayPalPayLaterSession({
   const memoizedLineItems = useDeepCompareMemoize(lineItems);
   const memoizedShippingOptions = useDeepCompareMemoize(shippingOptions);
   const memoizedAmountBreakdown = useDeepCompareMemoize(amountBreakdown);
+  const memoizedShippingAddressOverride = useDeepCompareMemoize(
+    shippingAddressOverride,
+  );
 
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
@@ -156,9 +161,11 @@ export function useBraintreePayPalPayLaterSession({
           cancelUrl,
           displayName,
           presentationMode,
+          shippingCallbackUrl,
           lineItems: memoizedLineItems,
           shippingOptions: memoizedShippingOptions,
           amountBreakdown: memoizedAmountBreakdown,
+          shippingAddressOverride: memoizedShippingAddressOverride,
           ...proxyCallbacks,
         }),
       failedSdkRef: failedInstanceRef,
@@ -187,9 +194,11 @@ export function useBraintreePayPalPayLaterSession({
     cancelUrl,
     displayName,
     presentationMode,
+    shippingCallbackUrl,
     memoizedLineItems,
     memoizedShippingOptions,
     memoizedAmountBreakdown,
+    memoizedShippingAddressOverride,
     proxyCallbacks,
     setError,
   ]);

--- a/packages/react-paypal-js/src/v6/index.ts
+++ b/packages/react-paypal-js/src/v6/index.ts
@@ -95,6 +95,11 @@ export {
   type UseBraintreePayPalPayLaterSessionProps,
   type UseBraintreePayPalPayLaterSessionReturn,
 } from "./hooks/Braintree/useBraintreePayPalPayLaterSession";
+export {
+  useBraintreeEligibleMethods,
+  type UseBraintreeEligibleMethodsProps,
+  type UseBraintreeEligibleMethodsReturn,
+} from "./hooks/Braintree/useBraintreeEligibleMethods";
 export * from "./hooks/useEligibleMethods";
 export { usePayPalMessages } from "./hooks/usePayPalMessages";
 

--- a/packages/react-paypal-js/src/v6/index.ts
+++ b/packages/react-paypal-js/src/v6/index.ts
@@ -90,6 +90,11 @@ export {
   type UseBraintreePayPalCheckoutWithVaultSessionProps,
   type UseBraintreePayPalCheckoutWithVaultSessionReturn,
 } from "./hooks/Braintree/useBraintreePayPalCheckoutWithVaultSession";
+export {
+  useBraintreePayPalPayLaterSession,
+  type UseBraintreePayPalPayLaterSessionProps,
+  type UseBraintreePayPalPayLaterSessionReturn,
+} from "./hooks/Braintree/useBraintreePayPalPayLaterSession";
 export * from "./hooks/useEligibleMethods";
 export { usePayPalMessages } from "./hooks/usePayPalMessages";
 

--- a/packages/react-paypal-js/src/v6/types/ProviderEnums.ts
+++ b/packages/react-paypal-js/src/v6/types/ProviderEnums.ts
@@ -15,6 +15,7 @@ export enum INSTANCE_DISPATCH_ACTION {
 export enum BRAINTREE_DISPATCH_ACTION {
   SET_LOADING_STATUS = "setLoadingStatus",
   SET_INSTANCE = "setInstance",
+  SET_ELIGIBILITY = "setEligibility",
   SET_ERROR = "setError",
   RESET_STATE = "resetState",
 }

--- a/packages/react-paypal-js/src/v6/types/braintree.ts
+++ b/packages/react-paypal-js/src/v6/types/braintree.ts
@@ -20,6 +20,22 @@ export interface BraintreeShippingOption {
   };
 }
 
+export interface BraintreeShippingAddressOverride {
+  line1: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  countryCode: string;
+  line2?: string;
+  phone?: string;
+  recipientName?: string;
+  recipientEmail?: string;
+  contactPreference?:
+    | "NO_CONTACT_INFO"
+    | "RETAIN_CONTACT_INFO"
+    | "UPDATE_CONTACT_INFO";
+}
+
 export interface BraintreeAmountBreakdown {
   itemTotal?: string;
   shipping?: string;
@@ -177,6 +193,12 @@ export interface BraintreeOneTimePaymentSessionOptions {
   ) => Promise<void>;
   lineItems?: BraintreeLineItem[];
   shippingOptions?: BraintreeShippingOption[];
+  shippingCallbackUrl?: string;
+  shippingAddressOverride?: BraintreeShippingAddressOverride;
+  contactPreference?:
+    | "NO_CONTACT_INFO"
+    | "RETAIN_CONTACT_INFO"
+    | "UPDATE_CONTACT_INFO";
   userAuthenticationEmail?: string;
   amountBreakdown?: BraintreeAmountBreakdown;
   returnUrl?: string;
@@ -192,7 +214,7 @@ export interface BraintreeBillingAgreementSessionOptions {
   amount?: string;
   currency?: string;
   offerCredit?: boolean;
-  shippingAddressOverride?: Record<string, unknown>;
+  shippingAddressOverride?: BraintreeShippingAddressOverride;
   userAction?: "CONTINUE" | "COMMIT" | "SETUP_NOW";
   displayName?: string;
   returnUrl?: string;
@@ -222,6 +244,7 @@ export interface BraintreeCheckoutWithVaultSessionOptions {
   ) => Promise<void>;
   lineItems?: BraintreeLineItem[];
   shippingOptions?: BraintreeShippingOption[];
+  shippingCallbackUrl?: string;
   userAuthenticationEmail?: string;
   amountBreakdown?: BraintreeAmountBreakdown;
   returnUrl?: string;
@@ -246,6 +269,12 @@ export interface BraintreePayLaterSessionOptions {
   ) => Promise<void>;
   lineItems?: BraintreeLineItem[];
   shippingOptions?: BraintreeShippingOption[];
+  shippingCallbackUrl?: string;
+  shippingAddressOverride?: BraintreeShippingAddressOverride;
+  contactPreference?:
+    | "NO_CONTACT_INFO"
+    | "RETAIN_CONTACT_INFO"
+    | "UPDATE_CONTACT_INFO";
   userAuthenticationEmail?: string;
   amountBreakdown?: BraintreeAmountBreakdown;
   returnUrl?: string;

--- a/packages/react-paypal-js/src/v6/types/braintree.ts
+++ b/packages/react-paypal-js/src/v6/types/braintree.ts
@@ -163,7 +163,7 @@ export interface BraintreeTokenizePayload {
 // googlepay, or advanced_cards.
 export type BraintreeEligibleFundingSource = "paypal" | "paylater" | "credit";
 
-export interface BraintreeEligibilityResult {
+export interface BraintreeEligiblePaymentMethodsOutput {
   paypal: boolean;
   paylater: boolean;
   credit: boolean;
@@ -368,7 +368,7 @@ export interface BraintreePayPalCheckoutInstance {
   createPayment: (options: BraintreeCreatePaymentOptions) => Promise<string>;
   findEligibleMethods: (
     options: BraintreeFindEligibleMethodsOptions,
-  ) => Promise<BraintreeEligibilityResult>;
+  ) => Promise<BraintreeEligiblePaymentMethodsOutput>;
   getClientId: () => Promise<string>;
   updatePayment: (
     options: BraintreeUpdatePaymentOptions,

--- a/packages/react-paypal-js/src/v6/types/braintree.ts
+++ b/packages/react-paypal-js/src/v6/types/braintree.ts
@@ -1,3 +1,5 @@
+import type { FindEligibleMethodsGetDetails } from "@paypal/paypal-js/sdk-v6";
+
 // ---- Shared types ----
 
 export interface BraintreeLineItem {
@@ -157,13 +159,17 @@ export interface BraintreeTokenizePayload {
 
 // ---- Eligibility result ----
 
+// Braintree supports a subset of the SDK's funding sources — no applepay,
+// googlepay, or advanced_cards.
+export type BraintreeEligibleFundingSource = "paypal" | "paylater" | "credit";
+
 export interface BraintreeEligibilityResult {
   paypal: boolean;
   paylater: boolean;
   credit: boolean;
-  getDetails: (
-    methodName: "paypal" | "paylater" | "credit",
-  ) => Record<string, unknown> | null;
+  getDetails: <T extends BraintreeEligibleFundingSource>(
+    methodName: T,
+  ) => FindEligibleMethodsGetDetails<T>;
 }
 
 // ---- Method options ----

--- a/packages/react-paypal-js/src/v6/types/braintree.ts
+++ b/packages/react-paypal-js/src/v6/types/braintree.ts
@@ -163,7 +163,7 @@ export interface BraintreeTokenizePayload {
 // googlepay, or advanced_cards.
 export type BraintreeEligibleFundingSource = "paypal" | "paylater" | "credit";
 
-export interface BraintreeEligiblePaymentMethodsOutput {
+export interface BraintreeEligibilityResult {
   paypal: boolean;
   paylater: boolean;
   credit: boolean;
@@ -368,7 +368,7 @@ export interface BraintreePayPalCheckoutInstance {
   createPayment: (options: BraintreeCreatePaymentOptions) => Promise<string>;
   findEligibleMethods: (
     options: BraintreeFindEligibleMethodsOptions,
-  ) => Promise<BraintreeEligiblePaymentMethodsOutput>;
+  ) => Promise<BraintreeEligibilityResult>;
   getClientId: () => Promise<string>;
   updatePayment: (
     options: BraintreeUpdatePaymentOptions,


### PR DESCRIPTION
## Summary

Adds Braintree PayPal **Pay Later (BNPL)** support to `@paypal/react-paypal-js` (v6), along with a companion **eligibility** hook and the provider-context plumbing needed to cache eligibility results. Also tightens error reporting and types across the existing Braintree session hooks.

## What's included

### New hooks
- **`useBraintreePayPalPayLaterSession`** — manages a Pay Later session, mirroring the existing one-time-payment / billing-agreement / checkout-with-vault hooks. Returns `{ error, isPending, handleClick }`, recreates the session when data options or the checkout instance change (deep-compared), skips recreation on callback-only changes, and won't retry a failed instance until it's replaced.
- **`useBraintreeEligibleMethods`** — calls `findEligibleMethods` on the shared checkout instance and caches the result on provider context. Fetches are deduped by `(instance, options)` so multiple mounts / remounts with the same options reuse the cached result; refetches when options or the instance change; recovers from transient failures when the consumer corrects the input; and is safe under React 18 StrictMode double-mount and post-unmount resolution.

### Provider / context plumbing
- New `SET_ELIGIBILITY` reducer action; `eligiblePaymentMethods` and `eligiblePaymentMethodsPayload` added to `BraintreePayPalState`.
- New **internal** `BraintreeDispatchContext` + `useBraintreePayPalDispatch` hook so hooks can write eligibility back into provider state. Not exported to external consumers.

### Error handling
- Provider-level (context) failures are now surfaced **separately and labeled** (`Braintree provider error: …`, with the original error as `cause`), distinct from "checkout instance not available" — so consumers can tell which layer failed.
- Per-hook instance-unavailable messages are now specific (e.g. `Braintree Pay Later checkout instance not available`, `Braintree One-Time Payment …`, `Braintree Billing Agreement …`, `Braintree Checkout With Vault …`).

### Types (`types/braintree.ts`)
- `getDetails` is now generically typed via `FindEligibleMethodsGetDetails<T>` from `@paypal/paypal-js/sdk-v6`.
- New `BraintreeEligibleFundingSource` union (`"paypal" | "paylater" | "credit"`).
- New typed `BraintreeShippingAddressOverride` (replaces `Record<string, unknown>`).
- Added `shippingCallbackUrl`, `shippingAddressOverride`, and `contactPreference` to the one-time / pay-later / checkout-with-vault option types.

### Exports & changeset
- Exports both new hooks and their `Props` / `Return` types from `v6/index.ts`.
- Adds a `minor` changeset for `@paypal/react-paypal-js`.

## Testing
- New unit tests for `useBraintreePayPalPayLaterSession` and `useBraintreeEligibleMethods` (init, refetch, caching, StrictMode, unmount, error labeling).
- Reducer tests for the `SET_ELIGIBILITY` action and `RESET_STATE`.
- Updated existing Braintree session-hook tests for the new labeled error messages and state shape.
