### PR TITLE
Fix: Make environment required

### DIFF
--- a/.changeset/bitter-kids-return.md
+++ b/.changeset/bitter-kids-return.md
@@ -3,3 +3,18 @@
 ---
 
 **BREAKING:** The v6 `environment` option is now required in the `PayPalProvider`. Previously, omitting `environment` silently defaulted to sandbox, which could cause production builds to load the sandbox SDK with a live `clientId`. Pass `environment: "production"` or `environment: "sandbox"` explicitly. TypeScript users will see a compile error; runtime callers will see a thrown `Error`.
+
+### v6 PayPalProvider
+
+Update the PayPalProvider to pass the environment property
+
+```
+<PayPalProvider
+  clientId={clientId}
+  environment="sandbox" // "production"
+  components={["paypal-payments",]}
+  pageType="checkout"
+>
+  <CheckoutPage />
+</PayPalProvider>
+```

--- a/.changeset/bitter-kids-return.md
+++ b/.changeset/bitter-kids-return.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": major
+---
+
+**BREAKING:** The v6 `environment` option is now required in the `PayPalProvider`. Previously, omitting `environment` silently defaulted to sandbox, which could cause production builds to load the sandbox SDK with a live `clientId`. Pass `environment: "production"` or `environment: "sandbox"` explicitly. TypeScript users will see a compile error; runtime callers will see a thrown `Error`.

--- a/.changeset/strict-otters-shout.md
+++ b/.changeset/strict-otters-shout.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": major
+---
+
+**BREAKING:** The v6 `environment` option is now required on `loadCoreSdkScript`. Previously, omitting `environment` silently defaulted to sandbox, which could cause production builds to load the sandbox SDK with a live `clientId`. Pass `environment: "production"` or `environment: "sandbox"` explicitly. TypeScript users will see a compile error; runtime callers will see a thrown `Error`.

--- a/.changeset/strict-otters-shout.md
+++ b/.changeset/strict-otters-shout.md
@@ -3,3 +3,13 @@
 ---
 
 **BREAKING:** The v6 `environment` option is now required on `loadCoreSdkScript`. Previously, omitting `environment` silently defaulted to sandbox, which could cause production builds to load the sandbox SDK with a live `clientId`. Pass `environment: "production"` or `environment: "sandbox"` explicitly. TypeScript users will see a compile error; runtime callers will see a thrown `Error`.
+
+### v6 loadCoreSdkScript
+
+Update usage of loadCoreSdkScript to pass the environment property correctly
+
+```
+const paypalGlobalNamespace = await loadCoreSdkScript({
+  environment: "sandbox", // "production"
+});
+```

--- a/packages/paypal-js/README.md
+++ b/packages/paypal-js/README.md
@@ -306,11 +306,13 @@ const paypal = await loadCoreSdkScript({
 
 **Options:**
 
-| Option          | Type                          | Description             |
-| --------------- | ----------------------------- | ----------------------- |
-| `environment`   | `"sandbox"` \| `"production"` | Target environment      |
-| `debug`         | `boolean`                     | Enable debug mode       |
-| `dataNamespace` | `string`                      | Custom global namespace |
+> **Important:** `environment` is **required**. The `clientId` does not determine which environment is loaded in v6 — `environment` does. A live `clientId` will still load the sandbox SDK if `environment: "sandbox"` is passed.
+
+| Option          | Type                          | Description                                                                                            |
+| --------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `environment`   | `"sandbox"` \| `"production"` | **Required.** Target environment. `clientId` does not select the environment in v6 — this option does. |
+| `debug`         | `boolean`                     | Enable debug mode                                                                                      |
+| `dataNamespace` | `string`                      | Custom global namespace                                                                                |
 
 ### Creating an SDK Instance
 

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -23,8 +23,8 @@ describe("loadCoreSdkScript()", () => {
       });
   });
 
