### PR TITLE
Fix: Update 2 bugs in useEligibleMethods hook

### DIFF
--- a/.changeset/loose-adults-obey.md
+++ b/.changeset/loose-adults-obey.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Fix stale error and potential perpetual loader bug in useEligibleMethods.

--- a/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.test.ts
@@ -141,9 +141,10 @@ describe("useEligibleMethods", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    test("should return isLoading=true when context has error but no eligibility data", () => {
-      // Context error (SDK load failure) doesn't set eligibilityError,
-      // but we still don't have eligibility data, so isLoading is true
+    test("should force isLoading=false and surface a labeled context error", () => {
+      // A context error (SDK load failure) is surfaced separately and labeled,
+      // and forces isLoading=false so a consumer that checks isLoading before
+      // error doesn't spin forever over a failure.
       const { result } = renderHook(() => useEligibleMethods(), {
         wrapper: createWrapper({
           loadingStatus: INSTANCE_LOADING_STATE.REJECTED,
@@ -152,9 +153,7 @@ describe("useEligibleMethods", () => {
         }),
       });
 
-      // isLoading is true because we don't have eligibility data
-      // The context error is returned separately
-      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isLoading).toBe(false);
       expect(result.current.error?.message).toContain("PayPal context error");
     });
   });
@@ -437,6 +436,89 @@ describe("useEligibleMethods", () => {
           loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
         }),
       });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.error).toBe(fetchError);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    test("should clear a stale error after a successful refetch", async () => {
+      // First fetch (payload A) fails; consumer then changes to payload B,
+      // which succeeds. The fresh attempt must reset the prior error so the
+      // hook doesn't return success-state data alongside a stale error.
+      let callCount = 0;
+      const mockSdkInstance = createMockSdkInstance(() => {
+        callCount += 1;
+        return callCount === 1
+          ? Promise.reject(new Error("network blip"))
+          : Promise.resolve(mockEligibilityResult);
+      });
+      let currentPayload = { currency: "USD" };
+
+      const { result, rerender } = renderHook(
+        () => useEligibleMethods({ payload: currentPayload as never }),
+        {
+          wrapper: createWrapper({
+            sdkInstance: mockSdkInstance,
+            eligiblePaymentMethods: null,
+            loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
+          }),
+        },
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Payload A failed.
+      expect(result.current.error).not.toBeNull();
+
+      // Consumer corrects the payload — this triggers a fresh fetch.
+      currentPayload = { currency: "EUR" };
+      rerender();
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockSdkInstance!.findEligibleMethods).toHaveBeenCalledTimes(2);
+      // The stale error from payload A is gone after the successful refetch.
+      expect(result.current.error).toBeNull();
+    });
+
+    test("should force isLoading=false when a fetch error is present alongside stale cached data", async () => {
+      // Cached eligibility is present but stale relative to the requested
+      // payload (different paymentFlow), which would normally mark
+      // isLoading=true. The refetch fails, so the present error must force
+      // isLoading=false instead of leaving the consumer on a perpetual spinner.
+      const fetchError = new Error("Fetch failed");
+      const mockSdkInstance = createMockSdkInstance(() =>
+        Promise.reject(fetchError),
+      );
+
+      const { result } = renderHook(
+        () =>
+          useEligibleMethods({
+            payload: {
+              currencyCode: "USD",
+              paymentFlow: "ONE_TIME_PAYMENT",
+            } as never,
+          }),
+        {
+          wrapper: createWrapper({
+            sdkInstance: mockSdkInstance,
+            eligiblePaymentMethods: mockEligibilityResult,
+            eligiblePaymentMethodsPayload: {
+              currencyCode: "USD",
+              paymentFlow: "VAULT_WITHOUT_PAYMENT",
+            },
+            loadingStatus: INSTANCE_LOADING_STATE.RESOLVED,
+          }),
+        },
+      );
 
       await act(async () => {
         await Promise.resolve();

--- a/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.ts
@@ -131,6 +131,10 @@ export function useEligibleMethods(
 
     let isSubscribed = true;
     setIsFetching(true);
+    // Clear any prior error when a new fetch begins so a successful refetch
+    // (e.g. after the consumer changes the payload) doesn't return fresh data
+    // alongside a stale error from the previous attempt.
+    setError(null);
 
     sdkInstance
       .findEligibleMethods(memoizedPayload)
@@ -162,9 +166,9 @@ export function useEligibleMethods(
     };
   }, [sdkInstance, memoizedPayload, dispatch, setError]);
 
-  // isLoading should be true if:
+  // isLoading should be true (unless an error is present) if:
   // 1. We're actively fetching, OR
-  // 2. We don't have eligibility data yet and no error occurred, OR
+  // 2. We don't have eligibility data yet, OR
   // 3. Eligibility data exists but was fetched with a different payload
   //    (e.g., navigating from VAULT_WITHOUT_PAYMENT to ONE_TIME_PAYMENT)
   // This prevents a flash of stale buttons before the new fetch completes
@@ -176,13 +180,15 @@ export function useEligibleMethods(
       eligiblePaymentMethodsPayload ?? undefined,
       memoizedPayload ?? undefined,
     );
+  // Forced false whenever an error is present so a consumer that checks
+  // isLoading before error never shows a perpetual spinner over a failure.
   const isLoading =
-    isFetching || (!eligiblePaymentMethods && !eligibilityError) || isStaleData;
+    !eligibilityError && (isFetching || !eligiblePaymentMethods || isStaleData);
 
   if (contextError) {
     return {
       eligiblePaymentMethods,
-      isLoading,
+      isLoading: false,
       error: new Error(`PayPal context error: ${contextError}`),
     };
   }


### PR DESCRIPTION
## Fix stale-error and loading-state bugs in `useEligibleMethods`

Fixes two defects in the v6 `useEligibleMethods` hook that diverged from the already-corrected `useBraintreeEligibleMethods`.

### Changes

- **Clear stale error on refetch.** The hook never reset `error`, so if a fetch for one payload failed and the consumer changed to a payload that succeeded, the hook returned the fresh data alongside the previous attempt's stale error. We now call `setError(null)` when a new fetch begins.
- **No perpetual spinner on error.** `isLoading` is now gated on the combined error state, so it is `false` whenever an error is present. The `contextError` branch returns `isLoading: false` instead of `true`, so a consumer that checks `isLoading` before `error` no longer spins forever on an SDK/provider init failure.

### Tests

- Stale error is cleared after a successful refetch following a failed one.
- A fetch error alongside stale cached data forces `isLoading: false`.
- A context error surfaces a labeled error and forces `isLoading: false`.
