### PR TITLE
Fix: v6 Server Eligibility Method 

### DIFF
--- a/.changeset/rename-fetch-eligible-methods.md
+++ b/.changeset/rename-fetch-eligible-methods.md
@@ -1,0 +1,15 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+Rename the v6 server-side `useFetchEligibleMethods` to `fetchEligibleMethods` and move it out of the `hooks/` directory. It is a plain server-side async function (`import "server-only"`, called with `await`), not a React hook — the `use` prefix falsely signaled a hook and tripped `eslint-plugin-react-hooks` (`rules-of-hooks` / `no-unnecessary-use-prefix`) in consumer projects, producing false "React Hook cannot be called in an async function / conditionally" errors.
+
+Also renames the client hook `useEligibleMethods`'s public option/result types `UseFetchEligibleMethodsOptions` / `UseFetchEligibleMethodsResult` to `UseEligibleMethodsOptions` / `UseEligibleMethodsResult` to match the hook name.
+
+All previous names remain exported as `@deprecated` aliases, so this is non-breaking:
+
+- `useFetchEligibleMethods` → `fetchEligibleMethods` (from `@paypal/react-paypal-js/sdk-v6/server`)
+- `UseFetchEligibleMethodsOptions` → `UseEligibleMethodsOptions`
+- `UseFetchEligibleMethodsResult` → `UseEligibleMethodsResult`
+
+The deprecated aliases will be removed in the next major release.

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -2299,13 +2299,13 @@ The `type` prop controls the button label:
 
 ## Server-Side Rendering
 
