### PR TITLE
Update docs font-family from PayPal Plain to PayPalOpen

### DIFF
--- a/docs/styles/paypal-fonts.css
+++ b/docs/styles/paypal-fonts.css
@@ -1,18 +1,18 @@
 @font-face {
-  font-family: "PayPal Plain";
+  font-family: "PayPalOpen";
   font-weight: 400;
   font-display: block;
   font-style: normal;
-  src: url("https://www.paypalobjects.com/marketing/pp-com-components/fonts/PayPal%20Plain/PayPalPlain-Regular.woff2")
+  src: url("https://www.paypalobjects.com/paypal-ui/fonts/PayPalOpen-Regular.woff2")
     format("woff2");
 }
 
 @font-face {
-  font-family: "PayPal Plain";
+  font-family: "PayPalOpen";
   font-weight: 500;
   font-display: block;
   font-style: normal;
-  src: url("https://www.paypalobjects.com/marketing/pp-com-components/fonts/PayPal%20Plain/PayPalPlain-Medium.woff2")
+  src: url("https://www.paypalobjects.com/paypal-ui/fonts/PayPalOpen-Medium.woff2")
     format("woff2");
 }
 
@@ -46,7 +46,7 @@ h5,
 h6 {
   font-family:
     "PayPal Pro",
-    "PayPal Plain",
+    "PayPalOpen",
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",


### PR DESCRIPTION
## What is the purpose of this PR?

`docs/styles/paypal-fonts.css` styles the TypeDoc-generated API reference site and self-hosts its own `@font-face` for `PayPal Plain` (weights 400/500), sourced from `paypalobjects.com/marketing/pp-com-components/fonts/`. Since the PayPalPlain font license is expiring, this updates the docs site to the org-sanctioned `PayPalOpen` replacement, sourced from the canonical shared CDN path (`paypalobjects.com/paypal-ui/fonts/`) already used by pp-react and other consumers.

Weight structure is preserved exactly as before — one shared family name (`PayPalOpen`) with two `@font-face` weights (400 → Regular, 500 → Medium), so headings/bold text continue to auto-select the Medium face via `font-weight`, same as the current `PayPal Plain` setup. This is a docs-only site (low traffic, not part of SDK/checkout rendering), so it uses the full un-subsetted canonical files rather than a UI-optimized subset from `paypal-sdk-fonts`.

**Jira Ticket:** [DTPPCPSDK-6791](https://paypal.atlassian.net/browse/DTPPCPSDK-6791)

## Type of change

- [ ] New feature (backward compatible change that adds new capability).
- [x] UI change
- [ ] Bug fix.
- [ ] Breaking change (backward incompatible change). Provide references to customer impact and communication.
- [ ] Refactor (no functional change)

## Testing Plan

Below is information that validates the successful implementation of this feature and how a release manager can validate the success of a release candidate in the absence of the PR author.

**PR Author:** [Nik Roman](https://paypal.enterprise.slack.com/team/U05UEBPF2P9)

**Backup Validator:** [Delaney Barrow](https://paypal.enterprise.slack.com/team/U08CJGPCH98)

**PR Author's Team:** PayPal JS SDK

**Test Environment URL:** N/A — not needed for this change

### Step-by-Step Validation

1. Check out this branch locally in `paypal-js`.
2. Confirm no remaining references to the old font: `grep -rn "PayPal Plain\|PayPalPlain" docs/` returns nothing.
3. Confirm both new font URLs resolve: `curl -I https://www.paypalobjects.com/paypal-ui/fonts/PayPalOpen-Regular.woff2` and `.../PayPalOpen-Medium.woff2` both return 200.
4. Build/serve the docs site and visually confirm body text and headings render with `PayPalOpen` (headings should still pick up the Medium weight).

### Rollback Considerations

Are there any services dependent on this change?

- [ ] Yes
- [x] No