### PR TITLE
feat: v6 Google Pay 3DS

### DIFF
--- a/.changeset/googlepay-3ds-react-update.md
+++ b/.changeset/googlepay-3ds-react-update.md
@@ -1,0 +1,13 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+Add 3D Secure (SCA) support to the Google Pay one-time payment hook and button.
+
+When `confirmOrder` returns `PAYER_ACTION_REQUIRED`, `useGooglePayOneTimePaymentSession`
+(and `GooglePayOneTimePaymentButton`) now launches the payer-action flow automatically. The
+3DS modal runs after Google's payment sheet closes, and `onApprove` fires only once the
+buyer completes authentication — so merchants never capture an unauthenticated order. The
+`onApprove` data now carries the resulting `liabilityShift` (via the new
+`GooglePayOnApproveData` type). A buyer cancel or authentication failure is reported through
+`onError`.

--- a/.changeset/googlepay-3ds-type-update.md
+++ b/.changeset/googlepay-3ds-type-update.md
@@ -1,0 +1,14 @@
+---
+"@paypal/paypal-js": minor
+---
+
+Update the v6 Google Pay types for 3D Secure (SCA) support.
+
+`GooglePayOneTimePaymentSession.initiatePayerAction` changes from the previous no-op
+placeholder to its real signature — `initiatePayerAction(options: { orderId: string }):
+Promise<InitiatePayerActionResponse>` — which resolves with the 3DS `liabilityShift` and
+rejects if the buyer cancels or authentication fails.
+
+Adds and exports three supporting types: `LiabilityShiftType`
+(`"UNKNOWN" | "NO" | "YES" | "POSSIBLE"`), `InitiatePayerActionOptions`, and
+`InitiatePayerActionResponse`.

--- a/packages/paypal-js/types/v6/components/googlepay-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/googlepay-payments.d.ts
@@ -267,6 +267,35 @@ export type GooglePayApprovePaymentResponse = {
 };
 
 /**
+ * Outcome of the issuer's 3D Secure authentication, indicating whether
+ * liability for the transaction has shifted to the card issuer.
+ */
+export type LiabilityShiftType = "UNKNOWN" | "NO" | "YES" | "POSSIBLE";
+
+/**
+ * Options passed when launching the 3DS payer action flow.
+ */
+export type InitiatePayerActionOptions = {
+  /** The PayPal order ID returned when the order was created. */
+  orderId: string;
+};
+
+/**
+ * Result of a successful 3DS payer action flow.
+ *
+ * If the buyer cancels the 3DS modal or authentication fails, the promise
+ * rejects instead of resolving, so the merchant does not attempt to capture an
+ * unauthenticated order.
+ */
+export type InitiatePayerActionResponse = {
+  /**
+   * The outcome of the issuer's authentication, indicating whether liability
+   * for the transaction has shifted to the card issuer.
+   */
+  liabilityShift?: LiabilityShiftType;
+};
+
+/**
  * Options for confirming a Google Pay order
  *
  * @remarks
@@ -365,14 +394,29 @@ export interface GooglePayOneTimePaymentSession {
   ): Promise<GooglePayApprovePaymentResponse>;
 
   /**
-   * Initiates 3DS authentication flow (placeholder)
+   * Launches the 3DS (Strong Customer Authentication) flow for an order.
    *
    * @remarks
-   * This method is currently a placeholder for future 3DS support.
+   * Call this after `confirmOrder` returns a `status` of
+   * `"PAYER_ACTION_REQUIRED"`. It opens PayPal's 3DS iframe modal and resolves
+   * once the buyer completes authentication, with the resulting `liabilityShift`.
    *
-   * @internal
+   * If the buyer cancels the modal or authentication fails, the promise
+   * **rejects** so the merchant does not capture an unauthenticated order.
+   *
+   * Note for Google Pay: the 3DS modal can only open after Google's payment
+   * sheet has closed, and that sheet stays open until the `onPaymentAuthorized`
+   * callback resolves. Do **not** `await` this method inside
+   * `onPaymentAuthorized` — return `{ transactionState: "SUCCESS" }` to close the
+   * sheet first, then handle this promise out-of-band.
+   *
+   * @param options - Object containing the PayPal `orderId`
+   * @returns Promise resolving with the 3DS `liabilityShift` outcome on success,
+   *   and rejecting on cancel or failure
    */
