### PR TITLE
Fix: React Google Pay silent return

### DIFF
--- a/.changeset/fruity-bats-say.md
+++ b/.changeset/fruity-bats-say.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Raises an error when the Google Pay script has not loaded when the React component has mounted.

--- a/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.test.ts
@@ -419,6 +419,61 @@ describe("useGooglePayOneTimePaymentSession", () => {
     });
   });
 
+  describe("pay.js loading timing (Tier 1: loud failure)", () => {
+    test("surfaces an error and calls onError when pay.js is missing at mount", () => {
+      removeGooglePayGlobal();
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      expectCurrentErrorValue(result.current.error);
+      expect(result.current.error?.message).toContain("pay.js");
+      expect(result.current.paymentsClient).toBeNull();
+      expect(result.current.formattedConfig).toBeNull();
+      expect(defaultProps.onError).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onError).toHaveBeenCalledWith(result.current.error);
+    });
+
+    test("does NOT auto-recover after pay.js loads late (recovery is Tier 2)", () => {
+      removeGooglePayGlobal();
+
+      const { result, rerender } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      expect(result.current.paymentsClient).toBeNull();
+      expect(result.current.error?.message).toContain("pay.js");
+
+      // pay.js arrives after mount; an unrelated re-render does not re-run the
+      // setup effect (window.google is not — and cannot be — a dependency).
+      setupGooglePayGlobal();
+      rerender();
+
+      expect(result.current.paymentsClient).toBeNull();
+      expect(result.current.error?.message).toContain("pay.js");
+    });
+
+    test("createGooglePayButton returns null and an error is present when pay.js is missing", async () => {
+      removeGooglePayGlobal();
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      let button: HTMLElement | null = null;
+      await act(async () => {
+        button = await result.current.createGooglePayButton({
+          onClick: jest.fn(),
+          buttonType: "pay",
+        });
+      });
+
+      expect(button).toBeNull();
+      expect(result.current.error?.message).toContain("pay.js");
+    });
+  });
+
   describe("handleClick - payment flow", () => {
     test("should handle payment authorization, confirm order, and call onApprove", async () => {
       const { result } = renderHook(() =>

--- a/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
@@ -227,6 +227,17 @@ export function useGooglePayOneTimePaymentSession({
       paymentsClientRef.current = null;
       setPaymentsClient(null);
       setFormattedConfig(null);
+
+      // This effect only runs in the browser (React skips effects during SSR),
+      // so reaching here means pay.js has not loaded yet. Fail loudly instead of
+      // silently rendering an empty button container.
+      const sdkNotLoadedError = new Error(
+        "Google Pay JS SDK (pay.js) is not loaded. Add " +
+          '<script src="https://pay.google.com/gp/p/js/pay.js"></script> ' +
+          "to your HTML before <GooglePayOneTimePaymentButton> mounts.",
+      );
+      setError(sdkNotLoadedError);
+      proxyCallbacks.onError?.(sdkNotLoadedError);
       return;
     }
 


### PR DESCRIPTION
This PR leverages `useError` to indicate when the Google Pay JS SDK (`pay.js`) hasn't loaded by the time the `PaymentsClient` setup effect runs in `useGooglePayOneTimePaymentSession`.

Previously, if `window.google.payments.api.PaymentsClient` was unavailable, the effect would null out `paymentsClient` / `formattedConfig` and bail silently — leaving consumers with an empty button container and no indication of what went wrong. Now the hook sets a descriptive `error` and invokes the `onError` callback, telling the integrator to add the `pay.js` `<script>` tag before the button mounts.

## Changes

- **`useGooglePayOneTimePaymentSession.ts`**: When `pay.js` is missing in the browser, construct an `Error` with actionable guidance (including the exact script tag to add), set it via `setError`, and call `proxyCallbacks.onError`. Includes a comment noting this branch is only reachable in the browser since React skips effects during SSR.
- **`useGooglePayOneTimePaymentSession.test.ts`**: Adds a `pay.js loading timing` test suite covering:
  - error + `onError` fire when `pay.js` is missing at mount
  - `createGooglePayButton` returns `null` with an error present when `pay.js` is missing
