### PR TITLE
Fix: Remove .tsbuildinfo file from package build

### DIFF
--- a/.changeset/stop-shipping-tsbuildinfo.md
+++ b/.changeset/stop-shipping-tsbuildinfo.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Stop shipping the TypeScript incremental-build cache (`dist/tsconfig.lib.tsbuildinfo`) in the published npm package. The build-info file is now written to `node_modules/.cache/tsc/` instead of `dist/`, trimming ~72 kB unpacked (~25 kB gzipped) from the tarball. No functional or API change — the library output is byte-identical.

--- a/packages/react-paypal-js/tsconfig.lib.json
+++ b/packages/react-paypal-js/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsc/react-paypal-js.tsbuildinfo"
   },
   // these are overridden by the Rollup plugin
   "outDir": "./dist",


### PR DESCRIPTION
## Summary
Stops the `@paypal/react-paypal-js` npm package from shipping `dist/tsconfig.lib.tsbuildinfo`, a TypeScript incremental-build cache with no value to consumers. `tsconfig.lib.json` now points `tsBuildInfoFile` outside `dist/` (to `node_modules/.cache/tsc/`), so the cache is still used for fast local/CI rebuilds but is no longer packed. Pure packaging hygiene — no functional or API change; `dist/esm`, `dist/cjs`, and `dist/types` are byte-identical.

## Pack size
| Metric | Before | After | diff |
|---|---|---|---|
| Package (gzip) | 162.6 kB | 138.0 kB | −24.6 kB |
| Unpacked | 743.6 kB | 672.1 kB | −71.5 kB |
| Files | 119 | 118 | −1 |

## Verification
- `npm pack --dry-run --workspace=@paypal/react-paypal-js` no longer lists any `*.tsbuildinfo`
- `npm run build` succeeds; `dist/` contains no `.tsbuildinfo`
- Incremental cache regenerates at the new path (`node_modules/.cache/tsc/`)