-  initiatePayerAction(): void;
+  initiatePayerAction(
+    options: InitiatePayerActionOptions,
+  ): Promise<InitiatePayerActionResponse>;
 }
 
 /**

--- a/packages/paypal-js/types/v6/tests/googlepay-payments.test.ts
+++ b/packages/paypal-js/types/v6/tests/googlepay-payments.test.ts
@@ -118,7 +118,10 @@ async function main() {
 
   // Check if 3DS is required
   if (approveResponse.status === "PAYER_ACTION_REQUIRED") {
-    googlePaySession.initiatePayerAction();
+    const payerActionResult = await googlePaySession.initiatePayerAction({
+      orderId: "ORDER-123",
+    });
+    payerActionResult.liabilityShift;
   }
 
   // Verify GooglePayPaymentsInstance narrowing from SdkInstance

--- a/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
@@ -25,6 +25,11 @@ export type GooglePayOneTimePaymentButtonProps =
  * Unlike PayPal/Venmo buttons (which use PayPal web components), this component
  * mounts the native Google Pay button created by `google.payments.api.PaymentsClient.createButton()`.
  *
+ * When an order requires 3DS (`PAYER_ACTION_REQUIRED`), the underlying hook runs the
+ * payer-action (SCA) flow automatically and calls `onApprove` only after the buyer
+ * authenticates — with `liabilityShift` included in the data. A cancel or failure is
+ * reported through `onError`.
+ *
  * @example
  * ```tsx
  * <GooglePayOneTimePaymentButton

--- a/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.test.ts
@@ -121,7 +121,9 @@ const createMockGooglePaySession = (): GooglePayOneTimePaymentSession => ({
     },
     links: [],
   }),
-  initiatePayerAction: jest.fn(),
+  initiatePayerAction: jest
+    .fn()
+    .mockResolvedValue({ liabilityShift: "POSSIBLE" }),
 });
 
 const createMockSdkInstance = (
@@ -500,7 +502,7 @@ describe("useGooglePayOneTimePaymentSession", () => {
       expect(authResult).toEqual({ transactionState: "SUCCESS" });
     });
 
-    test("should handle 3DS PAYER_ACTION_REQUIRED response", async () => {
+    test("should complete 3DS PAYER_ACTION_REQUIRED and approve with liabilityShift", async () => {
       (mockGooglePaySession.confirmOrder as jest.Mock).mockResolvedValue({
         id: "test-order-id",
         status: "PAYER_ACTION_REQUIRED",
@@ -522,6 +524,11 @@ describe("useGooglePayOneTimePaymentSession", () => {
           },
         ],
       });
+      (mockGooglePaySession.initiatePayerAction as jest.Mock).mockResolvedValue(
+        {
+          liabilityShift: "POSSIBLE",
+        },
+      );
 
       const { result } = renderHook(() =>
         useGooglePayOneTimePaymentSession(defaultProps),
@@ -538,9 +545,116 @@ describe("useGooglePayOneTimePaymentSession", () => {
         authResult = await capturedOnPaymentAuthorized!(mockPaymentData);
       });
 
-      expect(mockGooglePaySession.initiatePayerAction).toHaveBeenCalled();
-      expect(defaultProps.onApprove).toHaveBeenCalled();
+      // The callback returns SUCCESS immediately so the Google Pay sheet closes
+      // and the 3DS modal can open (3DS is not awaited inside the callback).
       expect(authResult).toEqual({ transactionState: "SUCCESS" });
+      expect(mockGooglePaySession.initiatePayerAction).toHaveBeenCalledWith({
+        orderId: "ORDER-123",
+      });
+
+      // onApprove fires out-of-band, only after 3DS resolves.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(defaultProps.onApprove).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "PAYER_ACTION_REQUIRED",
+          liabilityShift: "POSSIBLE",
+        }),
+      );
+      expect(defaultProps.onError).not.toHaveBeenCalled();
+    });
+
+    test("should route a 3DS cancel/failure to onError, not onApprove", async () => {
+      (mockGooglePaySession.confirmOrder as jest.Mock).mockResolvedValue({
+        id: "test-order-id",
+        status: "PAYER_ACTION_REQUIRED",
+        payment_source: {
+          google_pay: {
+            name: "Test User",
+            card: { last_digits: "1234", type: "CREDIT", brand: "VISA" },
+          },
+        },
+        links: [],
+      });
+      const threeDSError = new Error("3DS authentication failed");
+      (mockGooglePaySession.initiatePayerAction as jest.Mock).mockRejectedValue(
+        threeDSError,
+      );
+
+      const { result } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      let authResult: unknown;
+      await act(async () => {
+        authResult = await capturedOnPaymentAuthorized!(mockPaymentData);
+      });
+
+      // Sheet still closes on the merchant's behalf.
+      expect(authResult).toEqual({ transactionState: "SUCCESS" });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(defaultProps.onError).toHaveBeenCalledWith(threeDSError);
+      expect(defaultProps.onApprove).not.toHaveBeenCalled();
+      expectCurrentErrorValue(result.current.error);
+      expect(result.current.error).toEqual(threeDSError);
+    });
+
+    test("should not notify after unmount when 3DS resolves late", async () => {
+      (mockGooglePaySession.confirmOrder as jest.Mock).mockResolvedValue({
+        id: "test-order-id",
+        status: "PAYER_ACTION_REQUIRED",
+        payment_source: {
+          google_pay: {
+            name: "Test User",
+            card: { last_digits: "1234", type: "CREDIT", brand: "VISA" },
+          },
+        },
+        links: [],
+      });
+      // A payer-action promise we resolve manually, after unmount.
+      let resolvePayerAction: (value: {
+        liabilityShift: string;
+      }) => void = () => {};
+      (mockGooglePaySession.initiatePayerAction as jest.Mock).mockReturnValue(
+        new Promise((resolve) => {
+          resolvePayerAction = resolve;
+        }),
+      );
+
+      const { result, unmount } = renderHook(() =>
+        useGooglePayOneTimePaymentSession(defaultProps),
+      );
+
+      await act(async () => {
+        await result.current.handleClick();
+      });
+
+      await act(async () => {
+        await capturedOnPaymentAuthorized!(mockPaymentData);
+      });
+
+      unmount();
+
+      await act(async () => {
+        resolvePayerAction({ liabilityShift: "YES" });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(defaultProps.onApprove).not.toHaveBeenCalled();
+      expect(defaultProps.onError).not.toHaveBeenCalled();
     });
 
     test("should error when Google Pay SDK is not available", async () => {

--- a/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
@@ -14,8 +14,19 @@ import type {
   GooglePayButtonOptions,
   GooglePayApprovePaymentResponse,
   GooglePayTransactionInfo,
+  LiabilityShiftType,
   BasePaymentSessionReturn,
 } from "../types";
+
+/**
+ * Data passed to `onApprove`. When the order required 3DS
+ * (`PAYER_ACTION_REQUIRED`), this fires only after authentication succeeds and
+ * includes the resulting `liabilityShift`.
+ */
+export type GooglePayOnApproveData = GooglePayApprovePaymentResponse & {
+  /** The 3DS liability-shift outcome, present only when 3DS ran. */
+  liabilityShift?: LiabilityShiftType;
+};
 
 export type UseGooglePayOneTimePaymentSessionProps = {
   /**
@@ -39,8 +50,11 @@ export type UseGooglePayOneTimePaymentSessionProps = {
   createOrder: () => Promise<{ orderId: string }>;
   /**
    * Callback invoked when the payment is successfully approved.
+   *
+   * When 3DS (`PAYER_ACTION_REQUIRED`) is required, this fires only after the
+   * buyer completes authentication, and the data includes `liabilityShift`.
    */
-  onApprove: (data: GooglePayApprovePaymentResponse) => void | Promise<void>;
+  onApprove: (data: GooglePayOnApproveData) => void | Promise<void>;
   /**
    * Optional callback invoked when the payment is cancelled.
    */
@@ -91,6 +105,12 @@ export type UseGooglePayOneTimePaymentSessionReturn =
  * The hook manages the entire session lifecycle including order creation, payment confirmation,
  * 3DS (PAYER_ACTION_REQUIRED) handling, and error management.
  *
+ * When an order requires 3DS, the hook launches the payer-action (SCA) flow automatically and
+ * calls `onApprove` only after the buyer completes authentication — so `onApprove` (which
+ * merchants typically use to capture) never fires for an unauthenticated order. On that path the
+ * `onApprove` data also includes `liabilityShift`. If the buyer cancels or authentication fails,
+ * `onError` is called instead.
+ *
  * @example
  * ```typescript
  * function GooglePayCheckoutButton() {
@@ -120,7 +140,10 @@ export type UseGooglePayOneTimePaymentSessionReturn =
  *       const data = await response.json();
  *       return { orderId: data.id };
  *     },
- *     onApprove: (data) => console.log("Payment approved:", data),
+ *     onApprove: (data) => {
+ *       // data.liabilityShift is present when 3DS ran
+ *       console.log("Payment approved:", data);
+ *     },
  *     onError: (err) => console.error("Payment error:", err),
  *   });
  *
@@ -261,10 +284,41 @@ export function useGooglePayOneTimePaymentSession({
                   paymentData.paymentMethodData as unknown as GooglePayPaymentMethodData,
               });
 
-              // Handle 3DS (3-D Secure) authentication if required
-              // When confirmOrder returns PAYER_ACTION_REQUIRED status, initiate payer action
+              // Handle 3DS (3-D Secure) authentication when required.
+              // When confirmOrder returns PAYER_ACTION_REQUIRED, the buyer must
+              // complete authentication before the order can be captured.
               if (confirmResult.status === "PAYER_ACTION_REQUIRED") {
-                paypalSession.initiatePayerAction();
+                // Do NOT await here: the 3DS modal can only open once Google's
+                // payment sheet closes, and that sheet stays open until this
+                // callback resolves. So we kick off the 3DS flow, return SUCCESS
+                // to close the sheet, and notify the merchant out-of-band once
+                // authentication resolves. onApprove fires only on success, so
+                // merchants never capture an unauthenticated order.
+                paypalSession
+                  .initiatePayerAction({ orderId: order.orderId })
+                  .then((payerActionResult) => {
+                    if (!isMountedRef.current) {
+                      return;
+                    }
+                    // Merge liabilityShift into the approve payload so merchants
+                    // can read the SCA outcome without a separate order fetch.
+                    return proxyCallbacks.onApprove({
+                      ...confirmResult,
+                      ...payerActionResult,
+                    });
+                  })
+                  .catch((err) => {
+                    if (!isMountedRef.current) {
+                      return;
+                    }
+                    // The core SDK rejects with the same error for both buyer
+                    // cancel and authentication failure, so both surface here.
+                    const paymentError = toError(err);
+                    setError(paymentError);
+                    proxyCallbacks.onError?.(paymentError);
+                  });
+
+                return { transactionState: "SUCCESS" as const };
               }
 
               await proxyCallbacks.onApprove(confirmResult);
@@ -299,7 +353,14 @@ export function useGooglePayOneTimePaymentSession({
       setError(setupError);
       proxyCallbacks.onError?.(setupError);
     }
-  }, [googlePayConfig, environment, proxyCallbacks, sdkInstance, setError]);
+  }, [
+    googlePayConfig,
+    environment,
+    proxyCallbacks,
+    sdkInstance,
+    setError,
+    isMountedRef,
+  ]);
 
   const createGooglePayButton = useCallback(
     async (options: GooglePayButtonOptions): Promise<HTMLElement | null> => {

--- a/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useGooglePayOneTimePaymentSession.ts
@@ -20,11 +20,25 @@ import type {
 
 /**
  * Data passed to `onApprove`. When the order required 3DS
- * (`PAYER_ACTION_REQUIRED`), this fires only after authentication succeeds and
+ * (`PAYER_ACTION_REQUIRED`), this fires after the payer-action flow resolves and
  * includes the resulting `liabilityShift`.
+ *
+ * @remarks
+ * `liabilityShift` is the only 3DS field the JS SDK surfaces client-side. The
+ * full authentication result — `liability_shift` alongside the enrollment and
+ * authentication statuses — lives on the order at
+ * `payment_source.google_pay.card.authentication_result`. Merchants who need
+ * that richer context to decide whether to capture (for example, a `"NO"`
+ * shift can mean either a hard decline or "card not enrolled, proceed at your
+ * own risk") should read it from the order server-side rather than from this
+ * payload.
  */
 export type GooglePayOnApproveData = GooglePayApprovePaymentResponse & {
-  /** The 3DS liability-shift outcome, present only when 3DS ran. */
+  /**
+   * The 3DS liability-shift outcome, present only when 3DS ran. For the
+   * enrollment and authentication statuses, read the order's
+   * `payment_source.google_pay.card.authentication_result` server-side.
+   */
   liabilityShift?: LiabilityShiftType;
 };
 
@@ -51,8 +65,11 @@ export type UseGooglePayOneTimePaymentSessionProps = {
   /**
    * Callback invoked when the payment is successfully approved.
    *
-   * When 3DS (`PAYER_ACTION_REQUIRED`) is required, this fires only after the
-   * buyer completes authentication, and the data includes `liabilityShift`.
+   * When 3DS (`PAYER_ACTION_REQUIRED`) is required, this fires after the
+   * payer-action flow resolves, and the data includes `liabilityShift`.
+   * The enrollment and authentication statuses are not surfaced here; read the
+   * order's `payment_source.google_pay.card.authentication_result` server-side
+   * if you need them.
    */
   onApprove: (data: GooglePayOnApproveData) => void | Promise<void>;
   /**
@@ -106,10 +123,9 @@ export type UseGooglePayOneTimePaymentSessionReturn =
  * 3DS (PAYER_ACTION_REQUIRED) handling, and error management.
  *
  * When an order requires 3DS, the hook launches the payer-action (SCA) flow automatically and
- * calls `onApprove` only after the buyer completes authentication — so `onApprove` (which
- * merchants typically use to capture) never fires for an unauthenticated order. On that path the
- * `onApprove` data also includes `liabilityShift`. If the buyer cancels or authentication fails,
- * `onError` is called instead.
+ * calls `onApprove` (which merchants typically use to capture) after the payer-action flow
+ * resolves. On that path the `onApprove` data also includes `liabilityShift`. If the buyer
+ * cancels or authentication errors out, `onError` is called instead.
  *
  * @example
  * ```typescript
@@ -286,14 +302,15 @@ export function useGooglePayOneTimePaymentSession({
 
               // Handle 3DS (3-D Secure) authentication when required.
               // When confirmOrder returns PAYER_ACTION_REQUIRED, the buyer must
-              // complete authentication before the order can be captured.
+              // complete the payer-action flow before the order can be captured.
               if (confirmResult.status === "PAYER_ACTION_REQUIRED") {
                 // Do NOT await here: the 3DS modal can only open once Google's
                 // payment sheet closes, and that sheet stays open until this
                 // callback resolves. So we kick off the 3DS flow, return SUCCESS
                 // to close the sheet, and notify the merchant out-of-band once
-                // authentication resolves. onApprove fires only on success, so
-                // merchants never capture an unauthenticated order.
+                // the payer-action flow resolves. onApprove fires when that flow
+                // resolves; buyer cancel and authentication errors reject and are
+                // routed to onError instead.
                 paypalSession
                   .initiatePayerAction({ orderId: order.orderId })
                   .then((payerActionResult) => {
@@ -301,7 +318,10 @@ export function useGooglePayOneTimePaymentSession({
                       return;
                     }
                     // Merge liabilityShift into the approve payload so merchants
-                    // can read the SCA outcome without a separate order fetch.
+                    // can read the shift without a separate order fetch. The
+                    // enrollment/authentication statuses are not available
+                    // client-side; they live on the order's
+                    // payment_source.google_pay.card.authentication_result.
                     return proxyCallbacks.onApprove({
                       ...confirmResult,
                       ...payerActionResult,

--- a/packages/react-paypal-js/src/v6/index.ts
+++ b/packages/react-paypal-js/src/v6/index.ts
@@ -163,6 +163,7 @@ export {
 export {
   useGooglePayOneTimePaymentSession,
   type UseGooglePayOneTimePaymentSessionProps,
+  type GooglePayOnApproveData,
 } from "./hooks/useGooglePayOneTimePaymentSession";
 
 // React 19+ JSX SDK Web Components type declaration


### PR DESCRIPTION
## Add 3D Secure (SCA) support to Google Pay

Closes #952

`GooglePayOneTimePaymentSession.initiatePayerAction` was a no-op placeholder, which left Google Pay unusable for any order requiring 3DS in production. This implements the real payer-action flow end-to-end, matching the API shape proposed in the issue.

### `@paypal/paypal-js` — types
- Replace the placeholder `initiatePayerAction(): void` with its real signature: `initiatePayerAction(options: { orderId: string }): Promise<InitiatePayerActionResponse>` — resolves with the 3DS `liabilityShift`, rejects on buyer cancel or auth failure.
- Add and export `LiabilityShiftType` (`"UNKNOWN" | "NO" | "YES" | "POSSIBLE"`), `InitiatePayerActionOptions`, and `InitiatePayerActionResponse`.
- Update the v6 type-test to exercise the new signature.

### `@paypal/react-paypal-js` — hook & component
- `useGooglePayOneTimePaymentSession` now drives the full 3DS flow. When `confirmOrder` returns `PAYER_ACTION_REQUIRED`, it launches `initiatePayerAction({ orderId })` automatically.
- **onApprove fires only after authentication succeeds**, so merchants never capture an unauthenticated order. Its data now carries the resulting `liabilityShift` (new `GooglePayOnApproveData` export).
- Buyer cancel / authentication failure is routed to `onError` (the core SDK rejects both with the same error).
- 3DS is **not** awaited inside Google's `onPaymentAuthorized` callback: the Google Pay payment sheet must close before the 3DS modal can open, so the callback returns `SUCCESS` immediately and the flow completes out-of-band (guarded against post-unmount callbacks).

### Tests
- Rewrote the `PAYER_ACTION_REQUIRED` test to assert the `{ orderId }` call and out-of-band `onApprove` with `liabilityShift`.
- Added coverage for the reject → `onError` path and the post-unmount no-op guard.
