### PR TITLE
fix: require explicit v6 sdk environment

### DIFF
--- a/.changeset/wise-seals-choose.md
+++ b/.changeset/wise-seals-choose.md
@@ -1,0 +1,6 @@
+---
+"@paypal/paypal-js": major
+"@paypal/react-paypal-js": major
+---
+
+Require an explicit V6 SDK `environment` option so integrations do not silently load the sandbox SDK when the option is omitted.

--- a/packages/paypal-js/README.md
+++ b/packages/paypal-js/README.md
@@ -299,18 +299,18 @@ Use `loadCoreSdkScript()` to asynchronously load the V6 SDK:
 import { loadCoreSdkScript } from "@paypal/paypal-js/sdk-v6";
 
 const paypal = await loadCoreSdkScript({
-  environment: "sandbox", // "sandbox" | "production"
+  environment: "sandbox", // required: "sandbox" | "production"
   debug: true, // optional
 });
 ```
 
 **Options:**
 
-| Option          | Type                          | Description             |
-| --------------- | ----------------------------- | ----------------------- |
-| `environment`   | `"sandbox"` \| `"production"` | Target environment      |
-| `debug`         | `boolean`                     | Enable debug mode       |
-| `dataNamespace` | `string`                      | Custom global namespace |
+| Option          | Type                          | Required | Description                                                                        |
+| --------------- | ----------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `environment`   | `"sandbox"` \| `"production"` | Yes      | Target environment. The `clientId` does not determine which environment is loaded. |
+| `debug`         | `boolean`                     | No       | Enable debug mode                                                                  |
+| `dataNamespace` | `string`                      | No       | Custom global namespace                                                            |
 
 ### Creating an SDK Instance
 

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -23,16 +23,13 @@ describe("loadCoreSdkScript()", () => {
       });
   });
 
-  test("should default to using the sandbox environment", async () => {
-    const result = await loadCoreSdkScript();
-    expect(scriptAppendChildSpy).toHaveBeenCalledTimes(1);
-    const scriptElement = scriptAppendChildSpy.mock.calls[0][0];
-    expect(scriptElement.src).toBe(
-      "https://www.sandbox.paypal.com/web-sdk/v6/core",
+  test("should require an explicit environment", async () => {
+    expect(async () => {
+      await loadCoreSdkScript();
+    }).rejects.toThrowError(
+      'The "environment" option is required and must be either "production" or "sandbox"',
     );
-    expect(scriptElement.getAttribute("data-loading-state")).toBe("resolved");
-    expect(result).toBeDefined();
-    expect(window.paypal).toBeDefined();
+    expect(scriptAppendChildSpy).toHaveBeenCalledTimes(0);
   });
 
   test("should support options for using production environment", async () => {
@@ -46,7 +43,10 @@ describe("loadCoreSdkScript()", () => {
   });
 
   test("should support enabling debugging", async () => {
-    const result = await loadCoreSdkScript({ debug: true });
+    const result = await loadCoreSdkScript({
+      environment: "sandbox",
+      debug: true,
+    });
     expect(scriptAppendChildSpy).toHaveBeenCalledTimes(1);
     const scriptElement = scriptAppendChildSpy.mock.calls[0][0];
     expect(scriptElement.src).toBe(
@@ -58,8 +58,8 @@ describe("loadCoreSdkScript()", () => {
   });
 
   test("should avoid inserting two script elements when called twice sequentially", async () => {
-    const result1 = await loadCoreSdkScript();
-    const result2 = await loadCoreSdkScript();
+    const result1 = await loadCoreSdkScript({ environment: "sandbox" });
+    const result2 = await loadCoreSdkScript({ environment: "sandbox" });
     // should only insert the script once
     // the existing loaded window.paypal reference is returned on the second call
     expect(scriptAppendChildSpy).toHaveBeenCalledTimes(1);
@@ -76,8 +76,8 @@ describe("loadCoreSdkScript()", () => {
 
   test("should avoid inserting two script elements when called twice in parallel", async () => {
     const [result1, result2] = await Promise.all([
-      loadCoreSdkScript(),
-      loadCoreSdkScript(),
+      loadCoreSdkScript({ environment: "sandbox" }),
+      loadCoreSdkScript({ environment: "sandbox" }),
     ]);
     // should only insert the script once
     expect(scriptAppendChildSpy).toHaveBeenCalledTimes(1);
@@ -94,7 +94,9 @@ describe("loadCoreSdkScript()", () => {
 
   test("should return reference to existing script when loading state is pending", async () => {
     document.head.innerHTML = `<script src="https://www.sandbox.paypal.com/web-sdk/v6/core" data-loading-state="pending"></script>`;
-    const loadCoreSdkScriptReference = loadCoreSdkScript();
+    const loadCoreSdkScriptReference = loadCoreSdkScript({
+      environment: "sandbox",
+    });
 
     process.nextTick(() => {
       vi.stubGlobal("paypal", { version: "6" });
@@ -123,7 +125,7 @@ describe("loadCoreSdkScript()", () => {
     });
 
     expect(async () => {
-      await loadCoreSdkScript();
+      await loadCoreSdkScript({ environment: "sandbox" });
     }).rejects.toThrowError(
       'The script "https://www.sandbox.paypal.com/web-sdk/v6/core" failed to load. Check the HTTP status code and response body in DevTools to learn more.',
     );
@@ -148,6 +150,7 @@ describe("loadCoreSdkScript()", () => {
       const customNamespace = "myCustomNamespace";
 
       const result = await loadCoreSdkScript({
+        environment: "sandbox",
         dataNamespace: customNamespace,
       });
 
@@ -168,7 +171,7 @@ describe("loadCoreSdkScript()", () => {
 
     test("should error when dataNamespace is an empty string", async () => {
       expect(async () => {
-        await loadCoreSdkScript({ dataNamespace: "" });
+        await loadCoreSdkScript({ environment: "sandbox", dataNamespace: "" });
       }).rejects.toThrowError(
         'The "dataNamespace" option cannot be an empty string',
       );
@@ -176,7 +179,10 @@ describe("loadCoreSdkScript()", () => {
 
     test("should error when dataNamespace is only whitespace", async () => {
       expect(async () => {
-        await loadCoreSdkScript({ dataNamespace: "   " });
+        await loadCoreSdkScript({
+          environment: "sandbox",
+          dataNamespace: "   ",
+        });
       }).rejects.toThrowError(
         'The "dataNamespace" option cannot be an empty string',
       );
@@ -188,6 +194,7 @@ describe("loadCoreSdkScript()", () => {
       const integrationSource = "react-paypal-js";
 
       const result = await loadCoreSdkScript({
+        environment: "sandbox",
         dataSdkIntegrationSource: integrationSource,
       });
 
@@ -207,7 +214,10 @@ describe("loadCoreSdkScript()", () => {
 
     test("should error when dataSdkIntegrationSource is an empty string", async () => {
       expect(async () => {
-        await loadCoreSdkScript({ dataSdkIntegrationSource: "" });
+        await loadCoreSdkScript({
+          environment: "sandbox",
+          dataSdkIntegrationSource: "",
+        });
       }).rejects.toThrowError(
         'The "dataSdkIntegrationSource" option cannot be an empty string',
       );
@@ -215,7 +225,10 @@ describe("loadCoreSdkScript()", () => {
 
     test("should error when dataSdkIntegrationSource is only whitespace", async () => {
       expect(async () => {
-        await loadCoreSdkScript({ dataSdkIntegrationSource: "   " });
+        await loadCoreSdkScript({
+          environment: "sandbox",
+          dataSdkIntegrationSource: "   ",
+        });
       }).rejects.toThrowError(
         'The "dataSdkIntegrationSource" option cannot be an empty string',
       );

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -25,6 +25,7 @@ describe("loadCoreSdkScript()", () => {
 
   test("should require an explicit environment", async () => {
     expect(async () => {
+      // @ts-expect-error missing required environment
       await loadCoreSdkScript();
     }).rejects.toThrowError(
       'The "environment" option is required and must be either "production" or "sandbox"',

--- a/packages/paypal-js/src/v6/index.ts
+++ b/packages/paypal-js/src/v6/index.ts
@@ -14,15 +14,17 @@ const SCRIPT_LOADING_STATE = {
 
 const DATA_ATTRIBUTE_LOADING_STATE = "data-loading-state";
 
-function loadCoreSdkScript(options: LoadCoreSdkScriptOptions = {}) {
-  validateArguments(options);
+function loadCoreSdkScript(options?: LoadCoreSdkScriptOptions) {
+  const scriptOptions = options ?? {};
+
+  validateArguments(scriptOptions);
+
+  const { environment, debug, dataNamespace, dataSdkIntegrationSource } =
+    scriptOptions as LoadCoreSdkScriptOptions;
 
   if (isServer()) {
     return Promise.resolve(null);
   }
-
-  const { environment, debug, dataNamespace, dataSdkIntegrationSource } =
-    options;
   const namespace = dataNamespace ?? "paypal";
   const paypalWindowReference = getPayPalWindowNamespace(namespace);
   if (paypalWindowReference?.version.startsWith("6")) {
@@ -101,11 +103,13 @@ function validateArguments(options: unknown) {
   const { environment, dataNamespace, dataSdkIntegrationSource } =
     options as LoadCoreSdkScriptOptions;
 
-  if (
-    environment &&
-    environment !== "production" &&
-    environment !== "sandbox"
-  ) {
+  if (!environment) {
+    throw new Error(
+      'The "environment" option is required and must be either "production" or "sandbox"',
+    );
+  }
+
+  if (environment !== "production" && environment !== "sandbox") {
     throw new Error(
       'The "environment" option must be either "production" or "sandbox"',
     );

--- a/packages/paypal-js/src/v6/index.ts
+++ b/packages/paypal-js/src/v6/index.ts
@@ -14,6 +14,9 @@ const SCRIPT_LOADING_STATE = {
 
 const DATA_ATTRIBUTE_LOADING_STATE = "data-loading-state";
 
+function loadCoreSdkScript(
+  options: LoadCoreSdkScriptOptions,
+): Promise<PayPalV6Namespace | null>;
 function loadCoreSdkScript(options?: LoadCoreSdkScriptOptions) {
   const scriptOptions = options ?? {};
 

--- a/packages/paypal-js/types/v6/index.d.ts
+++ b/packages/paypal-js/types/v6/index.d.ts
@@ -237,7 +237,7 @@ interface CoreSdkScriptDataAttributes {
 }
 
 export interface LoadCoreSdkScriptOptions extends CoreSdkScriptDataAttributes {
-  environment?: "production" | "sandbox";
+  environment: "production" | "sandbox";
   debug?: boolean;
 }
 

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -78,6 +78,7 @@ import {
 function App() {
   return (
     <PayPalProvider
+      environment="sandbox"
       clientId="your-client-id"
       components={["paypal-payments"]}
       pageType="checkout"
@@ -121,7 +122,7 @@ The `PayPalProvider` component is the entry point for the V6 SDK. It handles loa
 | `components`              | `Components[]`                       | No       | SDK components to load. Defaults to `["paypal-payments"]`.                                                   |
 | `pageType`                | `string`                             | No       | Type of page: `"checkout"`, `"product-details"`, `"cart"`, `"product-listing"`, etc.                         |
 | `locale`                  | `string`                             | No       | Locale for the SDK (e.g., `"en_US"`).                                                                        |
-| `environment`             | `"sandbox" \| "production"`          | No       | SDK environment.                                                                                             |
+| `environment`             | `"sandbox" \| "production"`          | Yes      | SDK environment. The `clientId` does not determine which environment is loaded.                              |
 | `merchantId`              | `string \| string[]`                 | No       | PayPal merchant ID(s).                                                                                       |
 | `clientMetadataId`        | `string`                             | No       | Client metadata ID for tracking.                                                                             |
 | `partnerAttributionId`    | `string`                             | No       | Partner attribution ID (BN code).                                                                            |
@@ -153,6 +154,7 @@ function App() {
 
   return (
     <PayPalProvider
+      environment="sandbox"
       clientId={clientIdPromise}
       components={["paypal-payments"]}
       pageType="checkout"
@@ -172,6 +174,7 @@ function App() {
 
   return (
     <PayPalProvider
+      environment="sandbox"
       clientToken={tokenPromise}
       components={["paypal-payments"]}
       pageType="checkout"
@@ -194,6 +197,7 @@ function App() {
 
   return (
     <PayPalProvider
+      environment="sandbox"
       clientId={clientId}
       components={["paypal-payments"]}
       pageType="checkout"
@@ -280,6 +284,7 @@ Renders a Venmo button for one-time payments. Requires `"venmo-payments"` in the
 import { VenmoOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 <PayPalProvider
+  environment="sandbox"
   clientId={clientId}
   components={["paypal-payments", "venmo-payments"]}
   pageType="checkout"
@@ -371,6 +376,7 @@ function GooglePayCheckout() {
 function App() {
   return (
     <PayPalProvider
+      environment="sandbox"
       clientId="your-client-id"
       components={["googlepay-payments"]}
       pageType="checkout"
@@ -431,6 +437,7 @@ Renders a guest checkout button for card payments without a PayPal account (Bran
 import { PayPalGuestPaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 <PayPalProvider
+  environment="sandbox"
   clientId={clientId}
   components={["paypal-payments", "paypal-guest-payments"]}
   pageType="checkout"
@@ -490,6 +497,7 @@ Renders a PayPal button for subscription payments. Requires `"paypal-subscriptio
 import { PayPalSubscriptionButton } from "@paypal/react-paypal-js/sdk-v6";
 
 <PayPalProvider
