### PR TITLE
fix(react-paypal-js): handle wallet button hydration and async replacement

### DIFF
--- a/.changeset/wallet-button-lifecycle.md
+++ b/.changeset/wallet-button-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Handle wallet button hydration and asynchronous replacement without stale mounts or missing click handlers.

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.test.tsx
@@ -82,6 +82,19 @@ describe("ApplePayOneTimePaymentButton", () => {
     expect(container.querySelector("div")).toBeInTheDocument();
   });
 
+  it("attaches the click handler after hydration", () => {
+    mockUsePayPal.mockReturnValue({ isHydrated: false });
+    const { container, rerender } = render(
+      <ApplePayOneTimePaymentButton {...defaultProps} />,
+    );
+
+    mockUsePayPal.mockReturnValue({ isHydrated: true });
+    rerender(<ApplePayOneTimePaymentButton {...defaultProps} />);
+
+    fireEvent.click(container.querySelector("apple-pay-button")!);
+    expect(mockHandleClick).toHaveBeenCalledTimes(1);
+  });
+
   it("should call handleClick when button is clicked", () => {
     const { container } = render(
       <ApplePayOneTimePaymentButton {...defaultProps} />,

--- a/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/ApplePayOneTimePaymentButton.tsx
@@ -64,7 +64,7 @@ export const ApplePayOneTimePaymentButton = ({
 
     el.addEventListener("click", onClick);
     return () => el.removeEventListener("click", onClick);
-  }, []);
+  }, [isHydrated]);
 
   useEffect(() => {
     if (error) {

--- a/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.test.tsx
@@ -132,6 +132,44 @@ describe("GooglePayOneTimePaymentButton", () => {
     });
   });
 
+  it("does not let an older async button replace the latest one", async () => {
+    let resolveFirst!: (button: HTMLElement) => void;
+    const firstButton = document.createElement("button");
+    firstButton.dataset.request = "first";
+    const secondButton = document.createElement("button");
+    secondButton.dataset.request = "second";
+
+    mockCreateGooglePayButton
+      .mockReturnValueOnce(
+        new Promise<HTMLElement>((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(secondButton);
+
+    const { container, rerender } = render(
+      <GooglePayOneTimePaymentButton {...defaultProps} buttonType="pay" />,
+    );
+    rerender(
+      <GooglePayOneTimePaymentButton {...defaultProps} buttonType="buy" />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-request="second"]')).toBe(
+        secondButton,
+      );
+    });
+
+    resolveFirst(firstButton);
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-request="second"]')).toBe(
+        secondButton,
+      );
+      expect(container.querySelector('[data-request="first"]')).toBeNull();
+    });
+  });
+
   it("does not mount button when createGooglePayButton returns null", async () => {
     mockCreateGooglePayButton.mockResolvedValue(null);
 

--- a/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/GooglePayOneTimePaymentButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback } from "react";
+import React, { useEffect, useRef } from "react";
 
 import { useGooglePayOneTimePaymentSession } from "../hooks/useGooglePayOneTimePaymentSession";
 import { usePayPal } from "../hooks/usePayPal";
@@ -64,18 +64,18 @@ export const GooglePayOneTimePaymentButton = ({
     useGooglePayOneTimePaymentSession(hookProps);
   const { isHydrated } = usePayPal();
   const containerRef = useRef<HTMLDivElement>(null);
-  const buttonMountedRef = useRef(false);
   const handleClickRef = useRef(handleClick);
   handleClickRef.current = handleClick;
 
   const isDisabled = disabled || isPending;
 
-  // Create and mount the Google Pay button
-  const mountButton = useCallback(() => {
+  // Mount only the button requested by the current effect.
+  useEffect(() => {
     const container = containerRef.current;
-    if (!container || buttonMountedRef.current) {
+    if (!isHydrated || isPending || !container) {
       return;
     }
+    let isSubscribed = true;
 
     const mountIfReady = async () => {
       const button = await createGooglePayButton({
@@ -89,32 +89,27 @@ export const GooglePayOneTimePaymentButton = ({
         ...(buttonLocale && { buttonLocale }),
       });
 
-      if (!button) {
+      if (!isSubscribed || !button) {
         return;
       }
 
       // Clear any previous content and mount the button
       container.replaceChildren(button);
-      buttonMountedRef.current = true;
     };
 
     void mountIfReady();
+    return () => {
+      isSubscribed = false;
+    };
   }, [
+    isHydrated,
+    isPending,
     createGooglePayButton,
     buttonType,
     buttonColor,
     buttonSizeMode,
     buttonLocale,
   ]);
-
-  // Mount the button when hydrated and not pending
-  useEffect(() => {
-    if (isHydrated && !isPending) {
-      // Reset mounted flag when button options change so we remount
-      buttonMountedRef.current = false;
-      mountButton();
-    }
-  }, [isHydrated, isPending, mountButton]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Fixes

- Apple Pay: attach the native click listener when hydration renders the actual apple-pay-button. The initial placeholder previously caused the mount-only effect to return without ever attaching a listener.
- Google Pay: give each asynchronous button mount an effect-local cancellation flag. An older readiness response can no longer replace a newer button or mutate its detached container after unmount. Remove the redundant mounted ref and callback layer.

## Compatibility

No public API/type changes. Payment/session behavior is unchanged; these fixes only correct button event attachment and async DOM ownership.

## Verification

React 19/JSDOM mocked SDK: placeholder-to-hydrated Apple Pay click starts exactly one session (previously zero). Google Pay black-to-white option change with readiness promises resolved in reverse order retains white (previously reverted to black). Combined reviewed patch set: existing React suite has 914 passes, 2 pre-existing HostedFieldsProvider failures and 17 passing snapshots, identical to unmodified main. Lint/typecheck, Rollup builds, declarations and diff/format checks pass (five existing JSDoc warnings). No real wallet transactions or device/browser payment certification. No test files changed.

