### PR TITLE
feat(paypal-js): add v6 Local Payment Methods (LPM) types

### DIFF
--- a/.changeset/lpm-billing-address-required-fields.md
+++ b/.changeset/lpm-billing-address-required-fields.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Make `addressLine2` and `adminArea2` required (not optional) on the LPM `LPMSessionFieldBillingAddress` type, matching the internal SDK's `BillingAddress` shape where both fields are required.

--- a/.changeset/lpm-paypal-js-types.md
+++ b/.changeset/lpm-paypal-js-types.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": minor
+---
+
+Add TypeScript types for the v6 local payment methods (LPM) components. `LPMPaymentsInstance` and the `LPMComponents` union are now exported from `@paypal/paypal-js/sdk-v6`, and `SdkInstance`/`Components`/`CreateInstanceOptions` recognize LPM component names (e.g. `"ideal-payments"`, `"bancontact-payments"`) so `createInstance` returns the LPM methods when an LPM component is requested.

--- a/.changeset/lpm-paypal-js-types.md
+++ b/.changeset/lpm-paypal-js-types.md
@@ -3,3 +3,5 @@
 ---
 
 Add TypeScript types for the v6 local payment methods (LPM) components. `LPMPaymentsInstance` and the `LPMComponents` union are now exported from `@paypal/paypal-js/sdk-v6`, and `SdkInstance`/`Components`/`CreateInstanceOptions` recognize LPM component names (e.g. `"ideal-payments"`, `"bancontact-payments"`) so `createInstance` returns the LPM methods when an LPM component is requested.
+
+`SdkInstance` now narrows the LPM methods it exposes to only the components actually requested — for example `createInstance({ components: ["ideal-payments"] })` now types `createIdealOneTimePaymentSession` only, instead of surfacing all 50 LPM session-creation methods as optional. This is powered by a new single-source-of-truth `LPMComponentToSessionMethod` map (also exported) and an `LPMInstanceFor<T>` helper type, which replace the previous positionally-aligned `LPMComponents`/`LPMSessionMethodName` unions.

--- a/.changeset/lpm-paypal-js-types.md
+++ b/.changeset/lpm-paypal-js-types.md
@@ -5,3 +5,5 @@
 Add TypeScript types for the v6 local payment methods (LPM) components. `LPMPaymentsInstance` and the `LPMComponents` union are now exported from `@paypal/paypal-js/sdk-v6`, and `SdkInstance`/`Components`/`CreateInstanceOptions` recognize LPM component names (e.g. `"ideal-payments"`, `"bancontact-payments"`) so `createInstance` returns the LPM methods when an LPM component is requested.
 
 `SdkInstance` now narrows the LPM methods it exposes to only the components actually requested — for example `createInstance({ components: ["ideal-payments"] })` now types `createIdealOneTimePaymentSession` only, instead of surfacing all 50 LPM session-creation methods as optional. This is powered by a new single-source-of-truth `LPMComponentToSessionMethod` map (also exported) and an `LPMInstanceFor<T>` helper type, which replace the previous positionally-aligned `LPMComponents`/`LPMSessionMethodName` unions.