-  test("should default to using the sandbox environment", async () => {
-    const result = await loadCoreSdkScript();
+  test("should load the sandbox environment when environment is 'sandbox'", async () => {
+    const result = await loadCoreSdkScript({ environment: "sandbox" });
     expect(scriptAppendChildSpy).toHaveBeenCalledTimes(1);
     const scriptElement = scriptAppendChildSpy.mock.calls[0][0];
     expect(scriptElement.src).toBe(
@@ -46,7 +46,10 @@ describe("loadCoreSdkScript()", () => {
   });
 
   test("should support enabling debugging", async () => {
-    const result = await loadCoreSdkScript({ debug: true });
+    const result = await loadCoreSdkScript({
+      environment: "sandbox",
+      debug: true,
+    });
     expect(scriptAppendChildSpy).toHaveBeenCalledTimes(1);
     const scriptElement = scriptAppendChildSpy.mock.calls[0][0];
     expect(scriptElement.src).toBe(
@@ -58,8 +61,8 @@ describe("loadCoreSdkScript()", () => {
   });
 
   test("should avoid inserting two script elements when called twice sequentially", async () => {
-    const result1 = await loadCoreSdkScript();
-    const result2 = await loadCoreSdkScript();
+    const result1 = await loadCoreSdkScript({ environment: "sandbox" });
+    const result2 = await loadCoreSdkScript({ environment: "sandbox" });
     // should only insert the script once
     // the existing loaded window.paypal reference is returned on the second call
     expect(scriptAppendChildSpy).toHaveBeenCalledTimes(1);
@@ -76,8 +79,8 @@ describe("loadCoreSdkScript()", () => {
 
   test("should avoid inserting two script elements when called twice in parallel", async () => {
     const [result1, result2] = await Promise.all([
-      loadCoreSdkScript(),
-      loadCoreSdkScript(),
+      loadCoreSdkScript({ environment: "sandbox" }),
+      loadCoreSdkScript({ environment: "sandbox" }),
     ]);
     // should only insert the script once
     expect(scriptAppendChildSpy).toHaveBeenCalledTimes(1);
@@ -94,7 +97,9 @@ describe("loadCoreSdkScript()", () => {
 
   test("should return reference to existing script when loading state is pending", async () => {
     document.head.innerHTML = `<script src="https://www.sandbox.paypal.com/web-sdk/v6/core" data-loading-state="pending"></script>`;
-    const loadCoreSdkScriptReference = loadCoreSdkScript();
+    const loadCoreSdkScriptReference = loadCoreSdkScript({
+      environment: "sandbox",
+    });
 
     process.nextTick(() => {
       vi.stubGlobal("paypal", { version: "6" });
@@ -123,7 +128,7 @@ describe("loadCoreSdkScript()", () => {
     });
 
     expect(async () => {
-      await loadCoreSdkScript();
+      await loadCoreSdkScript({ environment: "sandbox" });
     }).rejects.toThrowError(
       'The script "https://www.sandbox.paypal.com/web-sdk/v6/core" failed to load. Check the HTTP status code and response body in DevTools to learn more.',
     );
@@ -139,7 +144,25 @@ describe("loadCoreSdkScript()", () => {
       // @ts-expect-error invalid arguments
       await loadCoreSdkScript({ environment: "bad_value" });
     }).rejects.toThrowError(
-      'The "environment" option must be either "production" or "sandbox"',
+      'The "environment" option is required and must be either "production" or "sandbox"',
+    );
+  });
+
+  test("should error when environment is omitted", async () => {
+    expect(async () => {
+      // @ts-expect-error environment is required
+      await loadCoreSdkScript({});
+    }).rejects.toThrowError(
+      'The "environment" option is required and must be either "production" or "sandbox"',
+    );
+  });
+
+  test("should error when environment is explicitly undefined", async () => {
+    expect(async () => {
+      // @ts-expect-error environment is required
+      await loadCoreSdkScript({ environment: undefined });
+    }).rejects.toThrowError(
+      'The "environment" option is required and must be either "production" or "sandbox"',
     );
   });
 
@@ -148,6 +171,7 @@ describe("loadCoreSdkScript()", () => {
       const customNamespace = "myCustomNamespace";
 
       const result = await loadCoreSdkScript({
+        environment: "sandbox",
         dataNamespace: customNamespace,
       });
 
@@ -168,7 +192,7 @@ describe("loadCoreSdkScript()", () => {
 
     test("should error when dataNamespace is an empty string", async () => {
       expect(async () => {
-        await loadCoreSdkScript({ dataNamespace: "" });
+        await loadCoreSdkScript({ environment: "sandbox", dataNamespace: "" });
       }).rejects.toThrowError(
         'The "dataNamespace" option cannot be an empty string',
       );
@@ -176,7 +200,10 @@ describe("loadCoreSdkScript()", () => {
 
     test("should error when dataNamespace is only whitespace", async () => {
       expect(async () => {
-        await loadCoreSdkScript({ dataNamespace: "   " });
+        await loadCoreSdkScript({
+          environment: "sandbox",
+          dataNamespace: "   ",
+        });
       }).rejects.toThrowError(
         'The "dataNamespace" option cannot be an empty string',
       );
@@ -188,6 +215,7 @@ describe("loadCoreSdkScript()", () => {
       const integrationSource = "react-paypal-js";
 
       const result = await loadCoreSdkScript({
+        environment: "sandbox",
         dataSdkIntegrationSource: integrationSource,
       });
 
@@ -207,7 +235,10 @@ describe("loadCoreSdkScript()", () => {
 
     test("should error when dataSdkIntegrationSource is an empty string", async () => {
       expect(async () => {
-        await loadCoreSdkScript({ dataSdkIntegrationSource: "" });
+        await loadCoreSdkScript({
+          environment: "sandbox",
+          dataSdkIntegrationSource: "",
+        });
       }).rejects.toThrowError(
         'The "dataSdkIntegrationSource" option cannot be an empty string',
       );
@@ -215,7 +246,10 @@ describe("loadCoreSdkScript()", () => {
 
     test("should error when dataSdkIntegrationSource is only whitespace", async () => {
       expect(async () => {
-        await loadCoreSdkScript({ dataSdkIntegrationSource: "   " });
+        await loadCoreSdkScript({
+          environment: "sandbox",
+          dataSdkIntegrationSource: "   ",
+        });
       }).rejects.toThrowError(
         'The "dataSdkIntegrationSource" option cannot be an empty string',
       );

--- a/packages/paypal-js/src/v6/index.ts
+++ b/packages/paypal-js/src/v6/index.ts
@@ -14,7 +14,7 @@ const SCRIPT_LOADING_STATE = {
 
 const DATA_ATTRIBUTE_LOADING_STATE = "data-loading-state";
 
-function loadCoreSdkScript(options: LoadCoreSdkScriptOptions = {}) {
+function loadCoreSdkScript(options: LoadCoreSdkScriptOptions) {
   validateArguments(options);
 
   if (isServer()) {
@@ -101,13 +101,9 @@ function validateArguments(options: unknown) {
   const { environment, dataNamespace, dataSdkIntegrationSource } =
     options as LoadCoreSdkScriptOptions;
 
-  if (
-    environment &&
-    environment !== "production" &&
-    environment !== "sandbox"
-  ) {
+  if (environment !== "production" && environment !== "sandbox") {
     throw new Error(
-      'The "environment" option must be either "production" or "sandbox"',
+      'The "environment" option is required and must be either "production" or "sandbox"',
     );
   }
 

--- a/packages/paypal-js/types/v6/index.d.ts
+++ b/packages/paypal-js/types/v6/index.d.ts
@@ -237,7 +237,7 @@ interface CoreSdkScriptDataAttributes {
 }
 
 export interface LoadCoreSdkScriptOptions extends CoreSdkScriptDataAttributes {
-  environment?: "production" | "sandbox";
+  environment: "production" | "sandbox";
   debug?: boolean;
 }
 

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -79,6 +79,7 @@ function App() {
   return (
     <PayPalProvider
       clientId="your-client-id"
+      environment="sandbox"
       components={["paypal-payments"]}
       pageType="checkout"
     >
@@ -121,7 +122,7 @@ The `PayPalProvider` component is the entry point for the V6 SDK. It handles loa
 | `components`              | `Components[]`                       | No       | SDK components to load. Defaults to `["paypal-payments"]`.                                                   |
 | `pageType`                | `string`                             | No       | Type of page: `"checkout"`, `"product-details"`, `"cart"`, `"product-listing"`, etc.                         |
 | `locale`                  | `string`                             | No       | Locale for the SDK (e.g., `"en_US"`).                                                                        |
-| `environment`             | `"sandbox" \| "production"`          | No       | SDK environment.                                                                                             |
+| `environment`             | `"sandbox" \| "production"`          | **Yes**  | **Required.** SDK environment. `clientId` does not select the environment in v6 — this prop does.            |
 | `merchantId`              | `string \| string[]`                 | No       | PayPal merchant ID(s).                                                                                       |
 | `clientMetadataId`        | `string`                             | No       | Client metadata ID for tracking.                                                                             |
 | `partnerAttributionId`    | `string`                             | No       | Partner attribution ID (BN code).                                                                            |
@@ -154,6 +155,7 @@ function App() {
   return (
     <PayPalProvider
       clientId={clientIdPromise}
+      environment="sandbox"
       components={["paypal-payments"]}
       pageType="checkout"
     >
@@ -173,6 +175,7 @@ function App() {
   return (
     <PayPalProvider
       clientToken={tokenPromise}
+      environment="sandbox"
       components={["paypal-payments"]}
       pageType="checkout"
     >
@@ -195,6 +198,7 @@ function App() {
   return (
     <PayPalProvider
       clientId={clientId}
+      environment="sandbox"
       components={["paypal-payments"]}
       pageType="checkout"
     >
@@ -281,6 +285,7 @@ import { VenmoOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 <PayPalProvider
   clientId={clientId}
+  environment="sandbox"
   components={["paypal-payments", "venmo-payments"]}
   pageType="checkout"
 >
@@ -372,6 +377,7 @@ function App() {
   return (
     <PayPalProvider
       clientId="your-client-id"
+      environment="sandbox"
       components={["googlepay-payments"]}
       pageType="checkout"
     >
@@ -432,6 +438,7 @@ import { PayPalGuestPaymentButton } from "@paypal/react-paypal-js/sdk-v6";
 
 <PayPalProvider
   clientId={clientId}
+  environment="sandbox"
   components={["paypal-payments", "paypal-guest-payments"]}
   pageType="checkout"
 >
@@ -491,6 +498,7 @@ import { PayPalSubscriptionButton } from "@paypal/react-paypal-js/sdk-v6";
 
 <PayPalProvider
   clientId={clientId}
+  environment="sandbox"
   components={["paypal-subscriptions"]}
   pageType="checkout"
 >
@@ -691,6 +699,7 @@ export default function App() {
   return (
     <PayPalProvider
       clientId="YOUR_CLIENT_ID"
+      environment="sandbox"
       components={["applepay-payments"]}
       pageType="checkout"
     >
@@ -1194,6 +1203,7 @@ function App() {
   return (
     <PayPalProvider
       clientToken="your-client-token"
+      environment="sandbox"
       components={["card-fields"]}
       pageType="checkout"
     >
@@ -1858,6 +1868,7 @@ export default async function CheckoutPage() {
   return (
     <PayPalProvider
       clientId={clientId}
+      environment="sandbox"
       pageType="checkout"
       eligibleMethodsResponse={eligibleMethodsResponse}
     >
@@ -1908,7 +1919,7 @@ import {
   PayPalOneTimePaymentButton,
 } from "@paypal/react-paypal-js/sdk-v6";
 
-<PayPalProvider clientId={clientId} pageType="checkout">
+<PayPalProvider clientId={clientId} environment="sandbox" pageType="checkout">
   <PayPalOneTimePaymentButton
     createOrder={async () => {
       const res = await fetch("/api/orders", { method: "POST" });

--- a/packages/react-paypal-js/src/v6/components/PayPalProvider.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalProvider.tsx
@@ -56,10 +56,15 @@ type PayPalProviderProps =
  * An unstable Promise reference (e.g., calling `fetchClientToken()` or `fetchClientId()` inline)
  * will cause the SDK to re-initialize on every render. Wrap the promise in `useMemo` or store it in state.
  *
+ * **The `environment` prop is required.** `clientId` does not select the environment in v6 — a
+ * live `clientId` will still load the sandbox SDK if `environment="sandbox"`. Pass
+ * `environment="production"` or `environment="sandbox"` explicitly.
+ *
  * @example
  * // With string clientToken
  * <PayPalProvider
  *   clientToken={token}
+ *   environment="sandbox"
  *   components={["paypal-payments", "venmo-payments"]}
  *   pageType="checkout"
  * >
@@ -70,6 +75,7 @@ type PayPalProviderProps =
  * // With string clientId
  * <PayPalProvider
  *   clientId="YOUR_CLIENT_ID"
+ *   environment="sandbox"
  *   components={["paypal-payments"]}
  *   pageType="checkout"
  * >
@@ -82,6 +88,7 @@ type PayPalProviderProps =
  *
  * <PayPalProvider
  *   clientToken={tokenPromise}
+ *   environment="sandbox"
  *   pageType="checkout"
  * >
  *   <PayPalOneTimePaymentButton />
@@ -93,6 +100,7 @@ type PayPalProviderProps =
  *
  * <PayPalProvider
  *   clientId={clientIdPromise}
+ *   environment="sandbox"
  *   pageType="checkout"
  * >
  *   <PayPalOneTimePaymentButton />
@@ -108,6 +116,7 @@ type PayPalProviderProps =
  *
  * <PayPalProvider
  *   clientToken={clientToken}
+ *   environment="sandbox"
  *   pageType="checkout"
  * >
  *   <PayPalOneTimePaymentButton />
@@ -123,6 +132,7 @@ type PayPalProviderProps =
  *
  * <PayPalProvider
  *   clientId={clientId}
+ *   environment="sandbox"
  *   pageType="checkout"
  * >
  *   <PayPalOneTimePaymentButton />
@@ -141,7 +151,7 @@ type PayPalProviderProps =
  *   return <PayPalOneTimePaymentButton orderId="ORDER-123" />;
  * }
  *
- * <PayPalProvider clientToken={token} pageType="checkout">
+ * <PayPalProvider clientToken={token} environment="sandbox" pageType="checkout">
  *   <MyCheckout />
  * </PayPalProvider>
  */


### PR DESCRIPTION
This PR updates the `environment` argument for `loadCoreSdkScript` to required, and in turn the v6 `PayPalProvider`, in response to [this issue](https://github.com/paypal/paypal-js/issues/945). All READMEs are updated as well to demonstrate the new requirement.

**This is a major breaking change**
Below are examples of where to update if you use `react-paypal-js` or `paypal-js`

### v6 PayPalProvider
```
<PayPalProvider
  clientId={clientId}
  environment="sandbox" // "production"
  components={["paypal-payments",]}
  pageType="checkout"
>
  <CheckoutPage />
</PayPalProvider>
```

### v6 loadCoreSdkScript
```
const paypalGlobalNamespace = await loadCoreSdkScript({
  environment: "sandbox", // "production"
});
```