### PR TITLE
Fix: Apple Pay Global Type

### DIFF
--- a/.changeset/loose-plums-repair.md
+++ b/.changeset/loose-plums-repair.md
@@ -1,0 +1,7 @@
+---
+"@paypal/paypal-js": minor
+---
+
+Remove PayPal's homegrown `ApplePaySession` browser-global typing from the v6 types.
+
+`@paypal/paypal-js/sdk-v6` no longer declares a stripped `ApplePaySession` class or augments the global `Window` interface with `ApplePaySession`. That augmentation conflicted with the community `@types/applepayjs` package (`TS2717` / `TS2687`), and because it shipped through the `sdk-v6` barrel it landed in every consumer's compilation — even projects that never use Apple Pay.

--- a/.changeset/loose-plums-repair.md
+++ b/.changeset/loose-plums-repair.md
@@ -1,7 +1,7 @@
 ---
-"@paypal/paypal-js": minor
+"@paypal/paypal-js": major
 ---
 
-Remove PayPal's homegrown `ApplePaySession` browser-global typing from the v6 types.
+A breaking change that removes PayPal's homegrown `ApplePaySession` browser-global typing from the v6 types.
 
 `@paypal/paypal-js/sdk-v6` no longer declares a stripped `ApplePaySession` class or augments the global `Window` interface with `ApplePaySession`. That augmentation conflicted with the community `@types/applepayjs` package (`TS2717` / `TS2687`), and because it shipped through the `sdk-v6` barrel it landed in every consumer's compilation — even projects that never use Apple Pay.

--- a/.changeset/remove-applepay-global-type.md
+++ b/.changeset/remove-applepay-global-type.md
@@ -7,4 +7,4 @@ Remove PayPal's homegrown `ApplePaySession` browser-global typing from the v6 ty
 
 `@paypal/paypal-js/sdk-v6` no longer declares a stripped `ApplePaySession` class or augments the global `Window` interface with `ApplePaySession`. That augmentation conflicted with the community `@types/applepayjs` package (`TS2717` / `TS2687`), and because it shipped through the `sdk-v6` barrel it landed in every consumer's compilation — even projects that never use Apple Pay.
 
-If you reference Apple's native `window.ApplePaySession` in your own code, install the community typings: `npm install --save-dev @types/applepayjs`.
+`@paypal/react-paypal-js` now types Apple's native session via `@types/applepayjs` internally. If you reference Apple Pay's native browser global in your own code, use the bare `ApplePaySession` global (e.g. `typeof ApplePaySession !== "undefined" && ApplePaySession.canMakePayments()`) and install the community typings: `npm install --save-dev @types/applepayjs`.

--- a/.changeset/remove-applepay-global-type.md
+++ b/.changeset/remove-applepay-global-type.md
@@ -1,0 +1,10 @@
+---
+"@paypal/paypal-js": minor
+"@paypal/react-paypal-js": minor
+---
+
+Remove PayPal's homegrown `ApplePaySession` browser-global typing from the v6 types.
+
+`@paypal/paypal-js/sdk-v6` no longer declares a stripped `ApplePaySession` class or augments the global `Window` interface with `ApplePaySession`. That augmentation conflicted with the community `@types/applepayjs` package (`TS2717` / `TS2687`), and because it shipped through the `sdk-v6` barrel it landed in every consumer's compilation — even projects that never use Apple Pay.
+
+If you reference Apple's native `window.ApplePaySession` in your own code, install the community typings: `npm install --save-dev @types/applepayjs`.

--- a/.changeset/remove-applepay-global-type.md
+++ b/.changeset/remove-applepay-global-type.md
@@ -1,10 +1,7 @@
 ---
-"@paypal/paypal-js": minor
 "@paypal/react-paypal-js": minor
 ---
 
 Remove PayPal's homegrown `ApplePaySession` browser-global typing from the v6 types.
-
-`@paypal/paypal-js/sdk-v6` no longer declares a stripped `ApplePaySession` class or augments the global `Window` interface with `ApplePaySession`. That augmentation conflicted with the community `@types/applepayjs` package (`TS2717` / `TS2687`), and because it shipped through the `sdk-v6` barrel it landed in every consumer's compilation — even projects that never use Apple Pay.
 
 `@paypal/react-paypal-js` now types Apple's native session via `@types/applepayjs` internally. If you reference Apple Pay's native browser global in your own code, use the bare `ApplePaySession` global (e.g. `typeof ApplePaySession !== "undefined" && ApplePaySession.canMakePayments()`) and install the community typings: `npm install --save-dev @types/applepayjs`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8971,6 +8971,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/applepayjs": {