+  environment="sandbox"
   clientId={clientId}
   components={["paypal-subscriptions"]}
   pageType="checkout"
@@ -690,6 +698,7 @@ function ApplePayCheckout() {
 export default function App() {
   return (
     <PayPalProvider
+      environment="sandbox"
       clientId="YOUR_CLIENT_ID"
       components={["applepay-payments"]}
       pageType="checkout"
@@ -1193,6 +1202,7 @@ import {
 function App() {
   return (
     <PayPalProvider
+      environment="sandbox"
       clientToken="your-client-token"
       components={["card-fields"]}
       pageType="checkout"
@@ -1857,6 +1867,7 @@ export default async function CheckoutPage() {
 
   return (
     <PayPalProvider
+      environment="sandbox"
       clientId={clientId}
       pageType="checkout"
       eligibleMethodsResponse={eligibleMethodsResponse}
@@ -1908,7 +1919,7 @@ import {
   PayPalOneTimePaymentButton,
 } from "@paypal/react-paypal-js/sdk-v6";
 
-<PayPalProvider clientId={clientId} pageType="checkout">
+<PayPalProvider environment="sandbox" clientId={clientId} pageType="checkout">
   <PayPalOneTimePaymentButton
     createOrder={async () => {
       const res = await fetch("/api/orders", { method: "POST" });

--- a/packages/react-paypal-js/src/v6/components/PayPalProvider.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalProvider.tsx
@@ -59,6 +59,7 @@ type PayPalProviderProps =
  * @example
  * // With string clientToken
  * <PayPalProvider
+ *   environment="sandbox"
  *   clientToken={token}
  *   components={["paypal-payments", "venmo-payments"]}
  *   pageType="checkout"
@@ -69,6 +70,7 @@ type PayPalProviderProps =
  * @example
  * // With string clientId
  * <PayPalProvider
+ *   environment="sandbox"
  *   clientId="YOUR_CLIENT_ID"
  *   components={["paypal-payments"]}
  *   pageType="checkout"
@@ -81,6 +83,7 @@ type PayPalProviderProps =
  * const tokenPromise = useMemo(() => fetchClientToken(), []);
  *
  * <PayPalProvider
+ *   environment="sandbox"
  *   clientToken={tokenPromise}
  *   pageType="checkout"
  * >
@@ -92,6 +95,7 @@ type PayPalProviderProps =
  * const clientIdPromise = useMemo(() => fetchClientId(), []);
  *
  * <PayPalProvider
+ *   environment="sandbox"
  *   clientId={clientIdPromise}
  *   pageType="checkout"
  * >
@@ -107,6 +111,7 @@ type PayPalProviderProps =
  * }, []);
  *
  * <PayPalProvider
+ *   environment="sandbox"
  *   clientToken={clientToken}
  *   pageType="checkout"
  * >
@@ -122,6 +127,7 @@ type PayPalProviderProps =
  * }, []);
  *
  * <PayPalProvider
+ *   environment="sandbox"
  *   clientId={clientId}
  *   pageType="checkout"
  * >
@@ -141,7 +147,7 @@ type PayPalProviderProps =
  *   return <PayPalOneTimePaymentButton orderId="ORDER-123" />;
  * }
  *
- * <PayPalProvider clientToken={token} pageType="checkout">
+ * <PayPalProvider environment="sandbox" clientToken={token} pageType="checkout">
  *   <MyCheckout />
  * </PayPalProvider>
  */


### PR DESCRIPTION
## Summary

Closes #945.

This makes the V6 SDK environment an explicit choice instead of silently falling back to sandbox when `environment` is omitted.

Changes:
- require `environment` in `LoadCoreSdkScriptOptions`
- throw a clear runtime error when `loadCoreSdkScript()` is called without `environment`
- update V6 loader tests from "default sandbox" to "explicit environment required"
- add `environment="sandbox"` to `PayPalProvider` docs/examples and mark the prop as required
- add a changeset for `@paypal/paypal-js` and `@paypal/react-paypal-js`

## Why

In V6, the `clientId` does not select sandbox vs production. If `environment` is omitted, the current loader falls through to `https://www.sandbox.paypal.com`, which can make a production integration silently load the sandbox SDK.

## Validation

- `npx vitest run src/v6/index.test.ts` from `packages/paypal-js`
- `npm run typecheck --workspace=@paypal/paypal-js`
- `npm run typecheck --workspace=@paypal/react-paypal-js`
- `npm run test --workspace=@paypal/react-paypal-js -- src/v6/components/PayPalProvider.test.tsx --runInBand`
- `npx prettier --check .changeset/wise-seals-choose.md packages/paypal-js/README.md packages/paypal-js/src/v6/index.ts packages/paypal-js/src/v6/index.test.ts packages/paypal-js/types/v6/index.d.ts packages/react-paypal-js/README.md packages/react-paypal-js/src/v6/components/PayPalProvider.tsx`
- `git diff --check`

Note: `npm run build --workspace=@paypal/paypal-js` fails on Windows before Rollup because the package script uses `rm -rf`. I verified the needed local build by running `npx rollup --config --bundleConfigAsCjs` from `packages/paypal-js`.