### PR TITLE
Fix: One Time Payment session type

### DIFF
--- a/.changeset/two-melons-read.md
+++ b/.changeset/two-melons-read.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Update paypal one time payment session start options to be optional.

--- a/packages/paypal-js/types/v6/components/paypal-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/paypal-payments.d.ts
@@ -112,7 +112,9 @@ export type PayPalPresentationModeOptions =
 
 export type OneTimePaymentSession = BasePaymentSession & {
   start: (
-    presentationModeOptions: PayPalPresentationModeOptions,
+    presentationModeOptions?: PayPalPresentationModeOptions = {
+      presentationMode: "auto",
+    },
     paymentSessionPromise?: Promise<{ orderId: string }>,
   ) => Promise<void | { redirectURL?: string }>;
   hasReturned?: () => boolean;


### PR DESCRIPTION
Updates an overlooked instance of `.start` that needs to include optional `options` argument.