### PR TITLE
fix apple pay disable property

### DIFF
--- a/.changeset/apple-pay-disabled-fix.md
+++ b/.changeset/apple-pay-disabled-fix.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Fix `disabled` on `ApplePayOneTimePaymentButton`: apply the disabled state (dimming + click gating) on the wrapper instead of writing `disabled` to Apple's `<apple-pay-button>`, which ignores the attribute and manages it internally.

--- a/.changeset/apple-pay-disabled-fix.md
+++ b/.changeset/apple-pay-disabled-fix.md
@@ -2,4 +2,4 @@
 "@paypal/react-paypal-js": patch
 ---
 
-Fix `disabled` on `ApplePayOneTimePaymentButton`: apply the disabled state (dimming + click gating) on the wrapper instead of writing `disabled` to Apple's `<apple-pay-button>`, which ignores the attribute and manages it internally.
+`ApplePayOneTimePaymentButton` no longer writes a `disabled` attribute to Apple's `<apple-pay-button>`, which ignored it and manages its own enabled/disabled state internally via `canMakePayments()`. The non-functional `disabled` prop has been removed — merchants control presentation themselves.

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/ApplePayOneTimePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/ApplePayOneTimePaymentButton.stories.tsx
@@ -1,36 +1,34 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import {
-    ApplePayOneTimePaymentButton,
-    useEligibleMethods,
+  ApplePayOneTimePaymentButton,
+  useEligibleMethods,
 } from "@paypal/react-paypal-js/sdk-v6";
 import type {
-    UseApplePayOneTimePaymentSessionProps,
-    ConfirmOrderResponse,
+  UseApplePayOneTimePaymentSessionProps,
+  ConfirmOrderResponse,
 } from "@paypal/react-paypal-js/sdk-v6";
 import {
-    createOrder,
-    applePayCallbacks,
-    applePayButtonStyleArgType,
-    applePayButtonTypeArgType,
-    disabledArgType,
+  createOrder,
+  applePayCallbacks,
+  applePayButtonStyleArgType,
+  applePayButtonTypeArgType,
 } from "../../shared/utils";
 import { V6DocPageStructure } from "../../components";
 import { getApplePayOneTimePaymentButtonCode } from "../../shared/code";
 
 type ApplePayStoryArgs = {
-    paymentRequest: UseApplePayOneTimePaymentSessionProps["paymentRequest"];
-    createOrder: () => Promise<{ orderId: string }>;
-    onApprove: (data: ConfirmOrderResponse) => void | Promise<void>;
-    onCancel?: () => void;
-    onError?: (error: Error) => void;
-    applePaySessionVersion: number;
-    displayName?: string;
-    domainName?: string;
-    buttonstyle?: "black" | "white" | "white-outline";
-    type?: string;
-    locale?: string;
-    disabled?: boolean;
+  paymentRequest: UseApplePayOneTimePaymentSessionProps["paymentRequest"];
+  createOrder: () => Promise<{ orderId: string }>;
+  onApprove: (data: ConfirmOrderResponse) => void | Promise<void>;
+  onCancel?: () => void;
+  onError?: (error: Error) => void;
+  applePaySessionVersion: number;
+  displayName?: string;
+  domainName?: string;
+  buttonstyle?: "black" | "white" | "white-outline";
+  type?: string;
+  locale?: string;
 };
 
 /**
@@ -44,119 +42,116 @@ type ApplePayStoryArgs = {
  * splitting the check and the button into separate components.
  */
 function ApplePayStoryWrapper(args: ApplePayStoryArgs) {
-    let canUseApplePay = false;
-    try {
-        canUseApplePay =
-            typeof window !== "undefined" &&
-            !!window.ApplePaySession?.canMakePayments();
-    } catch {
-        // canMakePayments() throws on non-HTTPS (InvalidAccessError)
+  let canUseApplePay = false;
+  try {
+    canUseApplePay =
+      typeof window !== "undefined" &&
+      !!window.ApplePaySession?.canMakePayments();
+  } catch {
+    // canMakePayments() throws on non-HTTPS (InvalidAccessError)
+  }
+
+  const {
+    eligiblePaymentMethods,
+    isLoading: isEligibilityLoading,
+    error: eligibilityError,
+  } = useEligibleMethods({
+    payload: { currencyCode: "USD" },
+  });
+
+  if (!canUseApplePay) {
+    const isSafari =
+      typeof navigator !== "undefined" &&
+      /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    const isHttps =
+      typeof window !== "undefined" && window.location.protocol === "https:";
+
+    let message: string;
+    if (!isSafari && !isHttps) {
+      message =
+        "Apple Pay requires Safari and HTTPS. The button will not render or function in this environment.";
+    } else if (!isSafari) {
+      message =
+        "Apple Pay requires Safari. The button will not render in this browser.";
+    } else if (!isHttps) {
+      message =
+        "Apple Pay requires HTTPS. The button will not render over an insecure connection. Use ngrok or deploy to HTTPS to preview.";
+    } else {
+      message =
+        "Apple Pay is not available on this device. Ensure Apple Pay is configured in Wallet.";
     }
-
-    const {
-        eligiblePaymentMethods,
-        isLoading: isEligibilityLoading,
-        error: eligibilityError,
-    } = useEligibleMethods({
-        payload: { currencyCode: "USD" },
-    });
-
-    if (!canUseApplePay) {
-        const isSafari =
-            typeof navigator !== "undefined" &&
-            /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-        const isHttps =
-            typeof window !== "undefined" &&
-            window.location.protocol === "https:";
-
-        let message: string;
-        if (!isSafari && !isHttps) {
-            message =
-                "Apple Pay requires Safari and HTTPS. The button will not render or function in this environment.";
-        } else if (!isSafari) {
-            message =
-                "Apple Pay requires Safari. The button will not render in this browser.";
-        } else if (!isHttps) {
-            message =
-                "Apple Pay requires HTTPS. The button will not render over an insecure connection. Use ngrok or deploy to HTTPS to preview.";
-        } else {
-            message =
-                "Apple Pay is not available on this device. Ensure Apple Pay is configured in Wallet.";
-        }
-
-        return (
-            <div
-                style={{
-                    padding: "12px 16px",
-                    border: "1px solid #e2e8f0",
-                    borderRadius: "4px",
-                    backgroundColor: "#f7fafc",
-                    color: "#4a5568",
-                    fontSize: "14px",
-                    lineHeight: "1.5",
-                }}
-            >
-                <strong>Note</strong>
-                <p style={{ margin: "4px 0 0" }}>{message}</p>
-            </div>
-        );
-    }
-
-    if (isEligibilityLoading) {
-        return <div>Checking Apple Pay eligibility...</div>;
-    }
-
-    if (eligibilityError) {
-        return (
-            <div style={{ color: "#c53030" }}>
-                Failed to check eligibility: {eligibilityError.message}
-            </div>
-        );
-    }
-
-    const isEligible = eligiblePaymentMethods?.isEligible("applepay");
-    const applePayConfig =
-        eligiblePaymentMethods?.getDetails("applepay")?.config;
-
-    if (!isEligible || !applePayConfig) {
-        return (
-            <div
-                style={{
-                    padding: "12px 16px",
-                    border: "1px solid #ffeeba",
-                    borderRadius: "4px",
-                    backgroundColor: "#fff3cd",
-                    color: "#856404",
-                    fontSize: "14px",
-                }}
-            >
-                Apple Pay is not eligible for this merchant/environment.
-            </div>
-        );
-    }
-
-    const { buttonstyle, type, locale, disabled, ...hookProps } = args;
 
     return (
-        <ApplePayOneTimePaymentButton
-            applePayConfig={applePayConfig}
-            buttonstyle={buttonstyle}
-            type={type}
-            locale={locale}
-            disabled={disabled}
-            {...hookProps}
-        />
+      <div
+        style={{
+          padding: "12px 16px",
+          border: "1px solid #e2e8f0",
+          borderRadius: "4px",
+          backgroundColor: "#f7fafc",
+          color: "#4a5568",
+          fontSize: "14px",
+          lineHeight: "1.5",
+        }}
+      >
+        <strong>Note</strong>
+        <p style={{ margin: "4px 0 0" }}>{message}</p>
+      </div>
     );
+  }
+
+  if (isEligibilityLoading) {
+    return <div>Checking Apple Pay eligibility...</div>;
+  }
+
+  if (eligibilityError) {
+    return (
+      <div style={{ color: "#c53030" }}>
+        Failed to check eligibility: {eligibilityError.message}
+      </div>
+    );
+  }
+
+  const isEligible = eligiblePaymentMethods?.isEligible("applepay");
+  const applePayConfig = eligiblePaymentMethods?.getDetails("applepay")?.config;
+
+  if (!isEligible || !applePayConfig) {
+    return (
+      <div
+        style={{
+          padding: "12px 16px",
+          border: "1px solid #ffeeba",
+          borderRadius: "4px",
+          backgroundColor: "#fff3cd",
+          color: "#856404",
+          fontSize: "14px",
+        }}
+      >
+        Apple Pay is not eligible for this merchant/environment.
+      </div>
+    );
+  }
+
+  const { buttonstyle, type, locale, ...hookProps } = args;
+
+  return (
+    <ApplePayOneTimePaymentButton
+      applePayConfig={applePayConfig}
+      buttonstyle={buttonstyle}
+      type={type}
+      locale={locale}
+      {...hookProps}
+    />
+  );
 }
 
 const meta: Meta<ApplePayStoryArgs> = {
-    title: "V6/Buttons/ApplePayOneTimePaymentButton",
-    tags: ["autodocs"],
-    parameters: {
-        controls: { expanded: true },
-        docs: {
-            description: {
-                component: `Apple Pay one-time payment button powered by the PayPal SDK.
+  title: "V6/Buttons/ApplePayOneTimePaymentButton",
+  tags: ["autodocs"],
+  parameters: {
+    controls: { expanded: true },
+    docs: {
+      description: {
+        component: `Apple Pay one-time payment button powered by the PayPal SDK.
 
 This component renders Apple's native \`<apple-pay-button>\` and manages the full Apple Pay payment flow — including merchant validation, payment authorization, and order confirmation — via the PayPal SDK.
 
@@ -179,49 +174,45 @@ This component renders Apple's native \`<apple-pay-button>\` and manages the ful
 
 It relies on the \`<PayPalProvider />\` parent component with \`components={["applepay-payments"]}\`.
 `,
-            },
-            page: () => (
-                <V6DocPageStructure
-                    code={getApplePayOneTimePaymentButtonCode()}
-                />
-            ),
-        },
+      },
+      page: () => (
+        <V6DocPageStructure code={getApplePayOneTimePaymentButtonCode()} />
+      ),
     },
-    argTypes: {
-        buttonstyle: applePayButtonStyleArgType,
-        type: applePayButtonTypeArgType,
-        locale: {
-            control: { type: "text" },
-            description:
-                "Locale for the Apple Pay button (e.g., 'en', 'fr', 'ja')",
-        },
-        disabled: disabledArgType,
-        createOrder: {
-            description:
-                "Function that creates an order and returns `{ orderId }`. Called during payment authorization after the buyer approves.",
-            table: { category: "Events" },
-        },
-        onApprove: {
-            description:
-                "Called after the payment is confirmed with PayPal. Receives `ConfirmOrderResponse` — use `data.approveApplePayPayment.id` to capture the order.",
-            table: { category: "Events" },
-        },
-        onCancel: {
-            description:
-                "Called when the buyer dismisses the Apple Pay payment sheet.",
-            table: { category: "Events" },
-        },
-        onError: {
-            description:
-                "Called when an error occurs during the Apple Pay flow (e.g., merchant validation failure, network error).",
-            table: { category: "Events" },
-        },
-        applePaySessionVersion: {
-            control: { type: "number", min: 4 },
-            description:
-                "Apple Pay JS API version passed to the ApplePaySession constructor. Must be at least 4.",
-        },
+  },
+  argTypes: {
+    buttonstyle: applePayButtonStyleArgType,
+    type: applePayButtonTypeArgType,
+    locale: {
+      control: { type: "text" },
+      description: "Locale for the Apple Pay button (e.g., 'en', 'fr', 'ja')",
     },
+    createOrder: {
+      description:
+        "Function that creates an order and returns `{ orderId }`. Called during payment authorization after the buyer approves.",
+      table: { category: "Events" },
+    },
+    onApprove: {
+      description:
+        "Called after the payment is confirmed with PayPal. Receives `ConfirmOrderResponse` — use `data.approveApplePayPayment.id` to capture the order.",
+      table: { category: "Events" },
+    },
+    onCancel: {
+      description:
+        "Called when the buyer dismisses the Apple Pay payment sheet.",
+      table: { category: "Events" },
+    },
+    onError: {
+      description:
+        "Called when an error occurs during the Apple Pay flow (e.g., merchant validation failure, network error).",
+      table: { category: "Events" },
+    },
+    applePaySessionVersion: {
+      control: { type: "number", min: 4 },
+      description:
+        "Apple Pay JS API version passed to the ApplePaySession constructor. Must be at least 4.",
+    },
+  },
 };
 
 export default meta;