+      "version": "14.0.9",
+      "resolved": "https://registry.npmjs.org/@types/applepayjs/-/applepayjs-14.0.9.tgz",
+      "integrity": "sha512-xEprYbb0TEP/XIiDPbVnTYpDai8fTFpsQfVSfTd81Is2GOMUy7ie019eyX6Mz2ECxfjoUVKaiGSL577roIeHCg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -20050,6 +20057,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20071,6 +20079,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20092,6 +20101,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20113,6 +20123,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20134,6 +20145,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20155,6 +20167,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20176,6 +20189,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20197,6 +20211,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20218,6 +20233,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20239,6 +20255,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20260,6 +20277,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -28476,6 +28494,7 @@
         "@testing-library/react": "^12.1.3",
         "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^14.5.2",
+        "@types/applepayjs": "^14.0.0",
         "@types/jest": "^27.4.0",
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
@@ -28620,6 +28639,7 @@
         "@storybook/addon-docs": "^10.2.4",
         "@storybook/react": "^10.2.4",
         "@storybook/react-vite": "^10.2.4",
+        "@types/applepayjs": "^14.0.0",
         "storybook": "^10.2.4",
         "vite": "^6.4.3"
       }

--- a/packages/paypal-js/README.md
+++ b/packages/paypal-js/README.md
@@ -371,6 +371,11 @@ These are the components that currently support the TypeScript types offered for
 | `applepay-payments`                | Apple Pay payment integration                       |
 | `googlepay-payments`               | Google Pay payment integration                      |
 
+> **Apple Pay & TypeScript:** the Apple Pay flow relies on Apple's native
+> `window.ApplePaySession` browser global. `paypal-js` does not ship types for it. If you
+> reference it in your own code, install the community typings:
+> `npm install --save-dev @types/applepayjs`.
+
 ### V6 TypeScript Types
 
 Import types from the `@paypal/paypal-js/sdk-v6` subpath:

--- a/packages/paypal-js/types/v6/components/applepay-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/applepay-payments.d.ts
@@ -235,7 +235,7 @@ export interface ApplePayPaymentsInstance {
    * ```typescript
    * // Check if Apple Pay is available
    * const isApplePayAvailable =
-   *   typeof ApplePaySession !== "undefined" && ApplePaySession.canMakePayments();
+   *   typeof window.ApplePaySession !== "undefined" && window.ApplePaySession.canMakePayments();
    *
    * if (!isApplePayAvailable) {
    *   return;

--- a/packages/paypal-js/types/v6/components/applepay-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/applepay-payments.d.ts
@@ -210,6 +210,11 @@ export type ApplePayOneTimePaymentSession = {
  * The {@link ApplePayPaymentsInstance} enables seamless integration with Apple Pay's payment flow,
  * providing a secure and user-friendly way to process payments through the Apple Pay platform.
  *
+ * @remarks
+ * The examples below reference Apple's native `ApplePaySession` browser global. PayPal does not
+ * ship types for it; install the community typings to type it in your own code:
+ * `npm install --save-dev @types/applepayjs`.
+ *
  */
 export interface ApplePayPaymentsInstance {
   /**
@@ -293,35 +298,4 @@ export interface ApplePayPaymentsInstance {
    * ```
    */
   createApplePayOneTimePaymentSession: () => ApplePayOneTimePaymentSession;
-}
-
-/**
- * Native Apple Pay session API (Safari-only).
- * @see https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession
- */
-declare class ApplePaySession {
-  static STATUS_SUCCESS: number;
-  static STATUS_FAILURE: number;
-  static canMakePayments(): boolean;
-  static supportsVersion(version: number): boolean;
-  constructor(version: number, paymentRequest: unknown);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onvalidatemerchant: ((event: any) => void) | null;
-  onpaymentmethodselected: (() => void) | null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onpaymentauthorized: ((event: any) => void) | null;
-  oncancel: (() => void) | null;
-
-  completeMerchantValidation(merchantSession: unknown): void;
-  completePaymentMethodSelection(update: unknown): void;
-  completePayment(result: { status: number }): void;
-  begin(): void;
-  abort(): void;
-}
-
-declare global {
-  interface Window {
-    ApplePaySession?: typeof ApplePaySession;
-  }
 }

