### PR TITLE
fix(types): add shipping address change errors

### DIFF
--- a/.changeset/quiet-rivers-reject.md
+++ b/.changeset/quiet-rivers-reject.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Add shipping address change error messages to the buttons component types.

--- a/packages/paypal-js/types/components/buttons.d.ts
+++ b/packages/paypal-js/types/components/buttons.d.ts
@@ -155,6 +155,14 @@ type OnShippingAddressChangeBuildOrderPatchPayloadArgs =
     shippingOptions?: CheckoutShippingOption[];
   };
 
+type ShippingAddressErrorType =
+  | "ADDRESS_ERROR"
+  | "COUNTRY_ERROR"
+  | "STATE_ERROR"
+  | "ZIP_ERROR";
+
+type ShippingAddressErrorMessages = Record<ShippingAddressErrorType, string>;
+
 type OnShippingOptionsChangeActions = {
   buildOrderPatchPayload: ({
     discount,
@@ -170,6 +178,7 @@ type OnShippingOptionsChangeActions = {
 
 type OnShippingAddressChangeData = {
   amount: CurrencyCodeAndValue;
+  errors: ShippingAddressErrorMessages;
   orderID?: string;
   paymentID?: string;
   paymentToken?: string;
@@ -196,7 +205,7 @@ type OnShippingAddressChangeActions = {
     shippingDiscount,
     taxTotal,
   }: OnShippingAddressChangeBuildOrderPatchPayloadArgs) => PatchOrderRequestBody;
-  reject: () => Promise<void>;
+  reject: (error: string) => Promise<void>;
 };
 
 export type DisplayOnlyOptions = "vaultable";

--- a/packages/paypal-js/types/tests/buttons.test.ts
+++ b/packages/paypal-js/types/tests/buttons.test.ts
@@ -91,6 +91,16 @@ async function main() {
     },
   });
 
+  paypal.Buttons({
+    onShippingAddressChange: (data, actions) => {
+      if (data.shippingAddress.countryCode !== "US") {
+        return actions.reject(data.errors.COUNTRY_ERROR);
+      }
+
+      return Promise.resolve();
+    },
+  });
+
   paypal
     .Buttons({
       onClick: (data, actions) => {


### PR DESCRIPTION
## Summary

Fixes #824 by updating the `onShippingAddressChange` button callback types to match the documented JavaScript SDK shape:

- adds `data.errors` with the documented shipping address error keys
- updates `actions.reject` to accept an error message string
- adds a type test that rejects unsupported countries with `data.errors.COUNTRY_ERROR`

PayPal docs reference: https://developer.paypal.com/docs/regional/th/checkout/reference/customize-sdk/#onshippingaddresschange

## Validation

```bash
npx prettier --check packages/paypal-js/types/components/buttons.d.ts packages/paypal-js/types/tests/buttons.test.ts
npm run typecheck --workspace=@paypal/paypal-js
npm run lint --workspace=@paypal/paypal-js
git diff --check
```