+
+Remove optional chaining (`?`) from `LPMInstanceFor<T>` methods since requested LPM components are guaranteed to exist at runtime on the SDK instance.

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -150,8 +150,8 @@ describe("loadCoreSdkScript()", () => {
 
   test("should error when environment is omitted", async () => {
     await expect(async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await loadCoreSdkScript({} as any);
+      // @ts-expect-error invalid arguments
+      await loadCoreSdkScript({});
     }).rejects.toThrow(
       'The "environment" option is required and must be either "production" or "sandbox"',
     );
@@ -159,8 +159,8 @@ describe("loadCoreSdkScript()", () => {
 
   test("should error when environment is explicitly undefined", async () => {
     await expect(async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await loadCoreSdkScript({ environment: undefined } as any);
+      // @ts-expect-error invalid arguments
+      await loadCoreSdkScript({ environment: undefined });
     }).rejects.toThrow(
       'The "environment" option is required and must be either "production" or "sandbox"',
     );

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -150,8 +150,8 @@ describe("loadCoreSdkScript()", () => {
 
   test("should error when environment is omitted", async () => {
     await expect(async () => {
-      // @ts-expect-error environment is required
-      await loadCoreSdkScript({});
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await loadCoreSdkScript({} as any);
     }).rejects.toThrow(
       'The "environment" option is required and must be either "production" or "sandbox"',
     );
@@ -159,8 +159,8 @@ describe("loadCoreSdkScript()", () => {
 
   test("should error when environment is explicitly undefined", async () => {
     await expect(async () => {
-      // @ts-expect-error environment is required
-      await loadCoreSdkScript({ environment: undefined });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await loadCoreSdkScript({ environment: undefined } as any);
     }).rejects.toThrow(
       'The "environment" option is required and must be either "production" or "sandbox"',
     );

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -186,8 +186,7 @@ describe("loadCoreSdkScript()", () => {
       );
 
       expect(result).toBeDefined();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(window[customNamespace as any]).toBeDefined();
+      expect(customNamespace in window).toBe(true);
     });
 
     test("should error when dataNamespace is an empty string", async () => {

--- a/packages/paypal-js/types/v6/components/lpm-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/lpm-payments.d.ts
@@ -1,0 +1,189 @@
+import {
+  BasePaymentSessionOptions,
+  BasePaymentSession,
+  PresentationModeOptionsForPopup,
+  PresentationModeOptionsForAuto,
+} from "./base-component";
+
+export type LPMOneTimePaymentSessionOptions = BasePaymentSessionOptions & {
+  orderId?: string;
+};
+
+export type LPMPresentationModeOptions =
+  | PresentationModeOptionsForAuto
+  | PresentationModeOptionsForPopup;
+
+/** Merchant-provided session-level inputs required by specific LPMs. */
+export type LPMSessionFieldPhone = {
+  countryCode: string;
+  nationalNumber: string;
+};
+
+export type LPMSessionFieldBillingAddress = {
+  addressLine1: string;
+  addressLine2?: string;
+  adminArea1: string;
+  adminArea2?: string;
+  postalCode: string;
+  countryCode: string;
+};
+
+export type LPMSessionFieldTaxInfo = {
+  taxId: string;
+  taxIdType: string;
+};
+
+/**
+ * Optional session-level inputs collected by the merchant and forwarded to the
+ * SDK when starting an LPM payment session. Only a subset of fields is required
+ * per LPM (see `LPMConfig.sessionFields` in the registry).
+ */
+export type LPMSessionFields = {
+  phone?: LPMSessionFieldPhone;
+  billingAddress?: LPMSessionFieldBillingAddress;
+  taxInfo?: LPMSessionFieldTaxInfo;
+  expiryDate?: string;
+  dateOfBirth?: string;
+  numberOfInstallments?: number;
+};
+
+/**
+ * Options passed to `LPMOneTimePaymentSession.start()`.
+ * Extends the presentation-mode options with optional merchant-collected
+ * session fields (phone, billingAddress, taxInfo, etc.) required by some LPMs.
+ */
+export type LPMStartOptions = LPMPresentationModeOptions & LPMSessionFields;
+
+export type LPMOneTimePaymentSessionPromise = Promise<{
+  orderId: string;
+  phone?: { countryCode: string; nationalNumber: string };
+  billingAddress?: {
+    addressLine1: string;
+    addressLine2?: string;
+    adminArea1: string;
+    adminArea2?: string;
+    postalCode: string;
+    countryCode: string;
+  };
+  taxInfo?: { taxId: string; taxIdType: string };
+  expiryDate?: string;
+}>;
+
+export type LPMOneTimePaymentSession = Omit<BasePaymentSession, "start"> & {
+  start: (
+    options: LPMStartOptions,
+    paymentSessionPromise?: LPMOneTimePaymentSessionPromise,
+  ) => Promise<void>;
+  createPaymentFields: (options: { type: string; value?: string }) => HTMLElement;
+  validate: () => Promise<boolean>;
+};
+
+export type LPMComponents =
+  | "ideal-payments"
+  | "bancontact-payments"
+  | "eps-payments"
+  | "blik-payments"
+  | "mybank-payments"
+  | "trustly-payments"
+  | "p24-payments"
+  | "multibanco-payments"
+  | "bizum-payments"
+  | "swish-payments"
+  | "klarna-payments"
+  | "twint-payments"
+  | "wechatpay-payments"
+  | "afterpay-payments"
+  | "oxxopay-payments"
+  | "boletobancario-payments"
+  | "verkkopankki-payments"
+  | "payu-payments"
+  | "paysafecard-payments"
+  | "mbway-payments"
+  | "satispay-payments"
+  | "wero-payments"
+  | "floa-payments"
+  | "scalapay-payments"
+  | "grabpay-payments"
+  | "pix-international-payments"
+  | "sepa-payments"
+  | "crypto-payments"
+  | "doku-payments"
+  | "dragonpay-payments"
+  | "estoniabank-payments"
+  | "fpx-payments"
+  | "gopay-payments"
+  | "alipay-payments"
+  | "indomaret-payments"
+  | "indonesiabanks-payments"
+  | "kredivo-payments"
+  | "linkaja-payments"
+  | "ovo-payments"
+  | "paysera-payments"
+  | "skrill-payments"
+  | "thailandbanks-payments"
+  | "blikpaylater-payments"
+  | "alfamart-payments"
+  | "zip-payments"
+  | "bancomatpay-payments"
+  | "latviabanks-payments"
+  | "fiuu-cash-payments"
+  | "lithuaniabanks-payments"
+  | "jeniuspay-payments";
+
+export type LPMSessionMethodName =
+  | "createIdealOneTimePaymentSession"
+  | "createBancontactOneTimePaymentSession"
+  | "createEpsOneTimePaymentSession"
+  | "createBlikOneTimePaymentSession"
+  | "createMyBankOneTimePaymentSession"
+  | "createTrustlyOneTimePaymentSession"
+  | "createP24OneTimePaymentSession"
+  | "createMultibancoOneTimePaymentSession"
+  | "createBizumOneTimePaymentSession"
+  | "createSwishOneTimePaymentSession"
+  | "createKlarnaOneTimePaymentSession"
+  | "createTwintOneTimePaymentSession"
+  | "createWechatpayOneTimePaymentSession"
+  | "createAfterpayOneTimePaymentSession"
+  | "createOxxopayOneTimePaymentSession"
+  | "createBoletobancarioOneTimePaymentSession"
+  | "createVerkkopankkiOneTimePaymentSession"
+  | "createPayuOneTimePaymentSession"
+  | "createPaysafecardOneTimePaymentSession"
+  | "createMbWayOneTimePaymentSession"
+  | "createSatispayOneTimePaymentSession"
+  | "createWeroOneTimePaymentSession"
+  | "createFloaOneTimePaymentSession"
+  | "createScalapayOneTimePaymentSession"
+  | "createGrabpayOneTimePaymentSession"
+  | "createPixInternationalOneTimePaymentSession"
+  | "createSepaOneTimePaymentSession"
+  | "createCryptoOneTimePaymentSession"
+  | "createDOKUOneTimePaymentSession"
+  | "createDragonpayOneTimePaymentSession"
+  | "createEstoniaOneTimePaymentSession"
+  | "createFpxOneTimePaymentSession"
+  | "createGopayOneTimePaymentSession"
+  | "createAlipayOneTimePaymentSession"
+  | "createIndomaretOneTimePaymentSession"
+  | "createIndonesiaBanksOneTimePaymentSession"
+  | "createKredivoOneTimePaymentSession"
+  | "createLinkajaOneTimePaymentSession"
+  | "createOvoOneTimePaymentSession"
+  | "createPayseraOneTimePaymentSession"
+  | "createSkrillOneTimePaymentSession"
+  | "createThailandBanksOneTimePaymentSession"
+  | "createBlikPayLaterOneTimePaymentSession"
+  | "createAlfamartOneTimePaymentSession"
+  | "createZipOneTimePaymentSession"
+  | "createBancomatPayOneTimePaymentSession"
+  | "createLatviaBanksOneTimePaymentSession"
+  | "createFIUUOneTimePaymentSession"
+  | "createLithuaniaBanksOneTimePaymentSession"
+  | "createJeniuspayOneTimePaymentSession";
+
+export type LPMPaymentsInstance = {
+  [K in LPMSessionMethodName]?: (
+    options: LPMOneTimePaymentSessionOptions,
+  ) => LPMOneTimePaymentSession;
+};

--- a/packages/paypal-js/types/v6/components/lpm-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/lpm-payments.d.ts
@@ -56,16 +56,9 @@ export type LPMStartOptions = LPMPresentationModeOptions & LPMSessionFields;
 
 export type LPMOneTimePaymentSessionPromise = Promise<{
   orderId: string;
-  phone?: { countryCode: string; nationalNumber: string };
-  billingAddress?: {
-    addressLine1: string;
-    addressLine2?: string;
-    adminArea1: string;
-    adminArea2?: string;
-    postalCode: string;
-    countryCode: string;
-  };
-  taxInfo?: { taxId: string; taxIdType: string };
+  phone?: LPMSessionFieldPhone;
+  billingAddress?: LPMSessionFieldBillingAddress;
+  taxInfo?: LPMSessionFieldTaxInfo;
   expiryDate?: string;
 }>;
 
@@ -74,7 +67,7 @@ export type LPMOneTimePaymentSession = Omit<BasePaymentSession, "start"> & {
     options: LPMStartOptions,
     paymentSessionPromise?: LPMOneTimePaymentSessionPromise,
   ) => Promise<void>;
-  createPaymentFields: (options: { type: string; value?: string }) => HTMLElement;
+  createPaymentFields: (options: { type: "email" | "name" | "tax_id" | "tax_id_type"; style?: Record<string, unknown>; value?: string }) => HTMLElement;
   validate: () => Promise<boolean>;
 };
 
@@ -120,7 +113,7 @@ export type LPMComponents =
   | "ovo-payments"
   | "paysera-payments"
   | "skrill-payments"
-  | "thailandbanks-payments"
+  | "thailand-banks-payments"
   | "blikpaylater-payments"
   | "alfamart-payments"
   | "zip-payments"
@@ -182,6 +175,12 @@ export type LPMSessionMethodName =
   | "createLithuaniaBanksOneTimePaymentSession"
   | "createJeniuspayOneTimePaymentSession";
 
+/**
+ * The {@link LPMPaymentsInstance} provides access to Local Payment Method (LPM)
+ * session creation methods, enabling integration with a wide range of regional
+ * payment methods (e.g. iDEAL, Bancontact, BLIK, Pix). Each method corresponds
+ * to a specific LPM component passed to `createInstance`.
+ */
 export type LPMPaymentsInstance = {
   [K in LPMSessionMethodName]?: (
     options: LPMOneTimePaymentSessionOptions,

--- a/packages/paypal-js/types/v6/components/lpm-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/lpm-payments.d.ts
@@ -18,9 +18,9 @@ export type LPMSessionFieldPhone = {
 
 export type LPMSessionFieldBillingAddress = {
   addressLine1: string;
-  addressLine2?: string;
+  addressLine2: string;
   adminArea1: string;
-  adminArea2?: string;
+  adminArea2: string;
   postalCode: string;
   countryCode: string;
 };

--- a/packages/paypal-js/types/v6/components/lpm-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/lpm-payments.d.ts
@@ -2,16 +2,13 @@ import {
   BasePaymentSessionOptions,
   BasePaymentSession,
   PresentationModeOptionsForPopup,
-  PresentationModeOptionsForAuto,
 } from "./base-component";
 
 export type LPMOneTimePaymentSessionOptions = BasePaymentSessionOptions & {
   orderId?: string;
 };
 
-export type LPMPresentationModeOptions =
-  | PresentationModeOptionsForAuto
-  | PresentationModeOptionsForPopup;
+export type LPMPresentationModeOptions = PresentationModeOptionsForPopup;
 
 /** Merchant-provided session-level inputs required by specific LPMs. */
 export type LPMSessionFieldPhone = {
@@ -33,6 +30,10 @@ export type LPMSessionFieldTaxInfo = {
   taxIdType: string;
 };
 
+export type LPMSessionFieldExpiryDate = {
+  expiry_date: string;
+};
+
 /**
  * Optional session-level inputs collected by the merchant and forwarded to the
  * SDK when starting an LPM payment session. Only a subset of fields is required
@@ -42,25 +43,24 @@ export type LPMSessionFields = {
   phone?: LPMSessionFieldPhone;
   billingAddress?: LPMSessionFieldBillingAddress;
   taxInfo?: LPMSessionFieldTaxInfo;
-  expiryDate?: string;
+  expiryDate?: LPMSessionFieldExpiryDate;
   dateOfBirth?: string;
   numberOfInstallments?: number;
 };
 
 /**
  * Options passed to `LPMOneTimePaymentSession.start()`.
- * Extends the presentation-mode options with optional merchant-collected
- * session fields (phone, billingAddress, taxInfo, etc.) required by some LPMs.
+ * Merchant-collected session fields (phone, billingAddress, taxInfo, etc.)
+ * required by some LPMs are provided via the `paymentSessionPromise` second
+ * argument, not via these presentation-mode options.
  */
-export type LPMStartOptions = LPMPresentationModeOptions & LPMSessionFields;
+export type LPMStartOptions = LPMPresentationModeOptions;
 
-export type LPMOneTimePaymentSessionPromise = Promise<{
-  orderId: string;
-  phone?: LPMSessionFieldPhone;
-  billingAddress?: LPMSessionFieldBillingAddress;
-  taxInfo?: LPMSessionFieldTaxInfo;
-  expiryDate?: string;
-}>;
+export type LPMOneTimePaymentSessionPromise = Promise<
+  {
+    orderId: string;
+  } & LPMSessionFields
+>;
 
 export type LPMOneTimePaymentSession = Omit<BasePaymentSession, "start"> & {
   start: (

--- a/packages/paypal-js/types/v6/components/lpm-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/lpm-payments.d.ts
@@ -151,7 +151,7 @@ export type LPMPaymentsInstance = {
 /**
  * Narrows {@link LPMPaymentsInstance} down to only the session-creation methods
  * for the LPM components present in `T`. Requesting `["ideal-payments"]` yields
- * only `createIdealOneTimePaymentSession?`, instead of all LPM methods.
+ * only `createIdealOneTimePaymentSession`, instead of all LPM methods.
  * `T` is generic over `readonly string[]` (rather than `Components[]`) to avoid
  * a circular import with `../index`; non-LPM entries in `T` are ignored via
  * `Extract`, and an empty extraction resolves to `{}` (a no-op intersection).
@@ -160,7 +160,7 @@ export type LPMInstanceFor<T extends readonly string[]> = {
   [C in Extract<
     T[number],
     LPMComponents
-  > as LPMComponentToSessionMethod[C]]?: (
+  > as LPMComponentToSessionMethod[C]]: (
     options: LPMOneTimePaymentSessionOptions,
   ) => LPMOneTimePaymentSession;
 };

--- a/packages/paypal-js/types/v6/components/lpm-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/lpm-payments.d.ts
@@ -71,109 +71,70 @@ export type LPMOneTimePaymentSession = Omit<BasePaymentSession, "start"> & {
   validate: () => Promise<boolean>;
 };
 
-export type LPMComponents =
-  | "ideal-payments"
-  | "bancontact-payments"
-  | "eps-payments"
-  | "blik-payments"
-  | "mybank-payments"
-  | "trustly-payments"
-  | "p24-payments"
-  | "multibanco-payments"
-  | "bizum-payments"
-  | "swish-payments"
-  | "klarna-payments"
-  | "twint-payments"
-  | "wechatpay-payments"
-  | "afterpay-payments"
-  | "oxxopay-payments"
-  | "boletobancario-payments"
-  | "verkkopankki-payments"
-  | "payu-payments"
-  | "paysafecard-payments"
-  | "mbway-payments"
-  | "satispay-payments"
-  | "wero-payments"
-  | "floa-payments"
-  | "scalapay-payments"
-  | "grabpay-payments"
-  | "pix-international-payments"
-  | "sepa-payments"
-  | "crypto-payments"
-  | "doku-payments"
-  | "dragonpay-payments"
-  | "estoniabank-payments"
-  | "fpx-payments"
-  | "gopay-payments"
-  | "alipay-payments"
-  | "indomaret-payments"
-  | "indonesiabanks-payments"
-  | "kredivo-payments"
-  | "linkaja-payments"
-  | "ovo-payments"
-  | "paysera-payments"
-  | "skrill-payments"
-  | "thailand-banks-payments"
-  | "blikpaylater-payments"
-  | "alfamart-payments"
-  | "zip-payments"
-  | "bancomatpay-payments"
-  | "latviabanks-payments"
-  | "fiuu-cash-payments"
-  | "lithuaniabanks-payments"
-  | "jeniuspay-payments";
+/**
+ * Single source of truth mapping each LPM component to the session-creation
+ * method it adds to the SDK instance. `LPMComponents` and `LPMSessionMethodName`
+ * are both derived from this map so they can never drift out of alignment, and
+ * {@link LPMInstanceFor} uses it to narrow the instance type to only the methods
+ * for the components actually requested in `createInstance`.
+ */
+export type LPMComponentToSessionMethod = {
+  "ideal-payments": "createIdealOneTimePaymentSession";
+  "bancontact-payments": "createBancontactOneTimePaymentSession";
+  "eps-payments": "createEpsOneTimePaymentSession";
+  "blik-payments": "createBlikOneTimePaymentSession";
+  "mybank-payments": "createMyBankOneTimePaymentSession";
+  "trustly-payments": "createTrustlyOneTimePaymentSession";
+  "p24-payments": "createP24OneTimePaymentSession";
+  "multibanco-payments": "createMultibancoOneTimePaymentSession";
+  "bizum-payments": "createBizumOneTimePaymentSession";
+  "swish-payments": "createSwishOneTimePaymentSession";
+  "klarna-payments": "createKlarnaOneTimePaymentSession";
+  "twint-payments": "createTwintOneTimePaymentSession";
+  "wechatpay-payments": "createWechatpayOneTimePaymentSession";
+  "afterpay-payments": "createAfterpayOneTimePaymentSession";
+  "oxxopay-payments": "createOxxopayOneTimePaymentSession";
+  "boletobancario-payments": "createBoletobancarioOneTimePaymentSession";
+  "verkkopankki-payments": "createVerkkopankkiOneTimePaymentSession";
+  "payu-payments": "createPayuOneTimePaymentSession";
+  "paysafecard-payments": "createPaysafecardOneTimePaymentSession";
+  "mbway-payments": "createMbWayOneTimePaymentSession";
+  "satispay-payments": "createSatispayOneTimePaymentSession";
+  "wero-payments": "createWeroOneTimePaymentSession";
+  "floa-payments": "createFloaOneTimePaymentSession";
+  "scalapay-payments": "createScalapayOneTimePaymentSession";
+  "grabpay-payments": "createGrabpayOneTimePaymentSession";
+  "pix-international-payments": "createPixInternationalOneTimePaymentSession";
+  "sepa-payments": "createSepaOneTimePaymentSession";
+  "crypto-payments": "createCryptoOneTimePaymentSession";
+  "doku-payments": "createDOKUOneTimePaymentSession";
+  "dragonpay-payments": "createDragonpayOneTimePaymentSession";
+  "estoniabank-payments": "createEstoniaOneTimePaymentSession";
+  "fpx-payments": "createFpxOneTimePaymentSession";
+  "gopay-payments": "createGopayOneTimePaymentSession";
+  "alipay-payments": "createAlipayOneTimePaymentSession";
+  "indomaret-payments": "createIndomaretOneTimePaymentSession";
+  "indonesiabanks-payments": "createIndonesiaBanksOneTimePaymentSession";
+  "kredivo-payments": "createKredivoOneTimePaymentSession";
+  "linkaja-payments": "createLinkajaOneTimePaymentSession";
+  "ovo-payments": "createOvoOneTimePaymentSession";
+  "paysera-payments": "createPayseraOneTimePaymentSession";
+  "skrill-payments": "createSkrillOneTimePaymentSession";
+  "thailand-banks-payments": "createThailandBanksOneTimePaymentSession";
+  "blikpaylater-payments": "createBlikPayLaterOneTimePaymentSession";
+  "alfamart-payments": "createAlfamartOneTimePaymentSession";
+  "zip-payments": "createZipOneTimePaymentSession";
+  "bancomatpay-payments": "createBancomatPayOneTimePaymentSession";
+  "latviabanks-payments": "createLatviaBanksOneTimePaymentSession";
+  "fiuu-cash-payments": "createFIUUOneTimePaymentSession";
+  "lithuaniabanks-payments": "createLithuaniaBanksOneTimePaymentSession";
+  "jeniuspay-payments": "createJeniuspayOneTimePaymentSession";
+};
+
+export type LPMComponents = keyof LPMComponentToSessionMethod;
 
 export type LPMSessionMethodName =
-  | "createIdealOneTimePaymentSession"
-  | "createBancontactOneTimePaymentSession"
-  | "createEpsOneTimePaymentSession"
-  | "createBlikOneTimePaymentSession"
-  | "createMyBankOneTimePaymentSession"
-  | "createTrustlyOneTimePaymentSession"
-  | "createP24OneTimePaymentSession"
-  | "createMultibancoOneTimePaymentSession"
-  | "createBizumOneTimePaymentSession"
-  | "createSwishOneTimePaymentSession"
-  | "createKlarnaOneTimePaymentSession"
-  | "createTwintOneTimePaymentSession"
-  | "createWechatpayOneTimePaymentSession"
-  | "createAfterpayOneTimePaymentSession"
-  | "createOxxopayOneTimePaymentSession"
-  | "createBoletobancarioOneTimePaymentSession"
-  | "createVerkkopankkiOneTimePaymentSession"
-  | "createPayuOneTimePaymentSession"
-  | "createPaysafecardOneTimePaymentSession"
-  | "createMbWayOneTimePaymentSession"
-  | "createSatispayOneTimePaymentSession"
-  | "createWeroOneTimePaymentSession"
-  | "createFloaOneTimePaymentSession"
-  | "createScalapayOneTimePaymentSession"
-  | "createGrabpayOneTimePaymentSession"
-  | "createPixInternationalOneTimePaymentSession"
-  | "createSepaOneTimePaymentSession"
-  | "createCryptoOneTimePaymentSession"
-  | "createDOKUOneTimePaymentSession"
-  | "createDragonpayOneTimePaymentSession"
-  | "createEstoniaOneTimePaymentSession"
-  | "createFpxOneTimePaymentSession"
-  | "createGopayOneTimePaymentSession"
-  | "createAlipayOneTimePaymentSession"
-  | "createIndomaretOneTimePaymentSession"
-  | "createIndonesiaBanksOneTimePaymentSession"
-  | "createKredivoOneTimePaymentSession"
-  | "createLinkajaOneTimePaymentSession"
-  | "createOvoOneTimePaymentSession"
-  | "createPayseraOneTimePaymentSession"
-  | "createSkrillOneTimePaymentSession"
-  | "createThailandBanksOneTimePaymentSession"
-  | "createBlikPayLaterOneTimePaymentSession"
-  | "createAlfamartOneTimePaymentSession"
-  | "createZipOneTimePaymentSession"
-  | "createBancomatPayOneTimePaymentSession"
-  | "createLatviaBanksOneTimePaymentSession"
-  | "createFIUUOneTimePaymentSession"
-  | "createLithuaniaBanksOneTimePaymentSession"
-  | "createJeniuspayOneTimePaymentSession";
+  LPMComponentToSessionMethod[keyof LPMComponentToSessionMethod];
 
 /**
  * The {@link LPMPaymentsInstance} provides access to Local Payment Method (LPM)
@@ -183,6 +144,23 @@ export type LPMSessionMethodName =
  */
 export type LPMPaymentsInstance = {
   [K in LPMSessionMethodName]?: (
+    options: LPMOneTimePaymentSessionOptions,
+  ) => LPMOneTimePaymentSession;
+};
+
+/**
+ * Narrows {@link LPMPaymentsInstance} down to only the session-creation methods
+ * for the LPM components present in `T`. Requesting `["ideal-payments"]` yields
+ * only `createIdealOneTimePaymentSession?`, instead of all LPM methods.
+ * `T` is generic over `readonly string[]` (rather than `Components[]`) to avoid
+ * a circular import with `../index`; non-LPM entries in `T` are ignored via
+ * `Extract`, and an empty extraction resolves to `{}` (a no-op intersection).
+ */
+export type LPMInstanceFor<T extends readonly string[]> = {
+  [C in Extract<
+    T[number],
+    LPMComponents
+  > as LPMComponentToSessionMethod[C]]?: (
     options: LPMOneTimePaymentSessionOptions,
   ) => LPMOneTimePaymentSession;
 };

--- a/packages/paypal-js/types/v6/index.d.ts
+++ b/packages/paypal-js/types/v6/index.d.ts
@@ -4,6 +4,8 @@ import { PayPalLegacyBillingInstance } from "./components/paypal-legacy-billing-
 import { VenmoPaymentsInstance } from "./components/venmo-payments";
 import { ApplePayPaymentsInstance } from "./components/applepay-payments";
 import { GooglePayPaymentsInstance } from "./components/googlepay-payments";
+import { LPMPaymentsInstance } from "./components/lpm-payments";
+import type { LPMComponents } from "./components/lpm-payments";
 import {
   EligiblePaymentMethodsOutput,
   FindEligibleMethodsOptions,
@@ -49,7 +51,8 @@ export type Components =
   | "paypal-legacy-billing-agreements"
   | "card-fields"
   | "applepay-payments"
-  | "googlepay-payments";
+  | "googlepay-payments"
+  | LPMComponents;
 
 export type PageTypes =
   | "cart"
@@ -101,6 +104,7 @@ export type CreateInstanceOptions<T extends readonly Components[]> =
  * - `"paypal-subscriptions"` - Adds PayPalSubscriptionsInstance methods
  * - `"applepay-payments"` - Adds ApplePayPaymentsInstance methods
  * - `"googlepay-payments"` - Adds GooglePayPaymentsInstance methods
+ * - LPM components (e.g. `"ideal-payments"`, `"bancontact-payments"`) - Adds LPMPaymentsInstance methods
  *
  * @example
  * ```typescript
@@ -163,7 +167,10 @@ export type SdkInstance<T extends readonly Components[]> = BaseInstance &
   ("applepay-payments" extends T[number] ? ApplePayPaymentsInstance : unknown) &
   ("googlepay-payments" extends T[number]
     ? GooglePayPaymentsInstance
-    : unknown);
+    : unknown) &
+  ([Extract<T[number], LPMComponents>] extends [never]
+    ? unknown
+    : LPMPaymentsInstance);
 
 /**
  * @internal
@@ -237,7 +244,7 @@ interface CoreSdkScriptDataAttributes {
 }
 
 export interface LoadCoreSdkScriptOptions extends CoreSdkScriptDataAttributes {
-  environment: "production" | "sandbox";
+  environment?: "production" | "sandbox";
   debug?: boolean;
 }
 
@@ -256,6 +263,7 @@ export * from "./components/paypal-messages";
 export * from "./components/paypal-subscriptions";
 export * from "./components/applepay-payments";
 export * from "./components/googlepay-payments";
+export * from "./components/lpm-payments";
 export * from "./components/web-components";
 
 // export a subset of types from base-component

--- a/packages/paypal-js/types/v6/index.d.ts
+++ b/packages/paypal-js/types/v6/index.d.ts
@@ -244,7 +244,7 @@ interface CoreSdkScriptDataAttributes {
 }
 
 export interface LoadCoreSdkScriptOptions extends CoreSdkScriptDataAttributes {
-  environment?: "production" | "sandbox";
+  environment: "production" | "sandbox";
   debug?: boolean;
 }
 

--- a/packages/paypal-js/types/v6/index.d.ts
+++ b/packages/paypal-js/types/v6/index.d.ts
@@ -4,8 +4,10 @@ import { PayPalLegacyBillingInstance } from "./components/paypal-legacy-billing-
 import { VenmoPaymentsInstance } from "./components/venmo-payments";
 import { ApplePayPaymentsInstance } from "./components/applepay-payments";
 import { GooglePayPaymentsInstance } from "./components/googlepay-payments";
-import { LPMPaymentsInstance } from "./components/lpm-payments";
-import type { LPMComponents } from "./components/lpm-payments";
+import type {
+  LPMComponents,
+  LPMInstanceFor,
+} from "./components/lpm-payments";
 import {
   EligiblePaymentMethodsOutput,
   FindEligibleMethodsOptions,
@@ -104,7 +106,7 @@ export type CreateInstanceOptions<T extends readonly Components[]> =
  * - `"paypal-subscriptions"` - Adds PayPalSubscriptionsInstance methods
  * - `"applepay-payments"` - Adds ApplePayPaymentsInstance methods
  * - `"googlepay-payments"` - Adds GooglePayPaymentsInstance methods
- * - LPM components (e.g. `"ideal-payments"`, `"bancontact-payments"`) - Adds LPMPaymentsInstance methods
+ * - LPM components (e.g. `"ideal-payments"`, `"bancontact-payments"`) - Adds only the session-creation method for each requested LPM component (e.g. `createIdealOneTimePaymentSession`)
  *
  * @example
  * ```typescript
@@ -168,9 +170,7 @@ export type SdkInstance<T extends readonly Components[]> = BaseInstance &
   ("googlepay-payments" extends T[number]
     ? GooglePayPaymentsInstance
     : unknown) &
-  ([Extract<T[number], LPMComponents>] extends [never]
-    ? unknown
-    : LPMPaymentsInstance);
+  LPMInstanceFor<T>;
 
 /**
  * @internal

--- a/packages/paypal-js/types/v6/tests/lpm-payments.test.ts
+++ b/packages/paypal-js/types/v6/tests/lpm-payments.test.ts
@@ -1,0 +1,66 @@
+import { loadCoreSdkScript } from "../../../src/v6";
+import type {
+  LPMOneTimePaymentSession,
+  LPMPaymentsInstance,
+  LPMStartOptions,
+  LPMSessionFields,
+  PayPalV6Namespace,
+} from "../index";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function main() {
+  let paypal: PayPalV6Namespace | null;
+
+  try {
+    paypal = await loadCoreSdkScript({
+      environment: "sandbox",
+      debug: true,
+    });
+  } catch (err) {
+    throw new Error(`Failed to load the paypal sdk script: ${err}`);
+  }
+
+  if (!paypal?.createInstance) {
+    throw new Error("Invalid paypal object for v6");
+  }
+
+  const sdkInstance = await paypal.createInstance({
+    clientToken: "fakeValue",
+    components: ["ideal-payments"],
+  });
+
+  const idealSession: LPMOneTimePaymentSession | undefined =
+    sdkInstance.createIdealOneTimePaymentSession?.({
+      onApprove: async () => undefined,
+    });
+
+  if (!idealSession) {
+    return;
+  }
+
+  // Session fields belong in the promise passed as the 2nd argument to
+  // start(), not on the presentation-mode options (1st argument).
+  const sessionFields: LPMSessionFields = {
+    phone: { countryCode: "31", nationalNumber: "612345678" },
+  };
+  const startOptions: LPMStartOptions = { presentationMode: "popup" };
+
+  await idealSession.start(
+    startOptions,
+    Promise.resolve({ orderId: "ORDER-123", ...sessionFields }),
+  );
+
+  // LPM sessions do not support "auto" presentation mode.
+  // @ts-expect-error "auto" is not a valid LPM presentation mode
+  await idealSession.start({ presentationMode: "auto" });
+
+  // Session fields must not be passed as part of the start() options.
+  // @ts-expect-error phone belongs on the paymentSessionPromise, not start options
+  await idealSession.start({ presentationMode: "popup", phone: sessionFields.phone });
+
+  // Verify LPMPaymentsInstance narrowing from SdkInstance
+  const instance: LPMPaymentsInstance = sdkInstance;
+  instance.createIdealOneTimePaymentSession?.({
+    onApprove: async () => undefined,
+  });
+}

--- a/packages/paypal-js/types/v6/tests/lpm-payments.test.ts
+++ b/packages/paypal-js/types/v6/tests/lpm-payments.test.ts
@@ -55,8 +55,11 @@ async function main() {
   await idealSession.start({ presentationMode: "auto" });
 
   // Session fields must not be passed as part of the start() options.
-  // @ts-expect-error phone belongs on the paymentSessionPromise, not start options
-  await idealSession.start({ presentationMode: "popup", phone: sessionFields.phone });
+  await idealSession.start({
+    presentationMode: "popup",
+    // @ts-expect-error phone belongs on the paymentSessionPromise, not start options
+    phone: sessionFields.phone,
+  });
 
   // Verify LPMPaymentsInstance narrowing from SdkInstance
   const instance: LPMPaymentsInstance = sdkInstance;

--- a/packages/paypal-js/types/v6/tests/lpm-payments.test.ts
+++ b/packages/paypal-js/types/v6/tests/lpm-payments.test.ts
@@ -61,9 +61,16 @@ async function main() {
     phone: sessionFields.phone,
   });
 
-  // Verify LPMPaymentsInstance narrowing from SdkInstance
+  // A narrower LPM instance (only the requested component's method) is
+  // always assignable to the full LPMPaymentsInstance (all methods optional).
   const instance: LPMPaymentsInstance = sdkInstance;
   instance.createIdealOneTimePaymentSession?.({
     onApprove: async () => undefined,
   });
+
+  // Requesting only "ideal-payments" must narrow the instance down to just
+  // createIdealOneTimePaymentSession; other LPM methods should not exist on
+  // the type at all (not merely be `undefined`).
+  // @ts-expect-error createBancontactOneTimePaymentSession is not part of the type when only "ideal-payments" was requested
+  sdkInstance.createBancontactOneTimePaymentSession;
 }

--- a/packages/paypal-js/types/v6/tests/lpm-payments.test.ts
+++ b/packages/paypal-js/types/v6/tests/lpm-payments.test.ts
@@ -29,14 +29,10 @@ async function main() {
     components: ["ideal-payments"],
   });
 
-  const idealSession: LPMOneTimePaymentSession | undefined =
-    sdkInstance.createIdealOneTimePaymentSession?.({
+  const idealSession: LPMOneTimePaymentSession =
+    sdkInstance.createIdealOneTimePaymentSession({
       onApprove: async () => undefined,
     });
-
-  if (!idealSession) {
-    return;
-  }
 
   // Session fields belong in the promise passed as the 2nd argument to
   // start(), not on the presentation-mode options (1st argument).


### PR DESCRIPTION
## Summary
- Adds TypeScript type declarations for the v6 SDK's Local Payment Methods (LPM) surface: `LPMComponents`, `LPMSessionMethodName`, `LPMOneTimePaymentSession`, and related types in `packages/paypal-js/types/v6/components/lpm-payments.d.ts`.
- Wires these types into `packages/paypal-js/types/v6/index.d.ts`.

## Context
This is PR 1 of 3 split out from #926 per review feedback requesting the original monolithic PR be broken up. This PR contains only the `paypal-js` type declarations, with no runtime code changes. It's a foundational dependency for the React wrapper split out in a follow-up PR.

## Test plan
- [x] `npm run typecheck` passes
- [x] `packages/paypal-js/src/v6/index.test.ts` updated and passing
- [x] Changeset included (`.changeset/lpm-paypal-js-types.md`)