-The `useFetchEligibleMethods` function (from the `/server` export path) lets you pre-fetch eligibility data on the server and pass it to `PayPalProvider` via the `eligibleMethodsResponse` prop. The provider hydrates the SDK instance with this response, so the client renders eligible payment methods immediately — no client-side eligibility round-trip and no flash of missing or stale buttons.
+The `fetchEligibleMethods` function (from the `/server` export path) lets you pre-fetch eligibility data on the server and pass it to `PayPalProvider` via the `eligibleMethodsResponse` prop. The provider hydrates the SDK instance with this response, so the client renders eligible payment methods immediately — no client-side eligibility round-trip and no flash of missing or stale buttons.
 
 **Step 1 — Fetch eligibility in a server component and hydrate the provider:**
 
 ```tsx
 // app/checkout/page.tsx (Next.js server component)
-import { useFetchEligibleMethods } from "@paypal/react-paypal-js/sdk-v6/server";
+import { fetchEligibleMethods } from "@paypal/react-paypal-js/sdk-v6/server";
 import { PayPalProvider } from "@paypal/react-paypal-js/sdk-v6";
 
 import { CheckoutForm } from "./CheckoutForm";
@@ -2317,7 +2317,7 @@ import { getAccessToken, getClientId } from "@/lib/paypal";
 export default async function CheckoutPage() {
   const accessToken = await getAccessToken();
 
-  const eligibleMethodsResponse = await useFetchEligibleMethods({
+  const eligibleMethodsResponse = await fetchEligibleMethods({
     environment: "sandbox",
     headers: {
       Authorization: `Bearer ${accessToken}`,

--- a/packages/react-paypal-js/src/v6/components/PayLaterOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayLaterOneTimePaymentButton.tsx
@@ -20,7 +20,7 @@ export type PayLaterOneTimePaymentButtonProps =
  * The `countryCode` and `productCode` are automatically populated from the eligibility API response
  * (available via `usePayPal().eligiblePaymentMethods`). The button requires eligibility to be configured
  * in the parent `PayPalProvider`, using either the `useEligibleMethods` hook client-side or
- * `useFetchEligibleMethods` server-side.
+ * `fetchEligibleMethods` server-side.
  *
  * **Eligibility must be fetched first.** Until eligibility is available, internally the button has no
  * `countryCode`/`productCode` to render with. Fetch eligibility (and wait for it) before rendering.
@@ -34,7 +34,7 @@ export type PayLaterOneTimePaymentButtonProps =
  * @example
  * function PayLaterCheckout() {
  *   // Fetch eligibility before rendering the button (or hydrate it server-side
- *   // via useFetchEligibleMethods)
+ *   // via fetchEligibleMethods)
  *   const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
  *     payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
  *   });

--- a/packages/react-paypal-js/src/v6/components/PayPalCreditOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalCreditOneTimePaymentButton.tsx
@@ -16,7 +16,7 @@ export type PayPalCreditOneTimePaymentButtonProps =
  *
  * The `countryCode` is automatically populated from the eligibility API response
  * (available via `usePayPal().eligiblePaymentMethods`). The button requires eligibility to be configured
- * in the parent `PayPalProvider`, using either the `useEligibleMethods` hook client-side or `useFetchEligibleMethods` server-side.
+ * in the parent `PayPalProvider`, using either the `useEligibleMethods` hook client-side or `fetchEligibleMethods` server-side.
  *
  * **Eligibility must be fetched first.** Until eligibility is available, internally the button has no
  * `countryCode` to render with. Fetch eligibility (and wait for it) before rendering.
@@ -30,7 +30,7 @@ export type PayPalCreditOneTimePaymentButtonProps =
  * @example
  * function CreditCheckout() {
  *   // Fetch eligibility before rendering the button (or hydrate it server-side
- *   // via useFetchEligibleMethods)
+ *   // via fetchEligibleMethods)
  *   const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
  *     payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
  *   });

--- a/packages/react-paypal-js/src/v6/components/PayPalCreditSavePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalCreditSavePaymentButton.tsx
@@ -16,7 +16,7 @@ export type PayPalCreditSavePaymentButtonProps =
  *
  * The `countryCode` is automatically populated from the eligibility API response
  * (available via `usePayPal().eligiblePaymentMethods`). The button requires eligibility to be configured
- * in the parent `PayPalProvider`, using either the `useEligibleMethods` hook client-side or `useFetchEligibleMethods` server-side.
+ * in the parent `PayPalProvider`, using either the `useEligibleMethods` hook client-side or `fetchEligibleMethods` server-side.
  *
  * Note, `autoRedirect` is not allowed because if given a `presentationMode` of `"redirect"` the button
  * would not be able to provide back `redirectURL` from `start`. Advanced integrations that need

--- a/packages/react-paypal-js/src/v6/components/PayPalProvider.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalProvider.test.tsx
@@ -452,7 +452,7 @@ describe("PayPalProvider", () => {
       await waitFor(() => expectResolvedState(state));
 
       // Provider no longer automatically calls findEligibleMethods
-      // Client-side fetching should be done via useFetchEligibleMethods hook
+      // Client-side fetching should be done via fetchEligibleMethods hook
       expect(mockFindEligibleMethods).not.toHaveBeenCalled();
       expect(state.eligiblePaymentMethods).toBeNull();
     });

--- a/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useEligibleMethods.ts
@@ -10,15 +10,20 @@ import {
 import { useError } from "./useError";
 import { deepEqual, useDeepCompareMemoize } from "../utils";
 
-export interface UseFetchEligibleMethodsOptions {
+export interface UseEligibleMethodsOptions {
   payload?: FindEligibleMethodsOptions;
 }
 
-export interface UseFetchEligibleMethodsResult {
+export interface UseEligibleMethodsResult {
   eligiblePaymentMethods: EligiblePaymentMethodsOutput | null;
   isLoading: boolean;
   error: Error | null;
 }
+
+/** @deprecated Renamed to `UseEligibleMethodsOptions`. */
+export type UseFetchEligibleMethodsOptions = UseEligibleMethodsOptions;
+/** @deprecated Renamed to `UseEligibleMethodsResult`. */
+export type UseFetchEligibleMethodsResult = UseEligibleMethodsResult;
 
 /**
  * Client-side hook to access eligible payment methods from the PayPal context.
@@ -58,8 +63,8 @@ export interface UseFetchEligibleMethodsResult {
  * }
  */
 export function useEligibleMethods(
-  options: UseFetchEligibleMethodsOptions = {},
-): UseFetchEligibleMethodsResult {
+  options: UseEligibleMethodsOptions = {},
+): UseEligibleMethodsResult {
   const { payload } = options;
   const {
     sdkInstance,

--- a/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
@@ -35,7 +35,7 @@ export type UsePayLaterOneTimePaymentSessionProps = (
  * to start, cancel, and destroy the session.
  *
  * Eligibility must be fetched separately (via the `useEligibleMethods` hook client-side or
- * `useFetchEligibleMethods` server-side) to obtain the `countryCode`/`productCode` the
+ * `fetchEligibleMethods` server-side) to obtain the `countryCode`/`productCode` the
  * `<paypal-pay-later-button>` needs to render.
  *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
@@ -51,7 +51,7 @@ export type UsePayLaterOneTimePaymentSessionProps = (
  *     onCancel: () => console.log('Cancelled'),
  *   });
  *
- *   // Fetch eligibility (or hydrate server-side via useFetchEligibleMethods)
+ *   // Fetch eligibility (or hydrate server-side via fetchEligibleMethods)
  *   const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
  *     payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
  *   });

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
@@ -33,7 +33,7 @@ export type UsePayPalCreditOneTimePaymentSessionProps = (
  * for redirect-based flows, and provides methods to start, cancel, and destroy the session.
  *
  * Eligibility must be fetched separately (via the `useEligibleMethods` hook client-side or
- * `useFetchEligibleMethods` server-side) to obtain the `countryCode` the
+ * `fetchEligibleMethods` server-side) to obtain the `countryCode` the
  * `<paypal-credit-button>` needs to render.
  *
  * @returns Object with: `error` (any session error), `isPending` (SDK loading), `handleClick` (starts session), `handleCancel` (cancels session), `handleDestroy` (cleanup)
@@ -49,7 +49,7 @@ export type UsePayPalCreditOneTimePaymentSessionProps = (
  *     onCancel: () => console.log('Cancelled'),
  *   });
  *
- *   // Fetch eligibility (or hydrate server-side via useFetchEligibleMethods)
+ *   // Fetch eligibility (or hydrate server-side via fetchEligibleMethods)
  *   const { eligiblePaymentMethods, isLoading } = useEligibleMethods({
  *     payload: { purchase_units: [{ amount: { currency_code: "USD" } }] },
  *   });

--- a/packages/react-paypal-js/src/v6/server.ts
+++ b/packages/react-paypal-js/src/v6/server.ts
@@ -3,4 +3,4 @@
  * Import from '@paypal/react-paypal-js/sdk-v6/server'
  */
 
-export * from "./hooks/useFetchEligibleMethods";
+export * from "./server/fetchEligibleMethods";

--- a/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.test.ts
@@ -1,7 +1,8 @@
 import {
+  fetchEligibleMethods,
   useFetchEligibleMethods,
   type FindEligiblePaymentMethodsRequestPayload,
-} from "./useFetchEligibleMethods";
+} from "./fetchEligibleMethods";
 
 import type { FindEligiblePaymentMethodsResponse } from "../types";
 
@@ -53,7 +54,7 @@ describe("fetchEligibleMethods", () => {
       json: async () => mockResponse,
     });
 
-    const result = await useFetchEligibleMethods({
+    const result = await fetchEligibleMethods({
       payload: mockPayload,
       environment: "sandbox",
       headers: mockHeaders,
@@ -83,7 +84,7 @@ describe("fetchEligibleMethods", () => {
       json: async () => mockResponse,
     });
 
-    await useFetchEligibleMethods({
+    await fetchEligibleMethods({
       payload: mockPayload,
       environment: "production",
       headers: mockHeaders,
@@ -103,7 +104,7 @@ describe("fetchEligibleMethods", () => {
       json: async () => mockResponse,
     });
 
-    await useFetchEligibleMethods({
+    await fetchEligibleMethods({
       environment: "sandbox",
     });
 
@@ -122,7 +123,7 @@ describe("fetchEligibleMethods", () => {
     });
 
     await expect(
-      useFetchEligibleMethods({
+      fetchEligibleMethods({
         environment: "sandbox",
       }),
     ).rejects.toThrow("Eligibility API error: 401");
@@ -134,7 +135,7 @@ describe("fetchEligibleMethods", () => {
     );
 
     await expect(
-      useFetchEligibleMethods({
+      fetchEligibleMethods({
         environment: "sandbox",
       }),
     ).rejects.toThrow("Failed to fetch eligible methods: Network error");
@@ -143,7 +144,7 @@ describe("fetchEligibleMethods", () => {
   test("should error when environment is omitted", async () => {
     await expect(
       // @ts-expect-error environment is required
-      useFetchEligibleMethods({ headers: mockHeaders }),
+      fetchEligibleMethods({ headers: mockHeaders }),
     ).rejects.toThrow(
       'The "environment" option is required and must be either "production" or "sandbox"',
     );
@@ -152,7 +153,7 @@ describe("fetchEligibleMethods", () => {
 
   test("should error when environment is explicitly undefined", async () => {
     await expect(
-      useFetchEligibleMethods({
+      fetchEligibleMethods({
         // @ts-expect-error environment is required
         environment: undefined,
         headers: mockHeaders,
@@ -170,7 +171,7 @@ describe("fetchEligibleMethods", () => {
       json: async () => mockResponse,
     });
 
-    await useFetchEligibleMethods({
+    await fetchEligibleMethods({
       environment: "sandbox",
       signal: abortController.signal,
     });
@@ -181,5 +182,9 @@ describe("fetchEligibleMethods", () => {
         signal: abortController.signal,
       }),
     );
+  });
+
+  test("exposes the deprecated useFetchEligibleMethods alias", () => {
+    expect(useFetchEligibleMethods).toBe(fetchEligibleMethods);
   });
 });

--- a/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.ts
@@ -80,7 +80,7 @@ export type FindEligiblePaymentMethodsRequestPayload = {
  *
  * @example
  * // Next.js server component
- * const response = await useFetchEligibleMethods({
+ * const response = await fetchEligibleMethods({
  *     headers: {
  *         "Content-Type": "application/json",
  *         Authorization: `Bearer ${clientToken}`,
@@ -91,7 +91,7 @@ export type FindEligiblePaymentMethodsRequestPayload = {
  *
  * <PayPalProvider eligibleMethodsResponse={response} ... />
  */
-export async function useFetchEligibleMethods(
+export async function fetchEligibleMethods(
   options: FindEligiblePaymentMethodsOptions & { signal?: AbortSignal },
 ): Promise<FindEligiblePaymentMethodsResponse> {
   const { payload, signal, environment, headers } = options;
@@ -131,3 +131,11 @@ export async function useFetchEligibleMethods(
     );
   }
 }
+
+/**
+ * @deprecated Renamed to `fetchEligibleMethods`. This is a server-side async
+ * function, not a React hook — the `use` prefix falsely triggers
+ * eslint-plugin-react-hooks (`rules-of-hooks` / `no-unnecessary-use-prefix`)
+ * in consumer projects. Import `fetchEligibleMethods` instead.
+ */
+export const useFetchEligibleMethods = fetchEligibleMethods;


### PR DESCRIPTION
The v6 server-side eligibility function is exported as useFetchEligibleMethods, but it's not a React hook — it's a server-only async function called with await in server components / loaders. The use prefix falsely trips eslint-plugin-react-hooks (rules-of-hooks / no-unnecessary-use-prefix) in consumer projects, surfacing bogus "React Hook cannot be called in an async function / conditionally" errors.

This PR renames the function and fixes two adjacent naming/placement issues, all non-breaking via @deprecated aliases:

- useFetchEligibleMethods --> fetchEligibleMethods, moved out of hooks/ into src/v6/server/
- Client hook types UseFetchEligibleMethodsOptions / UseFetchEligibleMethodsResult --> UseEligibleMethodsOptions / UseEligibleMethodsResult (matches useEligibleMethods)
- All previous names remain exported as @deprecated aliases (removed in next major)