### PR TITLE
fix(types): make one-time onApprove optional

### DIFF
--- a/.changeset/tiny-cats-approve.md
+++ b/.changeset/tiny-cats-approve.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Make `onApprove` optional for PayPal one-time payment sessions as declared.

--- a/packages/paypal-js/types/v6/components/paypal-payments.d.ts
+++ b/packages/paypal-js/types/v6/components/paypal-payments.d.ts
@@ -79,7 +79,10 @@ export type OnCancelDataSavePayments = {
   vaultSetupToken?: string;
 };
 
-export type PayPalOneTimePaymentSessionOptions = BasePaymentSessionOptions & {
+export type PayPalOneTimePaymentSessionOptions = Omit<
+  BasePaymentSessionOptions,
+  "onApprove"
+> & {
   commit?: boolean;
   orderId?: string;
   onApprove?: (data: OnApproveDataOneTimePayments) => Promise<void>;

--- a/packages/paypal-js/types/v6/tests/paypal-payments.test.ts
+++ b/packages/paypal-js/types/v6/tests/paypal-payments.test.ts
@@ -62,6 +62,10 @@ async function main() {
     commit: true,
   });
 
+  sdkInstance.createPayPalOneTimePaymentSession({
+    onCancel: onCancelCallback,
+  });
+
   const createOrder = () => Promise.resolve({ orderId: "ABC123" });
 
   const paypalButton = document.querySelector("paypal-button");


### PR DESCRIPTION
Closes #1020

## Summary

- remove the inherited required `onApprove` property before redeclaring it as optional
- add a compile-time regression case that creates a one-time payment session without `onApprove`
- add a patch changeset for `@paypal/paypal-js`

## Problem and root cause

`PayPalOneTimePaymentSessionOptions` intersected `BasePaymentSessionOptions`, where `onApprove` is required, with a local optional `onApprove?` declaration. TypeScript intersections preserve the required property, so the optional declaration had no effect and documented usages without the callback failed to compile.

Using `Omit<BasePaymentSessionOptions, "onApprove">` lets the one-time session type own the callback's optionality while preserving the rest of the base options.

## Verification

- RED: `npm run typecheck --workspace=@paypal/paypal-js` failed with TS2345 because `onApprove` was missing from the regression case
- GREEN: `npm run typecheck --workspace=@paypal/paypal-js`
- `eslint .` in `packages/paypal-js`
- `npm run test --workspace=@paypal/paypal-js` — 5 files, 54 tests passed
- `npm run build --workspace=@paypal/paypal-js`
- Prettier check on all three changed files

The repository-wide Prettier check currently also reports two unchanged files on `main`: `packages/paypal-js/types/v6/components/lpm-payments.d.ts` and `packages/paypal-js/types/v6/index.d.ts`. All files in this PR pass Prettier.

## Risk and compatibility

This is a type-only, backward-compatible relaxation. Existing callers that provide `onApprove` are unchanged, and there is no runtime code path change.

## AI assistance

Codex assisted with issue triage, the regression test, the minimal type change, and verification. The final diff and command results were reviewed before submission.