@@ -229,30 +220,24 @@ export default meta;
 type Story = StoryObj<ApplePayStoryArgs>;
 
 export const Default: Story = {
-    render: (args) => <ApplePayStoryWrapper {...args} />,
-    args: {
-        createOrder,
-        paymentRequest: {
-            countryCode: "US",
-            currencyCode: "USD",
-            requiredBillingContactFields: [
-                "name",
-                "phone",
-                "email",
-                "postalAddress",
-            ],
-            requiredShippingContactFields: [],
-            total: {
-                label: "Demo (Card is not charged)",
-                amount: "20.00",
-                type: "final",
-            },
-        },
-        applePaySessionVersion: 4,
-        buttonstyle: "black",
-        type: "buy",
-        locale: "en",
-        disabled: false,
-        ...applePayCallbacks,
+  render: (args) => <ApplePayStoryWrapper {...args} />,
+  args: {
+    createOrder,
+    paymentRequest: {
+      countryCode: "US",
+      currencyCode: "USD",
+      requiredBillingContactFields: ["name", "phone", "email", "postalAddress"],
+      requiredShippingContactFields: [],
+      total: {
+        label: "Demo (Card is not charged)",
+        amount: "20.00",
+        type: "final",
+      },
     },
+    applePaySessionVersion: 4,
+    buttonstyle: "black",
+    type: "buy",
+    locale: "en",
+    ...applePayCallbacks,
+  },
 };

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
@@ -94,15 +94,33 @@ describe("ApplePayOneTimePaymentButton", () => {
     expect(mockHandleClick).toHaveBeenCalledTimes(1);
   });
 
-  it("should set disabled attribute when disabled prop is true", () => {
+  it("never writes the disabled attribute to apple-pay-button (Apple manages it)", () => {
     const { container } = render(
       <ApplePayOneTimePaymentButton {...defaultProps} disabled={true} />,
     );
     const button = container.querySelector("apple-pay-button");
-    expect(button).toHaveAttribute("disabled");
+    expect(button).not.toHaveAttribute("disabled");
   });
 
-  it("should not set disabled attribute when error is present (allows retry)", () => {
+  it("applies disabled styling on the wrapper when disabled prop is true", () => {
+    const { container } = render(
+      <ApplePayOneTimePaymentButton {...defaultProps} disabled={true} />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.pointerEvents).toBe("none");
+    expect(wrapper.style.opacity).toBe("0.5");
+    expect(wrapper).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("does not call handleClick when the disabled prop is true", () => {
+    const { container } = render(
+      <ApplePayOneTimePaymentButton {...defaultProps} disabled={true} />,
+    );
+    fireEvent.click(container.querySelector("apple-pay-button")!);
+    expect(mockHandleClick).not.toHaveBeenCalled();
+  });
+
+  it("stays interactive when an error is present so the user can retry", () => {
     jest.spyOn(console, "error").mockImplementation();
     mockUseApplePayOneTimePaymentSession.mockReturnValue({
       error: new Error("Test error"),
@@ -116,9 +134,16 @@ describe("ApplePayOneTimePaymentButton", () => {
     );
     const button = container.querySelector("apple-pay-button");
     expect(button).not.toHaveAttribute("disabled");
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.pointerEvents).toBe("");
+    expect(wrapper).not.toHaveAttribute("aria-disabled");
+
+    fireEvent.click(button!);
+    expect(mockHandleClick).toHaveBeenCalledTimes(1);
   });
 
-  it("should set disabled attribute when isPending is true", () => {
+  it("applies disabled styling and blocks clicks while the SDK is loading (isPending)", () => {
     mockUseApplePayOneTimePaymentSession.mockReturnValue({
       error: null,
       isPending: true,
@@ -131,15 +156,28 @@ describe("ApplePayOneTimePaymentButton", () => {
     );
     const button = container.querySelector("apple-pay-button");
     expect(button).toBeInTheDocument();
-    expect(button).toHaveAttribute("disabled");
+    expect(button).not.toHaveAttribute("disabled");
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.pointerEvents).toBe("none");
+    expect(wrapper.style.opacity).toBe("0.5");
+    expect(wrapper).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.click(button!);
+    expect(mockHandleClick).not.toHaveBeenCalled();
   });
 
-  it("should not set disabled attribute when state is normal", () => {
+  it("applies no disabled styling when state is normal", () => {
     const { container } = render(
       <ApplePayOneTimePaymentButton {...defaultProps} />,
     );
     const button = container.querySelector("apple-pay-button");
     expect(button).not.toHaveAttribute("disabled");
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.pointerEvents).toBe("");
+    expect(wrapper.style.opacity).toBe("");
+    expect(wrapper).not.toHaveAttribute("aria-disabled");
   });
 
   it("should set default button attributes", () => {

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
@@ -94,30 +94,12 @@ describe("ApplePayOneTimePaymentButton", () => {
     expect(mockHandleClick).toHaveBeenCalledTimes(1);
   });
 
-  it("never writes the disabled attribute to apple-pay-button (Apple manages it)", () => {
+  it("never writes a disabled attribute to apple-pay-button (Apple manages it)", () => {
     const { container } = render(
-      <ApplePayOneTimePaymentButton {...defaultProps} disabled={true} />,
+      <ApplePayOneTimePaymentButton {...defaultProps} />,
     );
     const button = container.querySelector("apple-pay-button");
     expect(button).not.toHaveAttribute("disabled");
-  });
-
-  it("applies disabled styling on the wrapper when disabled prop is true", () => {
-    const { container } = render(
-      <ApplePayOneTimePaymentButton {...defaultProps} disabled={true} />,
-    );
-    const wrapper = container.firstElementChild as HTMLElement;
-    expect(wrapper.style.pointerEvents).toBe("none");
-    expect(wrapper.style.opacity).toBe("0.5");
-    expect(wrapper).toHaveAttribute("aria-disabled", "true");
-  });
-
-  it("does not call handleClick when the disabled prop is true", () => {
-    const { container } = render(
-      <ApplePayOneTimePaymentButton {...defaultProps} disabled={true} />,
-    );
-    fireEvent.click(container.querySelector("apple-pay-button")!);
-    expect(mockHandleClick).not.toHaveBeenCalled();
   });
 
   it("stays interactive when an error is present so the user can retry", () => {
@@ -135,49 +117,8 @@ describe("ApplePayOneTimePaymentButton", () => {
     const button = container.querySelector("apple-pay-button");
     expect(button).not.toHaveAttribute("disabled");
 
-    const wrapper = container.firstElementChild as HTMLElement;
-    expect(wrapper.style.pointerEvents).toBe("");
-    expect(wrapper).not.toHaveAttribute("aria-disabled");
-
     fireEvent.click(button!);
     expect(mockHandleClick).toHaveBeenCalledTimes(1);
-  });
-
-  it("applies disabled styling and blocks clicks while the SDK is loading (isPending)", () => {
-    mockUseApplePayOneTimePaymentSession.mockReturnValue({
-      error: null,
-      isPending: true,
-      handleClick: mockHandleClick,
-      handleCancel: mockHandleCancel,
-      handleDestroy: mockHandleDestroy,
-    });
-    const { container } = render(
-      <ApplePayOneTimePaymentButton {...defaultProps} />,
-    );
-    const button = container.querySelector("apple-pay-button");
-    expect(button).toBeInTheDocument();
-    expect(button).not.toHaveAttribute("disabled");
-
-    const wrapper = container.firstElementChild as HTMLElement;
-    expect(wrapper.style.pointerEvents).toBe("none");
-    expect(wrapper.style.opacity).toBe("0.5");
-    expect(wrapper).toHaveAttribute("aria-disabled", "true");
-
-    fireEvent.click(button!);
-    expect(mockHandleClick).not.toHaveBeenCalled();
-  });
-
-  it("applies no disabled styling when state is normal", () => {
-    const { container } = render(
-      <ApplePayOneTimePaymentButton {...defaultProps} />,
-    );
-    const button = container.querySelector("apple-pay-button");
-    expect(button).not.toHaveAttribute("disabled");
-
-    const wrapper = container.firstElementChild as HTMLElement;
-    expect(wrapper.style.pointerEvents).toBe("");
-    expect(wrapper.style.opacity).toBe("");
-    expect(wrapper).not.toHaveAttribute("aria-disabled");
   });
 
   it("should set default button attributes", () => {
@@ -230,7 +171,6 @@ describe("ApplePayOneTimePaymentButton", () => {
         buttonstyle="white"
         type="buy"
         locale="fr"
-        disabled={true}
         className="test"
       />,
     );

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
@@ -7,7 +7,8 @@ import type { UseApplePayOneTimePaymentSessionProps } from "../hooks/useApplePay
 import type { ApplePayButtonElementProps } from "../types/sdkWebComponents";
 
 export type ApplePayOneTimePaymentButtonProps =
-  UseApplePayOneTimePaymentSessionProps & ApplePayButtonElementProps;
+  UseApplePayOneTimePaymentSessionProps &
+    Omit<ApplePayButtonElementProps, "disabled">;
 
 /**
  * `ApplePayOneTimePaymentButton` renders a native Apple Pay button and manages
@@ -36,38 +37,26 @@ export const ApplePayOneTimePaymentButton = ({
   buttonstyle = "black",
   type = "pay",
   locale = "en",
-  disabled = false,
   className,
   ...hookProps
 }: ApplePayOneTimePaymentButtonProps): JSX.Element | null => {
-  const { error, isPending, handleClick, handleDestroy } =
+  const { error, handleClick, handleDestroy } =
     useApplePayOneTimePaymentSession(hookProps);
   const { isHydrated } = usePayPal();
   const buttonRef = useRef<HTMLElement>(null);
   const handleClickRef = useRef(handleClick);
   handleClickRef.current = handleClick;
 
-  const isDisabled = disabled || isPending;
-  // Apple's <apple-pay-button> does not observe a `disabled` attribute and
-  // manages it internally via canMakePayments(), so we never write it. Instead
-  // we gate interaction in JS. The click listener below is attached once on
-  // mount, so keep the latest disabled value in a ref to avoid a stale closure.
-  const isDisabledRef = useRef(isDisabled);
-  isDisabledRef.current = isDisabled;
-
-  // React's onClick doesn't work on <apple-pay-button> due to its shadow DOM,
-  // so we attach the click handler directly on the element.
+  // Apple's <apple-pay-button> manages its own enabled/disabled state internally
+  // via canMakePayments(); we deliberately don't add an SDK-level disabled layer
+  // (merchants control presentation themselves). React's onClick also doesn't
+  // work on the element due to its shadow DOM, so we attach the handler directly.
   useEffect(() => {
     const el = buttonRef.current;
     if (!el) {
       return;
     }
     const onClick = () => {
-      // Source of truth for the disabled state. Covers keyboard activation,
-      // which pointer-events: none on the wrapper cannot block.
-      if (isDisabledRef.current) {
-        return;
-      }
       handleClickRef.current().catch(() => {
         // Errors are captured by the hook's setError
       });
@@ -95,11 +84,7 @@ export const ApplePayOneTimePaymentButton = ({
   }
 
   return (
-    <div
-      className={className}
-      aria-disabled={isDisabled || undefined}
-      style={isDisabled ? { pointerEvents: "none", opacity: "0.5" } : undefined}
-    >
+    <div className={className}>
       <apple-pay-button
         ref={buttonRef}
         buttonstyle={buttonstyle}

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
@@ -48,6 +48,12 @@ export const ApplePayOneTimePaymentButton = ({
   handleClickRef.current = handleClick;
 
   const isDisabled = disabled || isPending;
+  // Apple's <apple-pay-button> does not observe a `disabled` attribute and
+  // manages it internally via canMakePayments(), so we never write it. Instead
+  // we gate interaction in JS. The click listener below is attached once on
+  // mount, so keep the latest disabled value in a ref to avoid a stale closure.
+  const isDisabledRef = useRef(isDisabled);
+  isDisabledRef.current = isDisabled;
 
   // React's onClick doesn't work on <apple-pay-button> due to its shadow DOM,
   // so we attach the click handler directly on the element.
@@ -57,6 +63,11 @@ export const ApplePayOneTimePaymentButton = ({
       return;
     }
     const onClick = () => {
+      // Source of truth for the disabled state. Covers keyboard activation,
+      // which pointer-events: none on the wrapper cannot block.
+      if (isDisabledRef.current) {
+        return;
+      }
       handleClickRef.current().catch(() => {
         // Errors are captured by the hook's setError
       });
@@ -84,13 +95,16 @@ export const ApplePayOneTimePaymentButton = ({
   }
 
   return (
-    <div className={className}>
+    <div
+      className={className}
+      aria-disabled={isDisabled || undefined}
+      style={isDisabled ? { pointerEvents: "none", opacity: "0.5" } : undefined}
+    >
       <apple-pay-button
         ref={buttonRef}
         buttonstyle={buttonstyle}
         type={type}
         locale={locale}
-        disabled={isDisabled || undefined}
       />
     </div>
   );


### PR DESCRIPTION
<img width="1510" height="911" alt="Screenshot 2026-06-30 at 9 55 38 AM" src="https://github.com/user-attachments/assets/23dbabca-f4a7-412f-9fc8-96de55fa5079" />
<img width="1507" height="908" alt="Screenshot 2026-06-30 at 9 55 32 AM" src="https://github.com/user-attachments/assets/35ca65b6-6b69-43de-9f04-c3fc19dea3dc" />


Remove the disabled attribute on web component. Add a customized attribute `isDisabled`, consistent with how we dealt with google payment button