### PR TITLE
Fix: PayPal Messages html element logoType type property

### DIFF
--- a/.changeset/upset-baboons-deny.md
+++ b/.changeset/upset-baboons-deny.md
@@ -2,4 +2,4 @@
 "@paypal/react-paypal-js": patch
 ---
 
-Adds 2 enum values to the paypal messages element logoType property.
+Adds 1 enum value to the paypal messages element logoType property.

--- a/.changeset/upset-baboons-deny.md
+++ b/.changeset/upset-baboons-deny.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Adds 2 enum values to the paypal messages element logoType property.

--- a/packages/react-paypal-js/src/v6/types/sdkWebComponents.ts
+++ b/packages/react-paypal-js/src/v6/types/sdkWebComponents.ts
@@ -46,7 +46,7 @@ export interface PayPalMessagesElement extends HTMLAttributes<HTMLElement> {
   "buyer-country"?: string;
   "currency-code"?: string;
   "logo-position"?: "INLINE" | "LEFT" | "RIGHT" | "TOP";
-  "logo-type"?: "MONOGRAM" | "WORDMARK" | "TEXT" | "NONE";
+  "logo-type"?: "MONOGRAM" | "WORDMARK" | "TEXT";
   "offer-types"?: string;
   "presentation-mode"?: "AUTO" | "MODAL" | "POPUP" | "REDIRECT";
   ref?: Ref<PayPalMessagesElement>;

--- a/packages/react-paypal-js/src/v6/types/sdkWebComponents.ts
+++ b/packages/react-paypal-js/src/v6/types/sdkWebComponents.ts
@@ -46,7 +46,7 @@ export interface PayPalMessagesElement extends HTMLAttributes<HTMLElement> {
   "buyer-country"?: string;
   "currency-code"?: string;
   "logo-position"?: "INLINE" | "LEFT" | "RIGHT" | "TOP";
-  "logo-type"?: "MONOGRAM" | "WORDMARK";
+  "logo-type"?: "MONOGRAM" | "WORDMARK" | "TEXT" | "NONE";
   "offer-types"?: string;
   "presentation-mode"?: "AUTO" | "MODAL" | "POPUP" | "REDIRECT";
   ref?: Ref<PayPalMessagesElement>;


### PR DESCRIPTION
Adds `"TEXT"` to the logoType property on the `PayPalMessagesElement` interface.

This is in response to this [issue](https://github.com/paypal/paypal-js/issues/987). After consulting with our paypal messaging team internally it was determined that a developer integrating with the latest React JS SDK components, which leverage the v6 PayPal JS SDK, should use the value `TEXT` for the `logoType` attribute when they want the same effect as `"NONE"`