--- a/packages/paypal-js/types/v6/components/applepay-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/applepay-payments.d.ts
@@ -235,7 +235,7 @@ export interface ApplePayPaymentsInstance {
    * ```typescript
    * // Check if Apple Pay is available
    * const isApplePayAvailable =
-   *   window.ApplePaySession && ApplePaySession.canMakePayments();
+   *   typeof ApplePaySession !== "undefined" && ApplePaySession.canMakePayments();
    *
    * if (!isApplePayAvailable) {
    *   return;

--- a/packages/react-paypal-js-storybook/v6/package.json
+++ b/packages/react-paypal-js-storybook/v6/package.json
@@ -29,6 +29,7 @@
     "@storybook/addon-docs": "^10.2.4",
     "@storybook/react": "^10.2.4",
     "@storybook/react-vite": "^10.2.4",
+    "@types/applepayjs": "^14.0.0",
     "storybook": "^10.2.4",
     "vite": "^6.4.3"
   }

--- a/packages/react-paypal-js-storybook/v6/src/shared/code.ts
+++ b/packages/react-paypal-js-storybook/v6/src/shared/code.ts
@@ -943,8 +943,8 @@ function ApplePayCheckout() {
     let canUseApplePay = false;
     try {
         canUseApplePay =
-            typeof window !== "undefined" &&
-            !!window.ApplePaySession?.canMakePayments();
+            typeof ApplePaySession !== "undefined" &&
+            !!ApplePaySession.canMakePayments();
     } catch {
         // Not available (e.g., non-HTTPS environment)
     }

--- a/packages/react-paypal-js-storybook/v6/src/stories/buttons/ApplePayOneTimePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/buttons/ApplePayOneTimePaymentButton.stories.tsx
@@ -45,8 +45,8 @@ function ApplePayStoryWrapper(args: ApplePayStoryArgs) {
   let canUseApplePay = false;
   try {
     canUseApplePay =
-      typeof window !== "undefined" &&
-      !!window.ApplePaySession?.canMakePayments();
+      typeof ApplePaySession !== "undefined" &&
+      !!ApplePaySession.canMakePayments();
   } catch {
     // canMakePayments() throws on non-HTTPS (InvalidAccessError)
   }
@@ -162,7 +162,7 @@ This component renders Apple's native \`<apple-pay-button>\` and manages the ful
 - Apple Pay JS SDK loaded via \`<script crossorigin src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"></script>\`
 
 **Merchant responsibilities (before rendering this component):**
-1. Check \`window.ApplePaySession?.canMakePayments()\` — only render the button if this returns \`true\`. This avoids unnecessary API calls on unsupported browsers.
+1. Check \`ApplePaySession.canMakePayments()\` — only render the button if this returns \`true\`. This avoids unnecessary API calls on unsupported browsers.
 2. Call \`useEligibleMethods()\` to fetch eligibility and obtain \`applePayConfig\` from \`getDetails("applepay").config\`.
 3. Pass \`applePayConfig\` explicitly to the component — this is a required prop.
 

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -758,7 +758,7 @@ Renders Apple's native `<apple-pay-button>` web component and manages the full A
 
 **Integration steps:**
 
-1. Check `window.ApplePaySession?.canMakePayments()` — only render the button if this returns `true`. Wrap in `try-catch` because it throws on non-HTTPS connections.
+1. Check `ApplePaySession.canMakePayments()` — only render the button if this returns `true`. Wrap in `try-catch` because it throws on non-HTTPS connections. (`ApplePaySession` is Apple's browser global; install `@types/applepayjs` to type it.)
 2. Call `useEligibleMethods()` to fetch eligibility and obtain `applePayConfig` from `getDetails("applepay").config`.
 3. Pass `applePayConfig` explicitly to the component — it is a required prop.
 
@@ -798,8 +798,8 @@ function ApplePayCheckout() {
   let canUseApplePay = false;
   try {
     canUseApplePay =
-      typeof window !== "undefined" &&
-      !!window.ApplePaySession?.canMakePayments();
+      typeof ApplePaySession !== "undefined" &&
+      !!ApplePaySession.canMakePayments();
   } catch {
     // Not available (e.g., non-HTTPS environment)
   }

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -752,6 +752,10 @@ Renders Apple's native `<apple-pay-button>` web component and manages the full A
 ></script>
 ```
 
+> **TypeScript:** the integration below references Apple's native `window.ApplePaySession`
+> global. PayPal does not ship types for it. Install the community typings to type it in your
+> own code: `npm install --save-dev @types/applepayjs`.
+
 **Integration steps:**
 
 1. Check `window.ApplePaySession?.canMakePayments()` — only render the button if this returns `true`. Wrap in `try-catch` because it throws on non-HTTPS connections.

--- a/packages/react-paypal-js/package.json
+++ b/packages/react-paypal-js/package.json
@@ -77,6 +77,7 @@
     "@testing-library/react": "^12.1.3",
     "@testing-library/react-hooks": "^7.0.2",
     "@testing-library/user-event": "^14.5.2",
+    "@types/applepayjs": "^14.0.0",
     "@types/jest": "^27.4.0",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",

--- a/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useApplePayOneTimePaymentSession.ts
@@ -10,7 +10,6 @@ import type {
   ApplePayOneTimePaymentSession,
   ApplePayConfig,
   ApplePayContact,
-  ApplePayPaymentToken,
   ConfirmOrderResponse,
   BasePaymentSessionReturn,
 } from "../types";
@@ -232,10 +231,13 @@ export function useApplePayOneTimePaymentSession({
       return;
     }
 
-    // Check if Apple Pay is available on this device/browser
+    // Check if Apple Pay is available on this device/browser.
+    // `ApplePaySession` is Apple's browser global (typed by @types/applepayjs); guard with
+    // `typeof` since it is absent outside Safari and referencing it bare would throw.
     if (
       typeof window === "undefined" ||
-      !window.ApplePaySession?.canMakePayments()
+      typeof ApplePaySession === "undefined" ||
+      !ApplePaySession.canMakePayments()
     ) {
       setError(new Error("Apple Pay is not available"));
       return;
@@ -247,7 +249,7 @@ export function useApplePayOneTimePaymentSession({
       return;
     }
 
-    const { ApplePaySession: ApplePaySessionConstructor } = window;
+    const ApplePaySessionConstructor = ApplePaySession;
 
     try {
       const paypalSession = sessionRef.current;
@@ -264,7 +266,7 @@ export function useApplePayOneTimePaymentSession({
       // Create Apple's native payment session
       const applePaySession = new ApplePaySessionConstructor(
         applePaySessionVersion,
-        fullPaymentRequest,
+        fullPaymentRequest as ApplePayJS.ApplePayPaymentRequest,
       );
       activeApplePaySessionRef.current = applePaySession;
 
@@ -295,13 +297,9 @@ export function useApplePayOneTimePaymentSession({
       };
 
       // Handle payment authorization
-      applePaySession.onpaymentauthorized = async (event: {
-        payment: {
-          token: ApplePayPaymentToken;
-          billingContact: ApplePayContact;
-          shippingContact?: ApplePayContact;
-        };
-      }) => {
+      applePaySession.onpaymentauthorized = async (
+        event: ApplePayJS.ApplePayPaymentAuthorizedEvent,
+      ) => {
         let didCompletePayment = false;
 
         // Call completePayment only once per ApplePaySession.
@@ -329,7 +327,10 @@ export function useApplePayOneTimePaymentSession({
           const confirmResult = await paypalSession.confirmOrder({
             orderId: order.orderId,
             token: event.payment.token,
-            billingContact: event.payment.billingContact,
+            // Apple types billingContact as optional, but PayPal's SDK requires it to
+            // proxy the order to Apple Pay; the merchant requests billing fields, so it
+            // is present at runtime.
+            billingContact: event.payment.billingContact as ApplePayContact,
             shippingContact: event.payment.shippingContact,
           });
 


### PR DESCRIPTION
This PR addresses a Typescript clash between `@types/applepayjs` and the v6 Apple Pay component types in `paypal-js`. The JS SDK and its associated wrappers should not handle types for other payment handlers that are not strictly owned/governed by PayPal. In this case the global `ApplePaySession` has been removed and replaced with `@types/applepayjs` as a devdependency, with instructions for integrations that rely on the Apple Pay window object to leverage the same DefinitelyTyped package.