### PR TITLE
Fix: Add default export for v6

### DIFF
--- a/.changeset/sdk-v6-default-export.md
+++ b/.changeset/sdk-v6-default-export.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Add a `default` export condition to the `./sdk-v6` subpath so bundlers/tracers (e.g. @vercel/nft) resolve it correctly and don't fall back to the v5 entry.

--- a/packages/paypal-js/package.json
+++ b/packages/paypal-js/package.json
@@ -16,7 +16,8 @@
     },
     "./sdk-v6": {
       "types": "./types/v6/index.d.ts",
-      "import": "./dist/v6/esm/paypal-js.js"
+      "import": "./dist/v6/esm/paypal-js.js",
+      "default": "./dist/v6/esm/paypal-js.js"
     }
   },
   "scripts": {

--- a/packages/paypal-js/src/exports.test.ts
+++ b/packages/paypal-js/src/exports.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "fs";
+
+import { describe, test, expect } from "vitest";
+
+// Read + parse instead of importing package.json so this stays valid under
+// the tsconfig (no resolveJsonModule) and matches the bundle tests' use of fs.
+const pkg = JSON.parse(readFileSync("package.json", "utf8")) as {
+  exports: Record<string, Record<string, string>>;
+};
+
+describe("package.json exports", () => {
+  // The "./sdk-v6" subpath must declare a "default" condition as a terminal
+  // fallback. Without it, tracers/bundlers (e.g. @vercel/nft) can mis-resolve
+  // the subpath and fall back to the v5 entry. See issue #979.
+  test('"./sdk-v6" declares a default condition', () => {
+    expect(pkg.exports["./sdk-v6"]).toHaveProperty("default");
+  });
+});


### PR DESCRIPTION
This PR adds a default export for the `./sdk-v6` subpath export in response to this [issue](https://github.com/paypal/paypal-js/issues/979). 

TLDR: `@vercel/nft`, which is used for Vercel SSR/serverless deploys, is mis-resolving the v6 subpath since it expects a default.