### PR TITLE
feat(types): add v6 web component DOM types

### DIFF
--- a/.changeset/soft-timers-greet.md
+++ b/.changeset/soft-timers-greet.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Add v6 web component DOM element types for PayPal, Venmo, Pay Later, card, message, and Apple Pay custom elements.

--- a/packages/paypal-js/types/v6/components/web-components.d.ts
+++ b/packages/paypal-js/types/v6/components/web-components.d.ts
@@ -1,0 +1,56 @@
+import { OnErrorData } from "./base-component";
+
+export interface PayPalButtonElement extends HTMLElement {
+  type?: "buynow" | "checkout" | "donate" | "pay" | "subscribe";
+  disabled?: boolean;
+  onError?: (data: OnErrorData) => void;
+}
+
+export interface PayPalPayLaterButtonElement extends HTMLElement {
+  countryCode?: string;
+  productCode?: string;
+  disabled?: boolean;
+}
+
+export interface PayPalCreditButtonElement extends HTMLElement {
+  countryCode?: string;
+  disabled?: boolean;
+}
+
+export interface PayPalBasicCardButtonElement extends HTMLElement {
+  buyerCountry?: string;
+  disabled?: boolean;
+}
+
+export interface PayPalMessageElement extends HTMLElement {
+  amount?: string;
+  "auto-bootstrap"?: boolean;
+  "buyer-country"?: string;
+  "currency-code"?: string;
+  "logo-position"?: "INLINE" | "LEFT" | "RIGHT" | "TOP";
+  "logo-type"?: "MONOGRAM" | "WORDMARK";
+  "offer-types"?: string;
+  "presentation-mode"?: "AUTO" | "MODAL" | "POPUP" | "REDIRECT";
+  "text-color"?: "BLACK" | "MONOCHROME" | "WHITE";
+  setContent?: (content: Record<string, unknown>) => void;
+}
+
+export interface ApplePayButtonElement extends HTMLElement {
+  buttonstyle?: string;
+  type?: string;
+  locale?: string;
+  disabled?: boolean;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "paypal-button": PayPalButtonElement;
+    "venmo-button": PayPalButtonElement;
+    "paypal-pay-later-button": PayPalPayLaterButtonElement;
+    "paypal-credit-button": PayPalCreditButtonElement;
+    "paypal-basic-card-button": PayPalBasicCardButtonElement;
+    "paypal-basic-card-container": HTMLElement;
+    "paypal-message": PayPalMessageElement;
+    "apple-pay-button": ApplePayButtonElement;
+  }
+}

--- a/packages/paypal-js/types/v6/index.d.ts
+++ b/packages/paypal-js/types/v6/index.d.ts
@@ -256,6 +256,7 @@ export * from "./components/paypal-messages";
 export * from "./components/paypal-subscriptions";
 export * from "./components/applepay-payments";
 export * from "./components/googlepay-payments";
+export * from "./components/web-components";
 
 // export a subset of types from base-component
 export {

--- a/packages/paypal-js/types/v6/tests/web-components.test.ts
+++ b/packages/paypal-js/types/v6/tests/web-components.test.ts
@@ -1,0 +1,58 @@
+import type {
+  ApplePayButtonElement,
+  PayPalBasicCardButtonElement,
+  PayPalButtonElement,
+  PayPalCreditButtonElement,
+  PayPalMessageElement,
+  PayPalPayLaterButtonElement,
+} from "../index";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function main() {
+  const paypalButton = document.createElement("paypal-button");
+  paypalButton.type = "checkout";
+  paypalButton.disabled = true;
+  paypalButton.onError = (error) => {
+    console.error(error.code);
+  };
+  const typedPayPalButton: PayPalButtonElement = paypalButton;
+
+  const venmoButton = document.querySelector("venmo-button");
+  venmoButton?.addEventListener("click", () => {});
+  const typedVenmoButton: PayPalButtonElement | null = venmoButton;
+
+  const payLaterButton = document.createElement("paypal-pay-later-button");
+  payLaterButton.countryCode = "US";
+  payLaterButton.productCode = "PAY_LATER_SHORT_TERM";
+  const typedPayLaterButton: PayPalPayLaterButtonElement = payLaterButton;
+
+  const creditButton = document.createElement("paypal-credit-button");
+  creditButton.countryCode = "US";
+  const typedCreditButton: PayPalCreditButtonElement = creditButton;
+
+  const basicCardButton = document.createElement("paypal-basic-card-button");
+  basicCardButton.buyerCountry = "US";
+  const typedBasicCardButton: PayPalBasicCardButtonElement = basicCardButton;
+
+  const message = document.createElement("paypal-message");
+  message.amount = "10.00";
+  message["currency-code"] = "USD";
+  message["logo-position"] = "INLINE";
+  message.setContent?.({ amount: "10.00" });
+  const typedMessage: PayPalMessageElement = message;
+
+  const applePayButton = document.createElement("apple-pay-button");
+  applePayButton.buttonstyle = "black";
+  applePayButton.locale = "en-US";
+  const typedApplePayButton: ApplePayButtonElement = applePayButton;
+
+  console.log({
+    typedPayPalButton,
+    typedVenmoButton,
+    typedPayLaterButton,
+    typedCreditButton,
+    typedBasicCardButton,
+    typedMessage,
+    typedApplePayButton,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds DOM element interfaces for v6 SDK web components such as `paypal-button`, `venmo-button`, `paypal-message`, and `apple-pay-button`.
- Augments `HTMLElementTagNameMap` so vanilla TypeScript users get typed results from `document.createElement()` and `document.querySelector()`.
- Adds a v6 type test covering common properties and event listener usage.

This is a focused step toward #924 for non-React / DOM integrations. It does not attempt to define every framework-specific JSX namespace.

## Validation
- `npx prettier --check .changeset/soft-timers-greet.md packages/paypal-js/types/v6/components/web-components.d.ts packages/paypal-js/types/v6/tests/web-components.test.ts packages/paypal-js/types/v6/index.d.ts`
- `npm run typecheck --workspace=@paypal/paypal-js`
- `npm run lint --workspace=@paypal/paypal-js`
- `git diff --check`

Fixes #924