### PR TITLE
Feat: BT-PayPal Pay Later button component

### DIFF
--- a/.changeset/tiny-seas-drive.md
+++ b/.changeset/tiny-seas-drive.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+Adds braintree with paypal pay later button component.

--- a/.changeset/tiny-seas-drive.md
+++ b/.changeset/tiny-seas-drive.md
@@ -2,4 +2,11 @@
 "@paypal/react-paypal-js": minor
 ---
 
-Adds braintree with paypal pay later button component.
+Add `BraintreePayPalPayLaterButton`, a prebuilt v6 button that renders
+`<paypal-pay-later-button>` and drives the Braintree PayPal Pay Later (BNPL) flow via
+`useBraintreePayPalPayLaterSession`, sourcing `countryCode`/`productCode` from provider
+eligibility.
+
+Docs: clarify that the Pay Later and Credit buttons require eligibility to be fetched first —
+via `useEligibleMethods` (client) or `useFetchEligibleMethods` (server) — with updated JSDoc
+and README examples.

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -1091,6 +1091,89 @@ function CheckoutWithVaultButton() {
 | `type`                    | `"pay" \| "checkout" \| "buynow" \| "donate" \| "subscribe"`  | No       | Button label type (default: `"pay"`)                              |
 | `disabled`                | `boolean`                                                     | No       | Disable the button                                                |
 
+### BraintreePayPalPayLaterButton
+
+Renders a `<paypal-pay-later-button>` web component for Braintree PayPal Pay Later (Buy Now, Pay Later) financing. Internally uses `useBraintreePayPalPayLaterSession` to create and start Pay Later sessions.
+
+Unlike the other Braintree buttons, **this button requires eligibility data.** It reads `countryCode` and `productCode` from `useBraintreePayPal().eligiblePaymentMethods`, which is populated by `useBraintreeEligibleMethods`. Fetch eligibility first — without it the button renders hidden (`display: none`).
+
+```tsx
+import {
+  BraintreePayPalPayLaterButton,
+  useBraintreePayPal,
+  useBraintreeEligibleMethods,
+  INSTANCE_LOADING_STATE,
+} from "@paypal/react-paypal-js/sdk-v6";
+import type { BraintreeApprovalData } from "@paypal/react-paypal-js/sdk-v6";
+
+function PayLaterCheckout() {
+  const { loadingStatus, braintreePayPalCheckoutInstance } =
+    useBraintreePayPal();
+
+  // Fetch eligibility before rendering the button
+  const { eligiblePaymentMethods, isLoading } = useBraintreeEligibleMethods({
+    amount: "100.00",
+    currency: "USD", // required
+    countryCode: "US",
+    paymentFlow: "ONE_TIME_PAYMENT",
+  });
+
+  if (isLoading || loadingStatus === INSTANCE_LOADING_STATE.PENDING) {
+    return <Spinner />;
+  }
+  if (!eligiblePaymentMethods?.paylater) {
+    return null;
+  }
+
+  return (
+    <BraintreePayPalPayLaterButton
+      amount="100.00"
+      currency="USD"
+      onApprove={async (data: BraintreeApprovalData) => {
+        const { nonce } =
+          await braintreePayPalCheckoutInstance!.tokenizePayment(data);
+        // Send nonce to your server
+        await fetch("/api/braintree/checkout", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ nonce }),
+        });
+      }}
+      onCancel={() => console.log("Cancelled")}
+      onError={(err) => console.error("Error", err)}
+    />
+  );
+}
+```
+
+Render `PayLaterCheckout` inside a `BraintreePayPalProvider` (see [BraintreePayPalProvider](#braintreepaypalprovider)).
+
+**Props:**
+
+| Prop                      | Type                                                                  | Required | Description                                                       |
+| ------------------------- | --------------------------------------------------------------------- | -------- | ----------------------------------------------------------------- |
+| `amount`                  | `string`                                                              | Yes      | Payment amount (e.g., `"100.00"`)                                 |
+| `currency`                | `string`                                                              | Yes      | ISO 4217 currency code (e.g., `"USD"`)                            |
+| `onApprove`               | `(data: BraintreeApprovalData) => Promise<void>`                      | Yes      | Called when buyer approves — tokenize the payment here            |
+| `intent`                  | `"authorize" \| "capture" \| "order"`                                 | No       | Payment intent (default: `"capture"`)                             |
+| `onCancel`                | `() => void`                                                          | No       | Called when buyer cancels                                         |
+| `onComplete`              | `() => void`                                                          | No       | Called when the payment flow completes                            |
+| `onError`                 | `(err: Error) => void`                                                | No       | Called on errors                                                  |
+| `onShippingAddressChange` | `(data: BraintreeShippingAddressChangeData) => Promise<void>`         | No       | Called when buyer changes shipping address                        |
+| `onShippingOptionsChange` | `(data: BraintreeShippingOptionsChangeData) => Promise<void>`         | No       | Called when buyer selects a shipping option                       |
+| `lineItems`               | `BraintreeLineItem[]`                                                 | No       | Line items for the transaction                                    |
+| `shippingOptions`         | `BraintreeShippingOption[]`                                           | No       | Available shipping options                                        |
+| `shippingCallbackUrl`     | `string`                                                              | No       | URL for server-side shipping callbacks                            |
+| `shippingAddressOverride` | `BraintreeShippingAddressOverride`                                    | No       | Pre-collected shipping address                                    |
+| `amountBreakdown`         | `BraintreeAmountBreakdown`                                            | No       | Breakdown of the total amount (item total, shipping, tax, etc.)   |
+| `contactPreference`       | `"NO_CONTACT_INFO" \| "RETAIN_CONTACT_INFO" \| "UPDATE_CONTACT_INFO"` | No       | How buyer contact information is handled                          |
+| `userAuthenticationEmail` | `string`                                                              | No       | Pre-fill the PayPal login email                                   |
+| `returnUrl`               | `string`                                                              | No       | Return URL (required for `"direct-app-switch"` presentation mode) |
+| `cancelUrl`               | `string`                                                              | No       | Cancel URL (required for `"direct-app-switch"` presentation mode) |
+| `displayName`             | `string`                                                              | No       | Merchant name displayed in the PayPal lightbox                    |
+| `presentationMode`        | `BraintreePresentationMode`                                           | No       | UI mode: `"auto"`, `"popup"`, `"modal"`, `"redirect"`, etc.       |
+| `disabled`                | `boolean`                                                             | No       | Disable the button                                                |
+
 ### Braintree Hooks
 
 #### `useBraintreePayPal()`
@@ -1121,12 +1204,84 @@ function CustomCheckout() {
 
 **Returns:**
 
-| Property                          | Type                                      | Description                                |
-| --------------------------------- | ----------------------------------------- | ------------------------------------------ |
-| `braintreePayPalCheckoutInstance` | `BraintreePayPalCheckoutInstance \| null` | The checkout instance (null while loading) |
-| `loadingStatus`                   | `INSTANCE_LOADING_STATE`                  | `"pending"`, `"resolved"`, or `"rejected"` |
-| `error`                           | `Error \| null`                           | Initialization error, if any               |
-| `isHydrated`                      | `boolean`                                 | `true` after client-side hydration         |
+| Property                          | Type                                      | Description                                                                |
+| --------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------- |
+| `braintreePayPalCheckoutInstance` | `BraintreePayPalCheckoutInstance \| null` | The checkout instance (null while loading)                                 |
+| `eligiblePaymentMethods`          | `BraintreeEligibilityResult \| null`      | Eligibility cached by `useBraintreeEligibleMethods` (`null` until fetched) |
+| `loadingStatus`                   | `INSTANCE_LOADING_STATE`                  | `"pending"`, `"resolved"`, or `"rejected"`                                 |
+| `error`                           | `Error \| null`                           | Initialization error, if any                                               |
+| `isHydrated`                      | `boolean`                                 | `true` after client-side hydration                                         |
+
+#### `useBraintreeEligibleMethods(props)`
+
+Fetches Braintree PayPal eligibility for the given checkout options by calling `findEligibleMethods()` on the shared checkout instance, and caches the result in `BraintreePayPalProvider` context (where buttons read it via `useBraintreePayPal().eligiblePaymentMethods`). Fetches are deduplicated by `(instance, options)` and re-run when the options change. Required before rendering eligibility-gated buttons such as `BraintreePayPalPayLaterButton`.
+
+```tsx
+import {
+  useBraintreePayPal,
+  useBraintreeEligibleMethods,
+  BraintreePayPalOneTimePaymentButton,
+  BraintreePayPalPayLaterButton,
+  INSTANCE_LOADING_STATE,
+} from "@paypal/react-paypal-js/sdk-v6";
+
+function CheckoutButtons() {
+  const { loadingStatus, braintreePayPalCheckoutInstance } =
+    useBraintreePayPal();
+  const { eligiblePaymentMethods, isLoading, error } =
+    useBraintreeEligibleMethods({
+      amount: "100.00",
+      currency: "USD",
+      countryCode: "US",
+      paymentFlow: "ONE_TIME_PAYMENT",
+    });
+
+  if (isLoading || loadingStatus === INSTANCE_LOADING_STATES.PENDING) {
+    return <Spinner />;
+  }
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <>
+      <BraintreePayPalOneTimePaymentButton
+        amount="100.00"
+        currency="USD"
+        // onApprove not show in this example
+        // see other examples for usage of tokenizePayment in onApprove
+        onApprove={onApprove}
+      />
+      {eligiblePaymentMethods?.paylater && (
+        <BraintreePayPalPayLaterButton
+          amount="100.00"
+          currency="USD"
+          onApprove={onApprove}
+        />
+      )}
+    </>
+  );
+}
+```
+
+**Props (`BraintreeFindEligibleMethodsOptions`):**
+
+| Prop          | Type                                                                                           | Required | Description                                 |
+| ------------- | ---------------------------------------------------------------------------------------------- | -------- | ------------------------------------------- |
+| `currency`    | `string`                                                                                       | Yes      | ISO 4217 currency code (e.g., `"USD"`)      |
+| `amount`      | `string`                                                                                       | No       | Checkout amount used for eligibility checks |
+| `countryCode` | `string`                                                                                       | No       | Buyer country code (e.g., `"US"`)           |
+| `paymentFlow` | `"ONE_TIME_PAYMENT" \| "VAULT_WITH_PAYMENT" \| "VAULT_WITHOUT_PAYMENT" \| "RECURRING_PAYMENT"` | No       | The flow eligibility is being checked for   |
+
+**Returns:**
+
+| Property                 | Type                                 | Description                                                               |
+| ------------------------ | ------------------------------------ | ------------------------------------------------------------------------- |
+| `eligiblePaymentMethods` | `BraintreeEligibilityResult \| null` | Eligibility result, or `null` until fetched                               |
+| `isLoading`              | `boolean`                            | `true` while the instance is initializing or eligibility is being fetched |
+| `error`                  | `Error \| null`                      | Fetch- or provider-level error, if any                                    |
+
+`BraintreeEligibilityResult` exposes the booleans `paypal`, `paylater`, and `credit`, plus `getDetails(method)` which returns the `countryCode` and `productCode` the buttons consume.
 
 #### `useBraintreePayPalOneTimePaymentSession(props)`
 
@@ -1204,6 +1359,51 @@ function CustomCheckoutVaultButton() {
     <button onClick={handleClick} disabled={isPending}>
       Pay & Save
     </button>
+  );
+}
+```
+
+**Returns:** `{ handleClick: () => void, isPending: boolean, error: Error | null }`
+
+#### `useBraintreePayPalPayLaterSession(props)`
+
+Creates a Pay Later (Buy Now, Pay Later) session. Returns a `handleClick` function to start the flow. Accepts the same props as `BraintreePayPalPayLaterButton` (minus `disabled`) — use this hook directly when you need full control over the `<paypal-pay-later-button>` UI. Eligibility (`countryCode`/`productCode`) must still be fetched via `useBraintreeEligibleMethods`.
+
+```tsx
+import {
+  useBraintreePayPalPayLaterSession,
+  useBraintreeEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
+
+function CustomPayLaterButton() {
+  const { handleClick, isPending } = useBraintreePayPalPayLaterSession({
+    amount: "100.00",
+    currency: "USD",
+    onApprove: async (data) => {
+      // tokenize and process
+    },
+  });
+
+  const { isLoading, eligiblePaymentMethods } = useBraintreeEligibleMethods({
+    currency: "USD",
+  });
+
+  if (isPending || isLoading) {
+    return <Spinner />;
+  }
+  if (!eligiblePaymentMethods?.paylater) {
+    return null;
+  }
+
+  const payLaterDetails = eligiblePaymentMethods.getDetails("paylater");
+
+  return (
+    <paypal-pay-later-button
+      onClick={() => handleClick()}
+      disabled={isPending}
+      countryCode={payLaterDetails?.countryCode}
+      productCode={payLaterDetails?.productCode}
+    />
   );
 }
 ```

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -1236,7 +1236,7 @@ function CheckoutButtons() {
       paymentFlow: "ONE_TIME_PAYMENT",
     });
 
-  if (isLoading || loadingStatus === INSTANCE_LOADING_STATES.PENDING) {
+  if (isLoading || loadingStatus === INSTANCE_LOADING_STATE.PENDING) {
     return <Spinner />;
   }
   if (error) {
@@ -1248,7 +1248,7 @@ function CheckoutButtons() {
       <BraintreePayPalOneTimePaymentButton
         amount="100.00"
         currency="USD"
-        // onApprove not show in this example
+        // onApprove not shown in this example
         // see other examples for usage of tokenizePayment in onApprove
         onApprove={onApprove}
       />

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -406,27 +406,46 @@ function App() {
 
 ### PayLaterOneTimePaymentButton
 
-Renders a Pay Later button for financing options. Country code and product code are automatically populated from eligibility data.
+Renders a Pay Later button for financing options. Country code and product code are automatically populated from eligibility data, so eligibility must be fetched first — via `useEligibleMethods()` client-side (shown below) or the provider's `eligibleMethodsResponse` prop server-side.
 
 ```tsx
-import { PayLaterOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
+import {
+  PayLaterOneTimePaymentButton,
+  useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
 
-<PayLaterOneTimePaymentButton
-  createOrder={async () => {
-    const { orderId } = await createOrder();
-    return { orderId };
-  }}
-  onApprove={(data: OnApproveDataOneTimePayments) =>
-    console.log("Pay Later approved!", data)
+function PayLaterCheckout() {
+  // Fetch eligibility first (or hydrate server-side via eligibleMethodsResponse)
+  const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+    payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+  });
+
+  if (isLoading) {
+    return <Spinner />;
   }
-  onCancel={(data: OnCancelDataOneTimePayments) =>
-    console.log("Pay Later cancelled", data)
+  if (!eligiblePaymentMethods?.isEligible("paylater")) {
+    return null;
   }
-  onError={(data: OnErrorData) => console.error("Pay Later error:", data)}
-  onComplete={(data: OnCompleteData) =>
-    console.log("Pay Later flow completed", data)
-  }
-/>;
+
+  return (
+    <PayLaterOneTimePaymentButton
+      createOrder={async () => {
+        const { orderId } = await createOrder();
+        return { orderId };
+      }}
+      onApprove={(data: OnApproveDataOneTimePayments) =>
+        console.log("Pay Later approved!", data)
+      }
+      onCancel={(data: OnCancelDataOneTimePayments) =>
+        console.log("Pay Later cancelled", data)
+      }
+      onError={(data: OnErrorData) => console.error("Pay Later error:", data)}
+      onComplete={(data: OnCompleteData) =>
+        console.log("Pay Later flow completed", data)
+      }
+    />
+  );
+}
 ```
 
 ### PayPalGuestPaymentButton
@@ -526,56 +545,96 @@ import { PayPalSubscriptionButton } from "@paypal/react-paypal-js/sdk-v6";
 
 ### PayPalCreditOneTimePaymentButton
 
-Renders a PayPal Credit button for one-time payments. The `countryCode` is automatically populated from eligibility data.
+Renders a PayPal Credit button for one-time payments. The `countryCode` is automatically populated from eligibility data, so eligibility must be fetched first — via `useEligibleMethods()` client-side (shown below) or the provider's `eligibleMethodsResponse` prop server-side.
 
 ```tsx
-import { PayPalCreditOneTimePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
+import {
+  PayPalCreditOneTimePaymentButton,
+  useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
 
-<PayPalCreditOneTimePaymentButton
-  createOrder={async () => {
-    const response = await fetch("/api/create-order", { method: "POST" });
-    const { orderId } = await response.json();
-    return { orderId };
-  }}
-  onApprove={({ orderId }: OnApproveDataOneTimePayments) =>
-    console.log("Credit payment approved:", orderId)
+function CreditCheckout() {
+  // Fetch eligibility first (or hydrate server-side via eligibleMethodsResponse)
+  const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+    payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+  });
+
+  if (isLoading) {
+    return <Spinner />;
   }
-  onCancel={(data: OnCancelDataOneTimePayments) =>
-    console.log("Credit payment cancelled", data)
+  if (!eligiblePaymentMethods?.isEligible("credit")) {
+    return null;
   }
-  onError={(data: OnErrorData) => console.error("Credit payment error:", data)}
-  onComplete={(data: OnCompleteData) =>
-    console.log("Credit payment flow completed", data)
-  }
-/>;
+
+  return (
+    <PayPalCreditOneTimePaymentButton
+      createOrder={async () => {
+        const response = await fetch("/api/create-order", { method: "POST" });
+        const { orderId } = await response.json();
+        return { orderId };
+      }}
+      onApprove={({ orderId }: OnApproveDataOneTimePayments) =>
+        console.log("Credit payment approved:", orderId)
+      }
+      onCancel={(data: OnCancelDataOneTimePayments) =>
+        console.log("Credit payment cancelled", data)
+      }
+      onError={(data: OnErrorData) =>
+        console.error("Credit payment error:", data)
+      }
+      onComplete={(data: OnCompleteData) =>
+        console.log("Credit payment flow completed", data)
+      }
+    />
+  );
+}
 ```
 
 ### PayPalCreditSavePaymentButton
 
-Renders a PayPal Credit button for saving a credit payment method (vaulting).
+Renders a PayPal Credit button for saving a credit payment method (vaulting). The `countryCode` is automatically populated from eligibility data, so eligibility must be fetched first — via `useEligibleMethods()` client-side (shown below) or the provider's `eligibleMethodsResponse` prop server-side.
 
 ```tsx
-import { PayPalCreditSavePaymentButton } from "@paypal/react-paypal-js/sdk-v6";
+import {
+  PayPalCreditSavePaymentButton,
+  useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
 
-<PayPalCreditSavePaymentButton
-  createVaultToken={async () => {
-    const response = await fetch("/api/create-vault-token", {
-      method: "POST",
-    });
-    const { vaultSetupToken } = await response.json();
-    return { vaultSetupToken };
-  }}
-  onApprove={(data: OnApproveDataSavePayments) =>
-    console.log("Credit saved:", data)
+function CreditSaveCheckout() {
+  // Fetch eligibility first (or hydrate server-side via eligibleMethodsResponse)
+  const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+    payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+  });
+
+  if (isLoading) {
+    return <Spinner />;
   }
-  onCancel={(data: OnCancelDataSavePayments) =>
-    console.log("Credit save cancelled", data)
+  if (!eligiblePaymentMethods?.isEligible("credit")) {
+    return null;
   }
-  onError={(data: OnErrorData) => console.error("Credit save error:", data)}
-  onComplete={(data: OnCompleteData) =>
-    console.log("Credit save flow completed", data)
-  }
-/>;
+
+  return (
+    <PayPalCreditSavePaymentButton
+      createVaultToken={async () => {
+        const response = await fetch("/api/create-vault-token", {
+          method: "POST",
+        });
+        const { vaultSetupToken } = await response.json();
+        return { vaultSetupToken };
+      }}
+      onApprove={(data: OnApproveDataSavePayments) =>
+        console.log("Credit saved:", data)
+      }
+      onCancel={(data: OnCancelDataSavePayments) =>
+        console.log("Credit save cancelled", data)
+      }
+      onError={(data: OnErrorData) => console.error("Credit save error:", data)}
+      onComplete={(data: OnCompleteData) =>
+        console.log("Credit save flow completed", data)
+      }
+    />
+  );
+}
 ```
 
 ### ApplePayOneTimePaymentButton
@@ -653,17 +712,26 @@ function ApplePayCheckout() {
     payload: { currencyCode: "USD" },
   });
 
-  if (!canUseApplePay)
+  if (!canUseApplePay) {
     return <div>Apple Pay is not available in this browser.</div>;
-  if (isLoading) return <div>Loading...</div>;
-  if (error) return <div>Error: {error.message}</div>;
+  }
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
 
   // Step 3: Check merchant eligibility and get config.
   const isEligible = eligiblePaymentMethods?.isEligible("applepay");
-  if (!isEligible) return <div>Apple Pay is not eligible.</div>;
+  if (!isEligible) {
+    return <div>Apple Pay is not eligible.</div>;
+  }
 
   const applePayConfig = eligiblePaymentMethods?.getDetails("applepay")?.config;
-  if (!applePayConfig) return null;
+  if (!applePayConfig) {
+    return null;
+  }
 
   return (
     <ApplePayOneTimePaymentButton
@@ -776,7 +844,9 @@ function App() {
       .then(({ clientToken }) => setClientToken(clientToken));
   }, []);
 
-  if (!clientToken) return <div>Loading...</div>;
+  if (!clientToken) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <BraintreePayPalProvider
@@ -845,7 +915,9 @@ function App() {
       .then(({ clientToken }) => setClientToken(clientToken));
   }, []);
 
-  if (!clientToken) return <div>Loading...</div>;
+  if (!clientToken) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <BraintreePayPalProvider
@@ -1337,7 +1409,9 @@ import { useEligibleMethods } from "@paypal/react-paypal-js/sdk-v6";
 function PaymentOptions() {
   const { eligiblePaymentMethods, isLoading, error } = useEligibleMethods();
 
-  if (isLoading) return <div>Checking eligibility...</div>;
+  if (isLoading) {
+    return <div>Checking eligibility...</div>;
+  }
 
   const isPayPalEligible = eligiblePaymentMethods?.isEligible("paypal");
   const isVenmoEligible = eligiblePaymentMethods?.isEligible("venmo");
@@ -1484,7 +1558,10 @@ function CustomVenmoButton() {
 #### usePayLaterOneTimePaymentSession
 
 ```tsx
-import { usePayLaterOneTimePaymentSession } from "@paypal/react-paypal-js/sdk-v6";
+import {
+  usePayLaterOneTimePaymentSession,
+  useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
 
 function CustomPayLaterButton() {
   const { handleClick } = usePayLaterOneTimePaymentSession({
@@ -1501,7 +1578,27 @@ function CustomPayLaterButton() {
       console.log("Payment session complete", data),
   });
 
-  return <paypal-pay-later-button onClick={() => handleClick()} />;
+  // Fetch eligibility to obtain the countryCode/productCode the button needs
+  const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+    payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+  });
+
+  if (isLoading) {
+    return null;
+  }
+  if (!eligiblePaymentMethods?.isEligible("paylater")) {
+    return null;
+  }
+
+  const payLaterDetails = eligiblePaymentMethods.getDetails("paylater");
+
+  return (
+    <paypal-pay-later-button
+      onClick={() => handleClick()}
+      countryCode={payLaterDetails?.countryCode}
+      productCode={payLaterDetails?.productCode}
+    />
+  );
 }
 ```
 
@@ -1588,7 +1685,10 @@ function CustomPayPalSubscriptionButton() {
 For PayPal Credit one-time payments.
 
 ```tsx
-import { usePayPalCreditOneTimePaymentSession } from "@paypal/react-paypal-js/sdk-v6";
+import {
+  usePayPalCreditOneTimePaymentSession,
+  useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
 
 function CustomPayPalCreditButton() {
   const { handleClick } = usePayPalCreditOneTimePaymentSession({
@@ -1605,7 +1705,26 @@ function CustomPayPalCreditButton() {
       console.log("Payment session complete", data),
   });
 
-  return <paypal-credit-button onClick={() => handleClick()} />;
+  // Fetch eligibility to obtain the countryCode the button needs
+  const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+    payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+  });
+
+  if (isLoading) {
+    return null;
+  }
+  if (!eligiblePaymentMethods?.isEligible("credit")) {
+    return null;
+  }
+
+  const creditDetails = eligiblePaymentMethods.getDetails("credit");
+
+  return (
+    <paypal-credit-button
+      onClick={() => handleClick()}
+      countryCode={creditDetails?.countryCode}
+    />
+  );
 }
 ```
 
@@ -1614,7 +1733,10 @@ function CustomPayPalCreditButton() {
 For saving PayPal Credit as a payment method.
 
 ```tsx
-import { usePayPalCreditSavePaymentSession } from "@paypal/react-paypal-js/sdk-v6";
+import {
+  usePayPalCreditSavePaymentSession,
+  useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
 
 function CustomPayPalCreditSaveButton() {
   const { handleClick } = usePayPalCreditSavePaymentSession({
@@ -1631,7 +1753,26 @@ function CustomPayPalCreditSaveButton() {
       console.log("Payment session complete", data),
   });
 
-  return <paypal-credit-button onClick={() => handleClick()} />;
+  // Fetch eligibility to obtain the countryCode the button needs
+  const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+    payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+  });
+
+  if (isLoading) {
+    return null;
+  }
+  if (!eligiblePaymentMethods?.isEligible("credit")) {
+    return null;
+  }
+
+  const creditDetails = eligiblePaymentMethods.getDetails("credit");
+
+  return (
+    <paypal-credit-button
+      onClick={() => handleClick()}
+      countryCode={creditDetails?.countryCode}
+    />
+  );
 }
 ```
 
@@ -1675,8 +1816,12 @@ function CustomApplePayButton() {
     onError: (err) => console.error("Apple Pay error:", err),
   });
 
-  if (isLoading || !applePayConfig) return null;
-  if (error) return <div>Error: {error.message}</div>;
+  if (isLoading || !applePayConfig) {
+    return null;
+  }
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
 
   return (
     <apple-pay-button

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.test.tsx
@@ -23,7 +23,7 @@ describe("BraintreePayPalPayLaterButton", () => {
     jest.clearAllMocks();
     mockGetDetails.mockReturnValue({
       countryCode: "US",
-      productCode: "PAY_LATER",
+      productCode: "PAYLATER",
     });
     mockUseBraintreePayPalPayLaterSession.mockReturnValue({
       error: null,
@@ -94,7 +94,7 @@ describe("BraintreePayPalPayLaterButton", () => {
     const button = container.querySelector("paypal-pay-later-button");
     expect(mockGetDetails).toHaveBeenCalledWith("paylater");
     expect(button).toHaveAttribute("countryCode", "US");
-    expect(button).toHaveAttribute("productCode", "PAY_LATER");
+    expect(button).toHaveAttribute("productCode", "PAYLATER");
   });
 
   it("should render without eligibility details when not available", () => {

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.test.tsx
@@ -23,7 +23,7 @@ describe("BraintreePayPalPayLaterButton", () => {
     jest.clearAllMocks();
     mockGetDetails.mockReturnValue({
       countryCode: "US",
-      productCode: "PAY_LATER_LONG_TERM",
+      productCode: "PAY_LATER",
     });
     mockUseBraintreePayPalPayLaterSession.mockReturnValue({
       error: null,
@@ -94,7 +94,7 @@ describe("BraintreePayPalPayLaterButton", () => {
     const button = container.querySelector("paypal-pay-later-button");
     expect(mockGetDetails).toHaveBeenCalledWith("paylater");
     expect(button).toHaveAttribute("countryCode", "US");
-    expect(button).toHaveAttribute("productCode", "PAY_LATER_LONG_TERM");
+    expect(button).toHaveAttribute("productCode", "PAY_LATER");
   });
 
   it("should render without eligibility details when not available", () => {

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.test.tsx
@@ -1,0 +1,219 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+
+import { BraintreePayPalPayLaterButton } from "./BraintreePayPalPayLaterButton";
+import { useBraintreePayPalPayLaterSession } from "../../hooks/Braintree/useBraintreePayPalPayLaterSession";
+import { useBraintreePayPal } from "../../hooks/Braintree/useBraintreePayPal";
+
+jest.mock("../../hooks/Braintree/useBraintreePayPalPayLaterSession", () => ({
+  useBraintreePayPalPayLaterSession: jest.fn(),
+}));
+jest.mock("../../hooks/Braintree/useBraintreePayPal", () => ({
+  useBraintreePayPal: jest.fn(),
+}));
+
+describe("BraintreePayPalPayLaterButton", () => {
+  const mockHandleClick = jest.fn();
+  const mockGetDetails = jest.fn();
+  const mockUseBraintreePayPalPayLaterSession =
+    useBraintreePayPalPayLaterSession as jest.Mock;
+  const mockUseBraintreePayPal = useBraintreePayPal as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDetails.mockReturnValue({
+      countryCode: "US",
+      productCode: "PAY_LATER_LONG_TERM",
+    });
+    mockUseBraintreePayPalPayLaterSession.mockReturnValue({
+      error: null,
+      isPending: false,
+      handleClick: mockHandleClick,
+    });
+    mockUseBraintreePayPal.mockReturnValue({
+      isHydrated: true,
+      eligiblePaymentMethods: { getDetails: mockGetDetails },
+    });
+  });
+
+  it("should render paypal-pay-later-button when hydrated", () => {
+    const { container } = render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+      />,
+    );
+    expect(
+      container.querySelector("paypal-pay-later-button"),
+    ).toBeInTheDocument();
+  });
+
+  it("should render a div when not hydrated", () => {
+    mockUseBraintreePayPal.mockReturnValue({
+      isHydrated: false,
+      eligiblePaymentMethods: { getDetails: mockGetDetails },
+    });
+    const { container } = render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+      />,
+    );
+    expect(
+      container.querySelector("paypal-pay-later-button"),
+    ).not.toBeInTheDocument();
+    expect(container.querySelector("div")).toBeInTheDocument();
+  });
+
+  it("should call handleClick when button is clicked", () => {
+    const { container } = render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+      />,
+    );
+    const button = container.querySelector("paypal-pay-later-button");
+
+    // @ts-expect-error button should be defined at this point, test will error if not
+    fireEvent.click(button);
+
+    expect(mockHandleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should populate countryCode and productCode from eligibility", () => {
+    const { container } = render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+      />,
+    );
+    const button = container.querySelector("paypal-pay-later-button");
+    expect(mockGetDetails).toHaveBeenCalledWith("paylater");
+    expect(button).toHaveAttribute("countryCode", "US");
+    expect(button).toHaveAttribute("productCode", "PAY_LATER_LONG_TERM");
+  });
+
+  it("should render without eligibility details when not available", () => {
+    mockUseBraintreePayPal.mockReturnValue({
+      isHydrated: true,
+      eligiblePaymentMethods: null,
+    });
+    const { container } = render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+      />,
+    );
+    const button = container.querySelector("paypal-pay-later-button");
+    expect(button).toBeInTheDocument();
+    expect(button).not.toHaveAttribute("countryCode");
+    expect(button).not.toHaveAttribute("productCode");
+  });
+
+  it("should disable the button when disabled=true is given as a prop", () => {
+    const { container } = render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+        disabled={true}
+      />,
+    );
+    const button = container.querySelector("paypal-pay-later-button");
+    expect(button).toHaveAttribute("disabled");
+  });
+
+  it("should disable button when error is present", () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    mockUseBraintreePayPalPayLaterSession.mockReturnValue({
+      error: new Error("Test error"),
+      isPending: false,
+      handleClick: mockHandleClick,
+    });
+    const { container } = render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+      />,
+    );
+    const button = container.querySelector("paypal-pay-later-button");
+    expect(button).toHaveAttribute("disabled");
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should not disable button when error is null", () => {
+    mockUseBraintreePayPalPayLaterSession.mockReturnValue({
+      error: null,
+      isPending: false,
+      handleClick: mockHandleClick,
+    });
+    const { container } = render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+      />,
+    );
+    const button = container.querySelector("paypal-pay-later-button");
+    expect(button).not.toHaveAttribute("disabled");
+  });
+
+  it("should disable button when isPending is true", () => {
+    mockUseBraintreePayPalPayLaterSession.mockReturnValue({
+      error: null,
+      isPending: true,
+      handleClick: mockHandleClick,
+    });
+    const { container } = render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+      />,
+    );
+    const button = container.querySelector("paypal-pay-later-button");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("disabled");
+  });
+
+  it("should pass hook props to useBraintreePayPalPayLaterSession", () => {
+    const onApprove = () => Promise.resolve();
+    render(
+      <BraintreePayPalPayLaterButton
+        onApprove={onApprove}
+        amount="100.00"
+        currency="USD"
+      />,
+    );
+    expect(mockUseBraintreePayPalPayLaterSession).toHaveBeenCalledWith({
+      onApprove,
+      amount: "100.00",
+      currency: "USD",
+    });
+  });
+
+  it("should log error to console when an error from the hook is present", () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    const testError = new Error("Test error");
+    mockUseBraintreePayPalPayLaterSession.mockReturnValue({
+      error: testError,
+      isPending: false,
+      handleClick: mockHandleClick,
+    });
+    render(
+      <BraintreePayPalPayLaterButton
+        amount="100.00"
+        currency="USD"
+        onApprove={() => Promise.resolve()}
+      />,
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(testError);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
@@ -30,6 +30,7 @@ export type BraintreePayPalPayLaterButtonProps =
  * @example
  * function CheckoutButtons() {
  *   const { braintreePayPalCheckoutInstance } = useBraintreePayPal();
+ *   // Wait for eligibility to be determined before rendering buttons
  *   const { eligiblePaymentMethods, isLoading } = useBraintreeEligibleMethods({
  *     amount,
  *     currency,
@@ -43,13 +44,16 @@ export type BraintreePayPalPayLaterButtonProps =
  *     // Send nonce to your server to complete the transaction
  *   };
  *
- *   if (!eligiblePaymentMethods?.isEligible("paylater")) return null;
+ *   if (!eligiblePaymentMethods?.isEligible("paylater")) {
+ *     return null;
+ *   }
  *
  *   return (
  *     <BraintreePayPalPayLaterButton
  *       amount="100"
  *       currency="USD"
  *       onApprove={handleOnApprove}
+ *       // ...other props (onCancel, onError, etc.)
  *     />
  *   );
  * }

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect } from "react";
+
+import { useBraintreePayPalPayLaterSession } from "../../hooks/Braintree/useBraintreePayPalPayLaterSession";
+import { useBraintreePayPal } from "../../hooks/Braintree/useBraintreePayPal";
+
+import type { UseBraintreePayPalPayLaterSessionProps } from "../../hooks/Braintree/useBraintreePayPalPayLaterSession";
+
+export type BraintreePayPalPayLaterButtonProps =
+  UseBraintreePayPalPayLaterSessionProps & {
+    disabled?: boolean;
+  };
+
+/**
+ * `BraintreePayPalPayLaterButton` is a prebuilt button that renders a
+ * `<paypal-pay-later-button>` web component and manages the Braintree PayPal
+ * Pay Later (Buy Now, Pay Later) flow.
+ *
+ * Combines {@link UseBraintreePayPalPayLaterSessionProps} and a `disabled` prop.
+ * Must be rendered inside a BraintreePayPalProvider.
+ *
+ * The `countryCode` and `productCode` are automatically populated from the Braintree
+ * eligibility result (available via `useBraintreePayPal().eligiblePaymentMethods`).
+ * Configure eligibility with the `useBraintreeEligibleMethods` hook.
+ *
+ * For full control over the button UI, use the {@link useBraintreePayPalPayLaterSession}
+ * hook directly instead.
+ *
+ * @example
+ * function CheckoutButtons() {
+ *   const { braintreePayPalCheckoutInstance } = useBraintreePayPal();
+ *
+ *   const handleOnApprove = async (data) => {
+ *     const { nonce } = await braintreePayPalCheckoutInstance.tokenizePayment({
+ *       orderID: data.orderId,
+ *       payerID: data.payerId,
+ *     });
+ *     // Send nonce to your server to complete the transaction
+ *   };
+ *
+ *   return (
+ *     <BraintreePayPalPayLaterButton
+ *       amount="100"
+ *       currency="USD"
+ *       onApprove={handleOnApprove}
+ *     />
+ *   );
+ * }
+ */
+export const BraintreePayPalPayLaterButton = ({
+  disabled = false,
+  ...hookProps
+}: BraintreePayPalPayLaterButtonProps): JSX.Element | null => {
+  const { eligiblePaymentMethods, isHydrated } = useBraintreePayPal();
+  const { error, isPending, handleClick } =
+    useBraintreePayPalPayLaterSession(hookProps);
+
+  const payLaterDetails = eligiblePaymentMethods?.getDetails("paylater");
+
+  useEffect(() => {
+    if (error) {
+      console.error(error);
+    }
+  }, [error]);
+
+  return isHydrated ? (
+    <paypal-pay-later-button
+      onClick={handleClick}
+      countryCode={payLaterDetails?.countryCode}
+      productCode={payLaterDetails?.productCode}
+      disabled={disabled || isPending || error !== null ? true : undefined}
+    ></paypal-pay-later-button>
+  ) : (
+    <div />
+  );
+};

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
@@ -32,8 +32,8 @@ export type BraintreePayPalPayLaterButtonProps =
  *   const { braintreePayPalCheckoutInstance } = useBraintreePayPal();
  *   // Wait for eligibility to be determined before rendering buttons
  *   const { eligiblePaymentMethods, isLoading } = useBraintreeEligibleMethods({
- *     amount,
- *     currency,
+ *     amount, // dynamic checkout amount that can be used for eligibility checks
+ *     currency: "USD",
  *     countryCode: "US",
  *     paymentFlow: "ONE_TIME_PAYMENT",
  *   });

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
@@ -18,9 +18,11 @@ export type BraintreePayPalPayLaterButtonProps =
  * Combines {@link UseBraintreePayPalPayLaterSessionProps} and a `disabled` prop.
  * Must be rendered inside a BraintreePayPalProvider.
  *
- * The `countryCode` and `productCode` are automatically populated from the Braintree
- * eligibility result (available via `useBraintreePayPal().eligiblePaymentMethods`).
- * Configure eligibility with the `useBraintreeEligibleMethods` hook.
+ * **Requires eligibility data.** This component reads `countryCode` and
+ * `productCode` from `useBraintreePayPal().eligiblePaymentMethods`, which is
+ * populated by `useBraintreeEligibleMethods`. **Without eligibility, the button
+ * renders with `display: none` and is invisible.** Wait for eligibility before
+ * rendering.
  *
  * For full control over the button UI, use the {@link useBraintreePayPalPayLaterSession}
  * hook directly instead.
@@ -28,14 +30,20 @@ export type BraintreePayPalPayLaterButtonProps =
  * @example
  * function CheckoutButtons() {
  *   const { braintreePayPalCheckoutInstance } = useBraintreePayPal();
+ *   const { eligiblePaymentMethods, isLoading } = useBraintreeEligibleMethods({
+ *     amount,
+ *     currency,
+ *     countryCode: "US",
+ *     paymentFlow: "ONE_TIME_PAYMENT",
+ *   });
+ *   if (isLoading) return <Spinner />;
  *
  *   const handleOnApprove = async (data) => {
- *     const { nonce } = await braintreePayPalCheckoutInstance.tokenizePayment({
- *       orderID: data.orderId,
- *       payerID: data.payerId,
- *     });
+ *     const { nonce } = await braintreePayPalCheckoutInstance.tokenizePayment(data);
  *     // Send nonce to your server to complete the transaction
  *   };
+ *
+ *   if (!eligiblePaymentMethods?.isEligible("paylater")) return null;
  *
  *   return (
  *     <BraintreePayPalPayLaterButton

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalPayLaterButton.tsx
@@ -44,7 +44,7 @@ export type BraintreePayPalPayLaterButtonProps =
  *     // Send nonce to your server to complete the transaction
  *   };
  *
- *   if (!eligiblePaymentMethods?.isEligible("paylater")) {
+ *   if (!eligiblePaymentMethods?.paylater) {
  *     return null;
  *   }
  *

--- a/packages/react-paypal-js/src/v6/components/PayLaterOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayLaterOneTimePaymentButton.tsx
@@ -19,7 +19,11 @@ export type PayLaterOneTimePaymentButtonProps =
  *
  * The `countryCode` and `productCode` are automatically populated from the eligibility API response
  * (available via `usePayPal().eligiblePaymentMethods`). The button requires eligibility to be configured
- * in the parent `PayPalProvider`.
+ * in the parent `PayPalProvider`, using either the `useEligibleMethods` hook client-side or
+ * `useFetchEligibleMethods` server-side.
+ *
+ * **Eligibility must be fetched first.** Until eligibility is available, internally the button has no
+ * `countryCode`/`productCode` to render with. Fetch eligibility (and wait for it) before rendering.
  *
  * Note, `autoRedirect` is not allowed because if given a `presentationMode` of `"redirect"` the button
  * would not be able to provide back `redirectURL` from `start`. Advanced integrations that need
@@ -28,12 +32,27 @@ export type PayLaterOneTimePaymentButtonProps =
  * `presentationMode` is optional and defaults to `"auto"`.
  *
  * @example
- * <PayLaterOneTimePaymentButton
- *   onApprove={() => {
- *      // ... on approve logic
- *   }}
- *   orderId="your-order-id"
- * />
+ * function PayLaterCheckout() {
+ *   // Fetch eligibility before rendering the button (or hydrate it server-side
+ *   // via useFetchEligibleMethods)
+ *   const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+ *     payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+ *   });
+ *
+ *   if (isLoading) return <Spinner />;
+ *   if (!eligiblePaymentMethods?.isEligible("paylater")) {
+ *     return null;
+ *   }
+ *
+ *   return (
+ *     <PayLaterOneTimePaymentButton
+ *       onApprove={() => {
+ *         // ... on approve logic
+ *       }}
+ *       orderId="your-order-id"
+ *     />
+ *   );
+ * }
  */
 export const PayLaterOneTimePaymentButton = ({
   disabled = false,

--- a/packages/react-paypal-js/src/v6/components/PayPalCreditOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalCreditOneTimePaymentButton.tsx
@@ -18,6 +18,9 @@ export type PayPalCreditOneTimePaymentButtonProps =
  * (available via `usePayPal().eligiblePaymentMethods`). The button requires eligibility to be configured
  * in the parent `PayPalProvider`, using either the `useEligibleMethods` hook client-side or `useFetchEligibleMethods` server-side.
  *
+ * **Eligibility must be fetched first.** Until eligibility is available, internally the button has no
+ * `countryCode` to render with. Fetch eligibility (and wait for it) before rendering.
+ *
  * Note, `autoRedirect` is not allowed because if given a `presentationMode` of `"redirect"` the button
  * would not be able to provide back `redirectURL` from `start`. Advanced integrations that need
  * `redirectURL` should use the {@link usePayPalCreditOneTimePaymentSession} hook directly.
@@ -25,12 +28,27 @@ export type PayPalCreditOneTimePaymentButtonProps =
  * `presentationMode` is optional and defaults to `"auto"`.
  *
  * @example
- * <PayPalCreditOneTimePaymentButton
- *   onApprove={() => {
- *      // ... on approve logic
- *   }}
- *   orderId="your-order-id"
- * />
+ * function CreditCheckout() {
+ *   // Fetch eligibility before rendering the button (or hydrate it server-side
+ *   // via useFetchEligibleMethods)
+ *   const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+ *     payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+ *   });
+ *
+ *   if (isLoading) return <Spinner />;
+ *   if (!eligiblePaymentMethods?.isEligible("credit")) {
+ *     return null;
+ *   }
+ *
+ *   return (
+ *     <PayPalCreditOneTimePaymentButton
+ *       onApprove={() => {
+ *         // ... on approve logic
+ *       }}
+ *       orderId="your-order-id"
+ *     />
+ *   );
+ * }
  */
 export const PayPalCreditOneTimePaymentButton = ({
   disabled = false,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
@@ -205,6 +205,7 @@ export function useBraintreePayPalPayLaterSession({
     displayName,
     presentationMode,
     shippingCallbackUrl,
+    contactPreference,
     memoizedLineItems,
     memoizedShippingOptions,
     memoizedAmountBreakdown,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
@@ -37,7 +37,9 @@ export interface UseBraintreePayPalPayLaterSessionReturn {
  * // Custom button using the hook directly with a <paypal-pay-later-button> web component
  * function PayPalPayLaterButton(props: UseBraintreePayPalPayLaterSessionProps) {
  *   const { isPending, handleClick } = useBraintreePayPalPayLaterSession(props);
- *   const { isLoading, eligiblePaymentMethods } = useBraintreeEligibleMethods();
+ *   const { isLoading, eligiblePaymentMethods } = useBraintreeEligibleMethods({
+ *     currency: "USD"
+ *   });
  *
  *   if (isPending || isLoading) return <Spinner />;
  *
@@ -51,8 +53,8 @@ export interface UseBraintreePayPalPayLaterSessionReturn {
  *     <paypal-pay-later-button
  *       onClick={() => handleClick()}
  *       disabled={isPending}
- *       country={payLaterDetails?.countryCode}
- *       product={payLaterDetails?.productCode}
+ *       countryCode={payLaterDetails?.countryCode}
+ *       productCode={payLaterDetails?.productCode}
  *     />
  *   );
  * }

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
@@ -100,6 +100,7 @@ export function useBraintreePayPalPayLaterSession({
   shippingOptions,
   amountBreakdown,
   shippingAddressOverride,
+  contactPreference,
 }: UseBraintreePayPalPayLaterSessionProps): UseBraintreePayPalPayLaterSessionReturn {
   const {
     braintreePayPalCheckoutInstance,
@@ -174,6 +175,7 @@ export function useBraintreePayPalPayLaterSession({
           shippingOptions: memoizedShippingOptions,
           amountBreakdown: memoizedAmountBreakdown,
           shippingAddressOverride: memoizedShippingAddressOverride,
+          contactPreference,
           ...proxyCallbacks,
         }),
       failedSdkRef: failedInstanceRef,

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
@@ -34,29 +34,36 @@ export interface UseBraintreePayPalPayLaterSessionReturn {
  * @returns Object with: `error` (any session error), `isPending` (checkout instance loading), `handleClick` (starts session)
  *
  * @example
- * // Custom button using the hook directly with a <paypal-button> web component
+ * // Custom button using the hook directly with a <paypal-pay-later-button> web component
  * function PayPalPayLaterButton(props: UseBraintreePayPalPayLaterSessionProps) {
  *   const { isPending, handleClick } = useBraintreePayPalPayLaterSession(props);
+ *   const { isLoading, eligiblePaymentMethods } = useBraintreeEligibleMethods();
+ *
+ *   if (isPending || isLoading) return <Spinner />;
+ *
+ *   if (!eligiblePaymentMethods?.isEligible("paylater")) {
+ *    return null;
+ *   }
+ *
+ *   const payLaterDetails = eligiblePaymentMethods.getDetails("paylater");
  *
  *   return (
- *     <paypal-button
- *       type="pay"
- *       fundingSource="paylater"
+ *     <paypal-pay-later-button
  *       onClick={() => handleClick()}
  *       disabled={isPending}
+ *       country={payLaterDetails?.countryCode}
+ *       product={payLaterDetails?.productCode}
  *     />
  *   );
  * }
  *
- * // Usage with tokenization in onApprove:
+ * // Pass your custom button props from a parent component:
  * function Checkout() {
  *   const { braintreePayPalCheckoutInstance } = useBraintreePayPal();
  *
+ *   // Tokenize payment in the onApprove callback and send the nonce to your server
  *   const handleOnApprove = async (data) => {
- *     const { nonce } = await braintreePayPalCheckoutInstance.tokenizePayment({
- *       orderID: data.orderId,
- *       payerID: data.payerId,
- *     });
+ *     const { nonce } = await braintreePayPalCheckoutInstance.tokenizePayment(data);
  *     // Send nonce to your server to complete the transaction
  *   };
  *
@@ -65,6 +72,7 @@ export interface UseBraintreePayPalPayLaterSessionReturn {
  *       amount="100.00"
  *       currency="USD"
  *       onApprove={handleOnApprove}
+ *       // ...other props (onCancel, onError, etc.)
  *     />
  *   );
  * }

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalPayLaterSession.ts
@@ -43,7 +43,7 @@ export interface UseBraintreePayPalPayLaterSessionReturn {
  *
  *   if (isPending || isLoading) return <Spinner />;
  *
- *   if (!eligiblePaymentMethods?.isEligible("paylater")) {
+ *   if (!eligiblePaymentMethods?.paylater) {
  *    return null;
  *   }
  *

--- a/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
@@ -34,6 +34,10 @@ export type UsePayLaterOneTimePaymentSessionProps = (
  * for redirect-based presentation modes (`"redirect"` and `"direct-app-switch"`), and provides methods
  * to start, cancel, and destroy the session.
  *
+ * Eligibility must be fetched separately (via the `useEligibleMethods` hook client-side or
+ * `useFetchEligibleMethods` server-side) to obtain the `countryCode`/`productCode` the
+ * `<paypal-pay-later-button>` needs to render.
+ *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
  *
  * `presentationMode` is optional and defaults to `"auto"`.
@@ -46,10 +50,20 @@ export type UsePayLaterOneTimePaymentSessionProps = (
  *     onApprove: (data) => console.log('Approved:', data),
  *     onCancel: () => console.log('Cancelled'),
  *   });
- *   const { eligiblePaymentMethods } = usePayPal();
+ *
+ *   // Fetch eligibility (or hydrate server-side via useFetchEligibleMethods)
+ *   const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+ *     payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+ *   });
+ *
+ *   if (isPending || isLoading) return <Spinner />;
+ *
+ *   if (!eligiblePaymentMethods?.isEligible("paylater")) {
+ *     return null;
+ *   }
+ *
  *   const payLaterDetails = eligiblePaymentMethods?.getDetails?.("paylater");
  *
- *   if (isPending) return null;
  *   if (error) return <div>Error: {error.message}</div>;
  *
  *   return (

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
@@ -32,6 +32,10 @@ export type UsePayPalCreditOneTimePaymentSessionProps = (
  * This hook creates and manages a PayPal Credit payment session. It handles session lifecycle, resume flows
  * for redirect-based flows, and provides methods to start, cancel, and destroy the session.
  *
+ * Eligibility must be fetched separately (via the `useEligibleMethods` hook client-side or
+ * `useFetchEligibleMethods` server-side) to obtain the `countryCode` the
+ * `<paypal-credit-button>` needs to render.
+ *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
  *
  * `presentationMode` is optional and defaults to `"auto"`.
@@ -44,10 +48,14 @@ export type UsePayPalCreditOneTimePaymentSessionProps = (
  *     onApprove: (data) => console.log('Approved:', data),
  *     onCancel: () => console.log('Cancelled'),
  *   });
- *   const { eligiblePaymentMethods } = usePayPal();
+ *
+ *   // Fetch eligibility (or hydrate server-side via useFetchEligibleMethods)
+ *   const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
+ *     payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
+ *   });
  *   const creditDetails = eligiblePaymentMethods?.getDetails?.("credit");
  *
- *   if (isPending) return null;
+ *   if (isPending || isLoading) return null;
  *   if (error) return <div>Error: {error.message}</div>;
  *
  *   return (

--- a/packages/react-paypal-js/src/v6/index.ts
+++ b/packages/react-paypal-js/src/v6/index.ts
@@ -52,6 +52,10 @@ export {
   BraintreePayPalCheckoutWithVaultButton,
   type BraintreePayPalCheckoutWithVaultButtonProps,
 } from "./components/Braintree/BraintreePayPalCheckoutWithVaultButton";
+export {
+  BraintreePayPalPayLaterButton,
+  type BraintreePayPalPayLaterButtonProps,
+} from "./components/Braintree/BraintreePayPalPayLaterButton";
 export { PayPalSavePaymentButton } from "./components/PayPalSavePaymentButton";
 export { VenmoOneTimePaymentButton } from "./components/VenmoOneTimePaymentButton";
 export {


### PR DESCRIPTION
This PR adds the BT-PayPal Pay Later static UI button component. This can be tested locally using `npm link` or `npm pack` in order to serve the package locally to the V6 Web SDK with Braintree sample integration. The [PR](https://github.com/paypal-examples/v6-web-sdk-with-braintree-sdk-sample-integration/pull/44) updates the Braintree-PayPal prebuilt React app and can be used to test the Pay Later button.