### PR TITLE
React: Update server eligibility method payload

### DIFF
--- a/.changeset/mean-dolls-obey.md
+++ b/.changeset/mean-dolls-obey.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+This change implements a new feature of the Eligibility API in response to JS SDK eligibility requests. In some cases the request merchant origin was getting overwritten. This caused a bug in particular in the Google Pay payments flow. Merchants can now pass a merchant origin to the eligibility API via the server method fetchEligibleMethods.

--- a/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.test.ts
+++ b/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.test.ts
@@ -120,6 +120,7 @@ describe("fetchEligibleMethods", () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: false,
       status: 401,
+      text: async () => "Unauthorized",
     });
 
     await expect(

--- a/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.ts
@@ -62,6 +62,9 @@ export type FindEligiblePaymentMethodsRequestPayload = {
     };
   };
   shopper_session_id?: string;
+  merchant_info?: {
+    merchant_origin?: string;
+  };
 };
 
 /**

--- a/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.ts
+++ b/packages/react-paypal-js/src/v6/server/fetchEligibleMethods.ts
@@ -122,7 +122,8 @@ export async function fetchEligibleMethods(
     );
 
     if (!response.ok) {
-      throw new Error(`Eligibility API error: ${response.status}`);
+      const body = await response.text();
+      throw new Error(`Eligibility API error: ${response.status} - ${body}`);
     }
 
     const data = await response.json();


### PR DESCRIPTION
This PR updates the `fetchEligibleMethods` server method payload to include the new `merchant_info` object that includes `merchant_domain`.