### PR TITLE
Feat: Make presentationMode optional for v6 hooks and button components

### DIFF
--- a/.changeset/funny-hands-refuse.md
+++ b/.changeset/funny-hands-refuse.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+Makes presentationMode optional for v6 buttons and hooks, and sets a default value for each hook.

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -260,17 +260,17 @@ import { PayPalOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 **Props:**
 
-| Prop               | Type                                                         | Description                                            |
-| ------------------ | ------------------------------------------------------------ | ------------------------------------------------------ |
-| `orderId`          | `string`                                                     | Static order ID (alternative to `createOrder`)         |
-| `createOrder`      | `() => Promise<{ orderId: string }>`                         | Async function to create an order                      |
-| `presentationMode` | `"auto" \| "popup" \| "modal" \| "redirect"`                 | How to present the payment session (default: `"auto"`) |
-| `onApprove`        | `(data) => void`                                             | Called when payment is approved                        |
-| `onCancel`         | `() => void`                                                 | Called when buyer cancels                              |
-| `onError`          | `(error) => void`                                            | Called on error                                        |
-| `onComplete`       | `(data) => void`                                             | Called when payment session completes                  |
-| `type`             | `"pay" \| "checkout" \| "buynow" \| "donate" \| "subscribe"` | Button label type                                      |
-| `disabled`         | `boolean`                                                    | Disable the button                                     |
+| Prop               | Type                                                         | Description                                                         |
+| ------------------ | ------------------------------------------------------------ | ------------------------------------------------------------------- |
+| `orderId`          | `string`                                                     | Static order ID (alternative to `createOrder`)                      |
+| `createOrder`      | `() => Promise<{ orderId: string }>`                         | Async function to create an order                                   |
+| `presentationMode` | `"auto" \| "popup" \| "modal" \| "redirect"`                 | Optional. How to present the payment session. Defaults to `"auto"`. |
+| `onApprove`        | `(data) => void`                                             | Called when payment is approved                                     |
+| `onCancel`         | `() => void`                                                 | Called when buyer cancels                                           |
+| `onError`          | `(error) => void`                                            | Called on error                                                     |
+| `onComplete`       | `(data) => void`                                             | Called when payment session completes                               |
+| `type`             | `"pay" \| "checkout" \| "buynow" \| "donate" \| "subscribe"` | Button label type                                                   |
+| `disabled`         | `boolean`                                                    | Disable the button                                                  |
 
 ### VenmoOneTimePaymentButton
 
@@ -1429,7 +1429,6 @@ function CustomPayPalButton() {
       const { orderId } = await createOrder();
       return { orderId };
     },
-    presentationMode: "auto",
     onApprove: (data: OnApproveDataOneTimePayments) =>
       console.log("Approved:", data),
     onCancel: (data: OnCancelDataOneTimePayments) => console.log("Cancelled"),
@@ -1535,7 +1534,6 @@ function CustomPayPalSaveButton() {
       const { vaultSetupToken } = await createVaultToken();
       return { vaultSetupToken };
     },
-    presentationMode: "popup",
     onApprove: (data: OnApproveDataSavePayments) => console.log("Saved:", data),
     onCancel: (data: OnCancelDataSavePayments) =>
       console.log("Cancelled", data),

--- a/packages/react-paypal-js/src/v6/components/PayLaterOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayLaterOneTimePaymentButton.tsx
@@ -25,13 +25,14 @@ export type PayLaterOneTimePaymentButtonProps =
  * would not be able to provide back `redirectURL` from `start`. Advanced integrations that need
  * `redirectURL` should use the {@link usePayLaterOneTimePaymentSession} hook directly.
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * <PayLaterOneTimePaymentButton
  *   onApprove={() => {
  *      // ... on approve logic
  *   }}
  *   orderId="your-order-id"
- *   presentationMode="auto"
  * />
  */
 export const PayLaterOneTimePaymentButton = ({

--- a/packages/react-paypal-js/src/v6/components/PayPalCreditOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalCreditOneTimePaymentButton.tsx
@@ -22,13 +22,14 @@ export type PayPalCreditOneTimePaymentButtonProps =
  * would not be able to provide back `redirectURL` from `start`. Advanced integrations that need
  * `redirectURL` should use the {@link usePayPalCreditOneTimePaymentSession} hook directly.
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * <PayPalCreditOneTimePaymentButton
  *   onApprove={() => {
  *      // ... on approve logic
  *   }}
  *   orderId="your-order-id"
- *   presentationMode="auto"
  * />
  */
 export const PayPalCreditOneTimePaymentButton = ({

--- a/packages/react-paypal-js/src/v6/components/PayPalCreditSavePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalCreditSavePaymentButton.tsx
@@ -22,13 +22,14 @@ export type PayPalCreditSavePaymentButtonProps =
  * would not be able to provide back `redirectURL` from `start`. Advanced integrations that need
  * `redirectURL` should use the {@link usePayPalCreditSavePaymentSession} hook directly.
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * <PayPalCreditSavePaymentButton
  *   onApprove={() => {
  *      // ... on approve logic
  *   }}
  *   vaultSetupToken="your-vault-setup-token"
- *   presentationMode="auto"
  * />
  */
 export const PayPalCreditSavePaymentButton = ({

--- a/packages/react-paypal-js/src/v6/components/PayPalOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalOneTimePaymentButton.tsx
@@ -21,13 +21,14 @@ type PayPalOneTimePaymentButtonProps = UsePayPalOneTimePaymentSessionProps &
  * would not be able to provide back `redirectURL` from `start`. Advanced integrations that need
  * `redirectURL` should use the {@link usePayPalOneTimePaymentSession} hook directly.
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * <PayPalOneTimePaymentButton
  *   onApprove={() => {
  *      // ... on approve logic
  *   }}
  *   orderId="your-order-id"
- *   presentationMode="auto"
  * />
  */
 export const PayPalOneTimePaymentButton = ({

--- a/packages/react-paypal-js/src/v6/components/PayPalSavePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalSavePaymentButton.tsx
@@ -22,13 +22,14 @@ type PayPalSavePaymentButtonProps = UsePayPalSavePaymentSessionProps &
  * would not be able to provide back `redirectURL` from `start`. Advanced integrations that need
  * `redirectURL` should use the {@link usePayPalSavePaymentSession} hook directly.
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * <PayPalSavePaymentButton
  *   onApprove={() => {
  *      // ... on approve logic
  *   }}
  *   vaultSetupToken="your-vault-setup-token"
- *   presentationMode="auto"
  * />
  */
 export const PayPalSavePaymentButton = ({

--- a/packages/react-paypal-js/src/v6/components/PayPalSubscriptionButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalSubscriptionButton.tsx
@@ -22,13 +22,14 @@ export type PayPalSubscriptionButtonProps =
  * would not be able to provide back `redirectURL` from `start`. Advanced integrations that need
  * `redirectURL` should use the {@link usePayPalSubscriptionPaymentSession} hook directly.
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * <PayPalSubscriptionButton
  *   onApprove={() => {
  *      // ... on approve logic
  *   }}
  *   createSubscription={() => Promise.resolve({ subscriptionId: "SUB-123" })}
- *   presentationMode="auto"
  * />
  */
 export const PayPalSubscriptionButton = ({

--- a/packages/react-paypal-js/src/v6/components/VenmoOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/VenmoOneTimePaymentButton.tsx
@@ -17,13 +17,14 @@ type VenmoOneTimePaymentButtonProps = UseVenmoOneTimePaymentSessionProps &
  * `VenmoOneTimePaymentButtonProps` combines the arguments for {@link UseVenmoOneTimePaymentSessionProps}
  * and {@link ButtonProps}.
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * <VenmoOneTimePaymentButton
  *   onApprove={() => {
  *      // ... on approve logic
  *   }}
  *   orderId="your-order-id"
- *   presentationMode="auto"
  * />
  */
 export const VenmoOneTimePaymentButton = ({

--- a/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.test.ts
@@ -286,6 +286,45 @@ describe("usePayLaterOneTimePaymentSession", () => {
     );
   });
 
+  test("should default presentationMode to 'auto' when not provided", async () => {
+    const mockStart = jest.fn();
+    const mockSession: OneTimePaymentSession = {
+      cancel: jest.fn(),
+      destroy: jest.fn(),
+      start: mockStart,
+    };
+    const mockCreatePayLaterOneTimePaymentSession = jest
+      .fn()
+      .mockReturnValue(mockSession);
+
+    (usePayPal as jest.Mock).mockReturnValue({
+      sdkInstance: {
+        createPayLaterOneTimePaymentSession:
+          mockCreatePayLaterOneTimePaymentSession,
+      },
+    });
+
+    const {
+      result: {
+        current: { handleClick },
+      },
+    } = renderHook(() =>
+      usePayLaterOneTimePaymentSession({
+        orderId: "123",
+        onApprove: jest.fn(),
+      }),
+    );
+
+    await act(async () => {
+      handleClick();
+    });
+
+    expect(mockStart).toHaveBeenCalledWith(
+      expect.objectContaining({ presentationMode: "auto" }),
+      undefined,
+    );
+  });
+
   test("should call the createOrder callback, if it was provided, on start inside the click handler", async () => {
     const mockStart = jest.fn();
     const mockSession: OneTimePaymentSession = {

--- a/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.test.ts
@@ -325,6 +325,49 @@ describe("usePayLaterOneTimePaymentSession", () => {
     );
   });
 
+  test("should forward fullPageOverlay when presentationMode is omitted", async () => {
+    const mockStart = jest.fn();
+    const mockSession: OneTimePaymentSession = {
+      cancel: jest.fn(),
+      destroy: jest.fn(),
+      start: mockStart,
+    };
+    const mockCreatePayLaterOneTimePaymentSession = jest
+      .fn()
+      .mockReturnValue(mockSession);
+
+    (usePayPal as jest.Mock).mockReturnValue({
+      sdkInstance: {
+        createPayLaterOneTimePaymentSession:
+          mockCreatePayLaterOneTimePaymentSession,
+      },
+    });
+
+    const {
+      result: {
+        current: { handleClick },
+      },
+    } = renderHook(() =>
+      usePayLaterOneTimePaymentSession({
+        orderId: "123",
+        onApprove: jest.fn(),
+        fullPageOverlay: { enabled: true },
+      }),
+    );
+
+    await act(async () => {
+      handleClick();
+    });
+
+    expect(mockStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        presentationMode: "auto",
+        fullPageOverlay: { enabled: true },
+      }),
+      undefined,
+    );
+  });
+
   test("should call the createOrder callback, if it was provided, on start inside the click handler", async () => {
     const mockStart = jest.fn();
     const mockSession: OneTimePaymentSession = {

--- a/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
@@ -12,6 +12,7 @@ import type {
   OneTimePaymentSession,
   PayLaterOneTimePaymentSessionOptions,
   PayPalPresentationModeOptions,
+  WithOptionalPresentationMode,
 } from "../types";
 
 export type UsePayLaterOneTimePaymentSessionProps = (
@@ -24,7 +25,7 @@ export type UsePayLaterOneTimePaymentSessionProps = (
       orderId: string;
     })
 ) &
-  PayPalPresentationModeOptions;
+  WithOptionalPresentationMode<PayPalPresentationModeOptions>;
 
 /**
  * Hook for managing Pay Later one-time payment sessions.
@@ -165,7 +166,7 @@ export function usePayLaterOneTimePaymentSession({
     }
 
     const startOptions = {
-      presentationMode,
+      presentationMode: presentationMode ?? "auto",
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
@@ -36,6 +36,8 @@ export type UsePayLaterOneTimePaymentSessionProps = (
  *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * function PayLaterCheckoutButton() {
  *   const { error, isPending, handleClick, handleCancel } = usePayLaterOneTimePaymentSession({

--- a/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
@@ -61,7 +61,7 @@ export type UsePayLaterOneTimePaymentSessionProps = (
  * }
  */
 export function usePayLaterOneTimePaymentSession({
-  presentationMode,
+  presentationMode = "auto",
   fullPageOverlay,
   autoRedirect,
   createOrder,
@@ -166,7 +166,7 @@ export function usePayLaterOneTimePaymentSession({
     }
 
     const startOptions = {
-      presentationMode: presentationMode ?? "auto",
+      presentationMode,
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.test.ts
@@ -472,6 +472,26 @@ describe("usePayPalCreditOneTimePaymentSession", () => {
       expect(mockPayPalSession.start).not.toHaveBeenCalled();
     });
 
+    test("should default presentationMode to 'auto' when not provided", async () => {
+      const props: UsePayPalCreditOneTimePaymentSessionProps = {
+        orderId: "test-order-id",
+        onApprove: jest.fn(),
+      };
+
+      const { result } = renderHook(() =>
+        usePayPalCreditOneTimePaymentSession(props),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockPayPalSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({ presentationMode: "auto" }),
+        undefined,
+      );
+    });
+
     test("should handle different presentation modes", async () => {
       const presentationModes = ["auto", "popup", "modal"] as const;
 

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.test.ts
@@ -492,6 +492,30 @@ describe("usePayPalCreditOneTimePaymentSession", () => {
       );
     });
 
+    test("should forward fullPageOverlay when presentationMode is omitted", async () => {
+      const props: UsePayPalCreditOneTimePaymentSessionProps = {
+        orderId: "test-order-id",
+        onApprove: jest.fn(),
+        fullPageOverlay: { enabled: true },
+      };
+
+      const { result } = renderHook(() =>
+        usePayPalCreditOneTimePaymentSession(props),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockPayPalSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          presentationMode: "auto",
+          fullPageOverlay: { enabled: true },
+        }),
+        undefined,
+      );
+    });
+
     test("should handle different presentation modes", async () => {
       const presentationModes = ["auto", "popup", "modal"] as const;
 

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
@@ -11,6 +11,7 @@ import type {
   OneTimePaymentSession,
   PayPalPresentationModeOptions,
   PayPalCreditOneTimePaymentSessionOptions,
+  WithOptionalPresentationMode,
 } from "../types";
 
 export type UsePayPalCreditOneTimePaymentSessionProps = (
@@ -23,7 +24,7 @@ export type UsePayPalCreditOneTimePaymentSessionProps = (
       orderId: string;
     })
 ) &
-  PayPalPresentationModeOptions;
+  WithOptionalPresentationMode<PayPalPresentationModeOptions>;
 
 /**
  * Hook for managing PayPal Credit one-time payment sessions.
@@ -162,7 +163,7 @@ export function usePayPalCreditOneTimePaymentSession({
     }
 
     const startOptions = {
-      presentationMode,
+      presentationMode: presentationMode ?? "auto",
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
@@ -58,7 +58,7 @@ export type UsePayPalCreditOneTimePaymentSessionProps = (
  * }
  */
 export function usePayPalCreditOneTimePaymentSession({
-  presentationMode,
+  presentationMode = "auto",
   fullPageOverlay,
   autoRedirect,
   createOrder,
@@ -163,7 +163,7 @@ export function usePayPalCreditOneTimePaymentSession({
     }
 
     const startOptions = {
-      presentationMode: presentationMode ?? "auto",
+      presentationMode: presentationMode,
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
@@ -34,6 +34,8 @@ export type UsePayPalCreditOneTimePaymentSessionProps = (
  *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * function CreditCheckoutButton() {
  *   const { error, isPending, handleClick, handleCancel } = usePayPalCreditOneTimePaymentSession({

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.test.ts
@@ -589,6 +589,29 @@ describe("usePayPalCreditSavePaymentSession", () => {
       );
     });
 
+    test("should forward fullPageOverlay when presentationMode is omitted", async () => {
+      const props: UsePayPalCreditSavePaymentSessionProps = {
+        vaultSetupToken: "test-vault-token",
+        onApprove: jest.fn(),
+        fullPageOverlay: { enabled: true },
+      };
+
+      const { result } = renderHook(() =>
+        usePayPalCreditSavePaymentSession(props),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockSavePaymentSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          presentationMode: "auto",
+          fullPageOverlay: { enabled: true },
+        }),
+      );
+    });
+
     test("should handle different presentation modes", async () => {
       const presentationModes = [
         "auto",

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.test.ts
@@ -570,6 +570,25 @@ describe("usePayPalCreditSavePaymentSession", () => {
       expect(mockSavePaymentSession.start).not.toHaveBeenCalled();
     });
 
+    test("should default presentationMode to 'auto' when not provided", async () => {
+      const props: UsePayPalCreditSavePaymentSessionProps = {
+        vaultSetupToken: "test-vault-token",
+        onApprove: jest.fn(),
+      };
+
+      const { result } = renderHook(() =>
+        usePayPalCreditSavePaymentSession(props),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockSavePaymentSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({ presentationMode: "auto" }),
+      );
+    });
+
     test("should handle different presentation modes", async () => {
       const presentationModes = [
         "auto",

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
@@ -34,6 +34,8 @@ export type UsePayPalCreditSavePaymentSessionProps = (
  *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * function SaveCreditButton() {
  *   const { error, isPending, handleClick, handleCancel } = usePayPalCreditSavePaymentSession({

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
@@ -11,6 +11,7 @@ import type {
   PayPalPresentationModeOptions,
   SavePaymentSessionOptions,
   BasePaymentSessionReturn,
+  WithOptionalPresentationMode,
 } from "../types";
 
 export type UsePayPalCreditSavePaymentSessionProps = (
@@ -23,7 +24,7 @@ export type UsePayPalCreditSavePaymentSessionProps = (
       vaultSetupToken: string;
     })
 ) &
-  PayPalPresentationModeOptions;
+  WithOptionalPresentationMode<PayPalPresentationModeOptions>;
 
 /**
  * Hook for managing PayPal Credit save payment sessions.
@@ -167,7 +168,7 @@ export function usePayPalCreditSavePaymentSession({
     }
 
     const startOptions = {
-      presentationMode,
+      presentationMode: presentationMode ?? "auto",
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
@@ -58,7 +58,7 @@ export type UsePayPalCreditSavePaymentSessionProps = (
  * }
  */
 export function usePayPalCreditSavePaymentSession({
-  presentationMode,
+  presentationMode = "auto",
   fullPageOverlay,
   autoRedirect,
   createVaultToken,
@@ -168,7 +168,7 @@ export function usePayPalCreditSavePaymentSession({
     }
 
     const startOptions = {
-      presentationMode: presentationMode ?? "auto",
+      presentationMode,
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.test.ts
@@ -524,6 +524,30 @@ describe("usePayPalOneTimePaymentSession", () => {
         undefined,
       );
     });
+
+    test("should forward fullPageOverlay when presentationMode is omitted", async () => {
+      const props: UsePayPalOneTimePaymentSessionProps = {
+        orderId: "test-order-id",
+        onApprove: jest.fn(),
+        fullPageOverlay: { enabled: true },
+      };
+
+      const { result } = renderHook(() =>
+        usePayPalOneTimePaymentSession(props),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockPayPalSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          presentationMode: "auto",
+          fullPageOverlay: { enabled: true },
+        }),
+        undefined,
+      );
+    });
   });
 
   describe("handleCancel", () => {

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.test.ts
@@ -504,6 +504,26 @@ describe("usePayPalOneTimePaymentSession", () => {
         mockPayPalContext({ sdkInstance: mockSdkInstance });
       }
     });
+
+    test("should default presentationMode to 'auto' when not provided", async () => {
+      const props: UsePayPalOneTimePaymentSessionProps = {
+        orderId: "test-order-id",
+        onApprove: jest.fn(),
+      };
+
+      const { result } = renderHook(() =>
+        usePayPalOneTimePaymentSession(props),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockPayPalSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({ presentationMode: "auto" }),
+        undefined,
+      );
+    });
   });
 
   describe("handleCancel", () => {

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
@@ -51,7 +51,7 @@ export type UsePayPalOneTimePaymentSessionProps = (
  * }
  */
 export function usePayPalOneTimePaymentSession({
-  presentationMode,
+  presentationMode = "auto",
   fullPageOverlay,
   autoRedirect,
   createOrder,
@@ -168,7 +168,7 @@ export function usePayPalOneTimePaymentSession({
     }
 
     const startOptions = {
-      presentationMode: presentationMode ?? "auto",
+      presentationMode,
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
@@ -34,11 +34,12 @@ export type UsePayPalOneTimePaymentSessionProps = (
  *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * function PayPalCheckoutButton() {
  *   const { isPending, error, handleClick, handleCancel } = usePayPalOneTimePaymentSession({
  *     orderId: "ORDER-123",
- *     presentationMode: "auto",
  *     onApprove: (data) => console.log("Approved:", data),
  *   });
  *

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
@@ -10,6 +10,7 @@ import {
   PayPalPresentationModeOptions,
   PayPalOneTimePaymentSessionOptions,
   BasePaymentSessionReturn,
+  WithOptionalPresentationMode,
 } from "../types";
 
 export type UsePayPalOneTimePaymentSessionProps = (
@@ -22,7 +23,7 @@ export type UsePayPalOneTimePaymentSessionProps = (
       orderId: string;
     })
 ) &
-  PayPalPresentationModeOptions;
+  WithOptionalPresentationMode<PayPalPresentationModeOptions>;
 
 /**
  * Hook for managing one-time payment sessions with PayPal.
@@ -167,7 +168,7 @@ export function usePayPalOneTimePaymentSession({
     }
 
     const startOptions = {
-      presentationMode,
+      presentationMode: presentationMode ?? "auto",
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.test.ts
@@ -850,4 +850,41 @@ describe("usePayPalSavePaymentSession", () => {
       presentationMode: "popup",
     });
   });
+
+  test("should default presentationMode to 'auto' when not provided", async () => {
+    const mockStart = jest.fn();
+    const mockSession: SavePaymentSession = {
+      cancel: jest.fn(),
+      destroy: jest.fn(),
+      start: mockStart,
+    };
+    const mockCreatePayPalSavePaymentSession = jest
+      .fn()
+      .mockReturnValue(mockSession);
+
+    (usePayPal as jest.Mock).mockReturnValue({
+      sdkInstance: {
+        createPayPalSavePaymentSession: mockCreatePayPalSavePaymentSession,
+      },
+    });
+
+    const {
+      result: {
+        current: { handleClick },
+      },
+    } = renderHook(() =>
+      usePayPalSavePaymentSession({
+        vaultSetupToken: "vault-token-123",
+        onApprove: jest.fn(),
+      }),
+    );
+
+    await act(async () => {
+      handleClick();
+    });
+
+    expect(mockStart).toHaveBeenCalledWith(
+      expect.objectContaining({ presentationMode: "auto" }),
+    );
+  });
 });

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.test.ts
@@ -887,4 +887,45 @@ describe("usePayPalSavePaymentSession", () => {
       expect.objectContaining({ presentationMode: "auto" }),
     );
   });
+
+  test("should forward fullPageOverlay when presentationMode is omitted", async () => {
+    const mockStart = jest.fn();
+    const mockSession: SavePaymentSession = {
+      cancel: jest.fn(),
+      destroy: jest.fn(),
+      start: mockStart,
+    };
+    const mockCreatePayPalSavePaymentSession = jest
+      .fn()
+      .mockReturnValue(mockSession);
+
+    (usePayPal as jest.Mock).mockReturnValue({
+      sdkInstance: {
+        createPayPalSavePaymentSession: mockCreatePayPalSavePaymentSession,
+      },
+    });
+
+    const {
+      result: {
+        current: { handleClick },
+      },
+    } = renderHook(() =>
+      usePayPalSavePaymentSession({
+        vaultSetupToken: "vault-token-123",
+        onApprove: jest.fn(),
+        fullPageOverlay: { enabled: true },
+      }),
+    );
+
+    await act(async () => {
+      handleClick();
+    });
+
+    expect(mockStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        presentationMode: "auto",
+        fullPageOverlay: { enabled: true },
+      }),
+    );
+  });
 });

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
@@ -11,6 +11,7 @@ import type {
   PayPalPresentationModeOptions,
   SavePaymentSessionOptions,
   BasePaymentSessionReturn,
+  WithOptionalPresentationMode,
 } from "../types";
 
 export type UsePayPalSavePaymentSessionProps = (
@@ -23,7 +24,7 @@ export type UsePayPalSavePaymentSessionProps = (
       vaultSetupToken: string;
     })
 ) &
-  PayPalPresentationModeOptions;
+  WithOptionalPresentationMode<PayPalPresentationModeOptions>;
 
 /**
  * Hook for managing a PayPal save payment session, vault without purchase.
@@ -162,7 +163,7 @@ export function usePayPalSavePaymentSession({
     }
 
     const startOptions = {
-      presentationMode,
+      presentationMode: presentationMode ?? "auto",
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
@@ -35,6 +35,8 @@ export type UsePayPalSavePaymentSessionProps = (
  *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * function SavePayPalButton() {
  *   const { error, isPending, handleClick, handleCancel } = usePayPalSavePaymentSession({

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
@@ -53,7 +53,7 @@ export type UsePayPalSavePaymentSessionProps = (
  * }
  */
 export function usePayPalSavePaymentSession({
-  presentationMode,
+  presentationMode = "auto",
   fullPageOverlay,
   autoRedirect,
   createVaultToken,
@@ -163,7 +163,7 @@ export function usePayPalSavePaymentSession({
     }
 
     const startOptions = {
-      presentationMode: presentationMode ?? "auto",
+      presentationMode,
       fullPageOverlay,
       autoRedirect,
     } as PayPalPresentationModeOptions;

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.test.ts
@@ -442,6 +442,33 @@ describe("usePayPalSubscriptionPaymentSession", () => {
       );
     });
 
+    test("should forward fullPageOverlay when presentationMode is omitted", async () => {
+      const subscriptionPromise = Promise.resolve({
+        subscriptionId: "test-subscription-id",
+      });
+      const props: UsePayPalSubscriptionPaymentSessionProps = {
+        createSubscription: jest.fn().mockReturnValue(subscriptionPromise),
+        onApprove: jest.fn(),
+        fullPageOverlay: { enabled: true },
+      };
+
+      const { result } = renderHook(() =>
+        usePayPalSubscriptionPaymentSession(props),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockPayPalSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          presentationMode: "auto",
+          fullPageOverlay: { enabled: true },
+        }),
+        subscriptionPromise,
+      );
+    });
+
     test("should handle different presentation modes", async () => {
       const presentationModes = [
         "auto",

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.test.ts
@@ -419,6 +419,29 @@ describe("usePayPalSubscriptionPaymentSession", () => {
       expect(mockPayPalSession.start).not.toHaveBeenCalled();
     });
 
+    test("should default presentationMode to 'auto' when not provided", async () => {
+      const subscriptionPromise = Promise.resolve({
+        subscriptionId: "test-subscription-id",
+      });
+      const props: UsePayPalSubscriptionPaymentSessionProps = {
+        createSubscription: jest.fn().mockReturnValue(subscriptionPromise),
+        onApprove: jest.fn(),
+      };
+
+      const { result } = renderHook(() =>
+        usePayPalSubscriptionPaymentSession(props),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockPayPalSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({ presentationMode: "auto" }),
+        subscriptionPromise,
+      );
+    });
+
     test("should handle different presentation modes", async () => {
       const presentationModes = [
         "auto",

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.ts
@@ -28,9 +28,11 @@ export type UsePayPalSubscriptionPaymentSessionProps =
  *
  * @param props - Configuration options including presentation mode and callbacks
  * @param props.createSubscription - Function that returns a promise resolving to an object with subscriptionId
- * @param props.presentationMode - How the subscription experience is presented: 'popup', 'modal', 'auto', or 'payment-handler'
+ * @param props.presentationMode - (Optional, defaults to `'auto'`) How the subscription experience is presented: 'popup', 'modal', 'auto', or 'payment-handler'
  * @param props.fullPageOverlay - Whether to show a full-page overlay during the subscription flow
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
+ *
+ * `presentationMode` is optional and defaults to `"auto"`.
  *
  * @example
  * function SubscriptionCheckoutButton() {

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.ts
@@ -11,11 +11,12 @@ import type {
   PayPalSubscriptionPresentationModeOptions,
   PayPalSubscriptionPaymentSession,
   PayPalSubscriptionSessionOptions,
+  WithOptionalPresentationMode,
 } from "../types";
 
 export type UsePayPalSubscriptionPaymentSessionProps =
   PayPalSubscriptionSessionOptions &
-    PayPalSubscriptionPresentationModeOptions & {
+    WithOptionalPresentationMode<PayPalSubscriptionPresentationModeOptions> & {
       createSubscription: () => Promise<{ subscriptionId: string }>;
     };
 
@@ -129,7 +130,7 @@ export function usePayPalSubscriptionPaymentSession({
     }
 
     const startOptions = {
-      presentationMode,
+      presentationMode: presentationMode ?? "auto",
       fullPageOverlay,
     } as PayPalSubscriptionPresentationModeOptions;
 

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.ts
@@ -51,7 +51,7 @@ export type UsePayPalSubscriptionPaymentSessionProps =
  * }
  */
 export function usePayPalSubscriptionPaymentSession({
-  presentationMode,
+  presentationMode = "auto",
   fullPageOverlay,
   createSubscription,
   ...callbacks
@@ -130,7 +130,7 @@ export function usePayPalSubscriptionPaymentSession({
     }
 
     const startOptions = {
-      presentationMode: presentationMode ?? "auto",
+      presentationMode,
       fullPageOverlay,
     } as PayPalSubscriptionPresentationModeOptions;
 

--- a/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.test.ts
@@ -459,6 +459,24 @@ describe("useVenmoOneTimePaymentSession", () => {
       expect(mockVenmoSession.start).not.toHaveBeenCalled();
     });
 
+    test("should default presentationMode to 'auto' when not provided", async () => {
+      const props: UseVenmoOneTimePaymentSessionProps = {
+        orderId: "test-order-id",
+        onApprove: jest.fn(),
+      };
+
+      const { result } = renderHook(() => useVenmoOneTimePaymentSession(props));
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockVenmoSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({ presentationMode: "auto" }),
+        undefined,
+      );
+    });
+
     test("should handle different presentation modes", async () => {
       const presentationModes = ["auto", "popup", "modal"] as const;
 

--- a/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.test.ts
@@ -477,6 +477,28 @@ describe("useVenmoOneTimePaymentSession", () => {
       );
     });
 
+    test("should forward fullPageOverlay when presentationMode is omitted", async () => {
+      const props: UseVenmoOneTimePaymentSessionProps = {
+        orderId: "test-order-id",
+        onApprove: jest.fn(),
+        fullPageOverlay: { enabled: true },
+      };
+
+      const { result } = renderHook(() => useVenmoOneTimePaymentSession(props));
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      expect(mockVenmoSession.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          presentationMode: "auto",
+          fullPageOverlay: { enabled: true },
+        }),
+        undefined,
+      );
+    });
+
     test("should handle different presentation modes", async () => {
       const presentationModes = ["auto", "popup", "modal"] as const;
 

--- a/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.ts
@@ -35,10 +35,11 @@ export type UseVenmoOneTimePaymentSessionProps = (
  *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
  *
+ * `presentationMode` is optional and defaults to `"auto"`.
+ *
  * @example
  * function VenmoCheckout() {
  *   const { error, isPending, handleClick, handleCancel } = useVenmoOneTimePaymentSession({
- *     presentationMode: 'auto',
  *     createOrder: async () => ({ orderId: 'ORDER-123' }),
  *     onApprove: (data) => console.log('Approved:', data),
  *     onCancel: () => console.log('Cancelled'),

--- a/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.ts
@@ -12,6 +12,7 @@ import type {
   VenmoOneTimePaymentSessionOptions,
   VenmoOneTimePaymentSessionPromise,
   BasePaymentSessionReturn,
+  WithOptionalPresentationMode,
 } from "../types";
 
 export type UseVenmoOneTimePaymentSessionProps = (
@@ -24,7 +25,7 @@ export type UseVenmoOneTimePaymentSessionProps = (
       orderId: string;
     })
 ) &
-  VenmoPresentationModeOptions;
+  WithOptionalPresentationMode<VenmoPresentationModeOptions>;
 
 /**
  * Hook for managing Venmo one-time payment sessions.
@@ -133,7 +134,7 @@ export function useVenmoOneTimePaymentSession({
     }
 
     const startOptions = {
-      presentationMode,
+      presentationMode: presentationMode ?? "auto",
       fullPageOverlay,
     } as VenmoPresentationModeOptions;
 

--- a/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.ts
@@ -53,7 +53,7 @@ export type UseVenmoOneTimePaymentSessionProps = (
  * }
  */
 export function useVenmoOneTimePaymentSession({
-  presentationMode,
+  presentationMode = "auto",
   fullPageOverlay,
   createOrder,
   orderId,
@@ -134,7 +134,7 @@ export function useVenmoOneTimePaymentSession({
     }
 
     const startOptions = {
-      presentationMode: presentationMode ?? "auto",
+      presentationMode,
       fullPageOverlay,
     } as VenmoPresentationModeOptions;
 

--- a/packages/react-paypal-js/src/v6/types/index.ts
+++ b/packages/react-paypal-js/src/v6/types/index.ts
@@ -12,3 +12,20 @@ export interface BasePaymentSessionReturn {
   handleCancel: () => void;
   handleDestroy: () => void;
 }
+
+/**
+ * Wraps an SDK presentation-mode discriminated union so that the `presentationMode`
+ * discriminator becomes optional. When omitted, the React hook defaults it to `"auto"`
+ * at runtime, so the consumer can rely on the `"auto"` branch's sibling-field shape.
+ *
+ * Either: the user picks a mode explicitly (the original strict union applies) — or:
+ * they omit `presentationMode`, in which case only the auto-branch's allowed siblings
+ * are valid.
+ */
+export type WithOptionalPresentationMode<
+  T extends { presentationMode: string },
+> =
+  | T
+  | (Omit<Extract<T, { presentationMode: "auto" }>, "presentationMode"> & {
+      presentationMode?: undefined;
+    });


### PR DESCRIPTION
This PR loosens the v6 Button and Hook prop types strictness for the key `presentationMode`. This property is currently required based on the types in `paypal-js`. With this change each hook will default to `auto` and the button components will no longer carry the requirement of including a `presentationMode` prop.

This is an alternative solution to the issue brought up [here](https://github.com/paypal/paypal-js/issues/933).