### PR TITLE
fix(react-paypal-js): release v6 payment sessions exactly once

### DIFF
--- a/.changeset/v6-session-ownership.md
+++ b/.changeset/v6-session-ownership.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Release v6 payment sessions exactly once when they are canceled, replaced, or unmounted.

--- a/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
@@ -96,8 +96,9 @@ export function usePayLaterOneTimePaymentSession({
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleDestroy = useCallback(() => {
-    sessionRef.current?.destroy();
+    const session = sessionRef.current;
     sessionRef.current = null;
+    session?.destroy();
   }, []);
 
   // Handle SDK availability
@@ -163,7 +164,10 @@ export function usePayLaterOneTimePaymentSession({
     }
 
     return () => {
-      newSession.destroy();
+      if (sessionRef.current === newSession) {
+        sessionRef.current = null;
+        newSession.destroy();
+      }
     };
   }, [sdkInstance, orderId, proxyCallbacks, presentationMode, setError]);
 

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
@@ -87,8 +87,9 @@ export function usePayPalCreditOneTimePaymentSession({
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleDestroy = useCallback(() => {
-    sessionRef.current?.destroy();
+    const session = sessionRef.current;
     sessionRef.current = null;
+    session?.destroy();
   }, []);
 
   const handleCancel = useCallback(() => {
@@ -158,7 +159,10 @@ export function usePayPalCreditOneTimePaymentSession({
     }
 
     return () => {
-      newSession.destroy();
+      if (sessionRef.current === newSession) {
+        sessionRef.current = null;
+        newSession.destroy();
+      }
     };
   }, [sdkInstance, orderId, proxyCallbacks, presentationMode, setError]);
 

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
@@ -79,8 +79,9 @@ export function usePayPalCreditSavePaymentSession({
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleDestroy = useCallback(() => {
-    sessionRef.current?.destroy();
+    const session = sessionRef.current;
     sessionRef.current = null;
+    session?.destroy();
   }, []);
 
   // Handle SDK availability
@@ -145,7 +146,10 @@ export function usePayPalCreditSavePaymentSession({
     }
 
     return () => {
-      newSession.destroy();
+      if (sessionRef.current === newSession) {
+        sessionRef.current = null;
+        newSession.destroy();
+      }
     };
   }, [
     sdkInstance,

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalGuestPaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalGuestPaymentSession.ts
@@ -84,8 +84,9 @@ export function usePayPalGuestPaymentSession({
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleDestroy = useCallback(() => {
-    sessionRef.current?.destroy();
+    const session = sessionRef.current;
     sessionRef.current = null;
+    session?.destroy();
   }, []);
 
   const handleCancel = useCallback(() => {
@@ -134,7 +135,10 @@ export function usePayPalGuestPaymentSession({
     sessionRef.current = newSession;
 
     return () => {
-      newSession.destroy();
+      if (sessionRef.current === newSession) {
+        sessionRef.current = null;
+        newSession.destroy();
+      }
     };
   }, [
     sdkInstance,

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
@@ -73,8 +73,9 @@ export function usePayPalOneTimePaymentSession({
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleDestroy = useCallback(() => {
-    sessionRef.current?.destroy();
+    const session = sessionRef.current;
     sessionRef.current = null;
+    session?.destroy();
   }, []);
 
   const handleCancel = useCallback(() => {
@@ -146,7 +147,10 @@ export function usePayPalOneTimePaymentSession({
     }
 
     return () => {
-      newSession.destroy();
+      if (sessionRef.current === newSession) {
+        sessionRef.current = null;
+        newSession.destroy();
+      }
     };
   }, [
     sdkInstance,

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
@@ -74,8 +74,9 @@ export function usePayPalSavePaymentSession({
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleDestroy = useCallback(() => {
-    sessionRef.current?.destroy();
+    const session = sessionRef.current;
     sessionRef.current = null;
+    session?.destroy();
   }, []);
 
   // Handle SDK availability
@@ -140,7 +141,10 @@ export function usePayPalSavePaymentSession({
     }
 
     return () => {
-      newSession.destroy();
+      if (sessionRef.current === newSession) {
+        sessionRef.current = null;
+        newSession.destroy();
+      }
     };
   }, [
     sdkInstance,

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSubscriptionPaymentSession.ts
@@ -70,8 +70,9 @@ export function usePayPalSubscriptionPaymentSession({
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleDestroy = useCallback(() => {
-    sessionRef.current?.destroy();
+    const session = sessionRef.current;
     sessionRef.current = null;
+    session?.destroy();
   }, []);
 
   const handleCancel = useCallback(() => {
@@ -117,7 +118,10 @@ export function usePayPalSubscriptionPaymentSession({
     sessionRef.current = newSession;
 
     return () => {
-      newSession.destroy();
+      if (sessionRef.current === newSession) {
+        sessionRef.current = null;
+        newSession.destroy();
+      }
     };
   }, [sdkInstance, proxyCallbacks, setError]);
 

--- a/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/useVenmoOneTimePaymentSession.ts
@@ -72,8 +72,9 @@ export function useVenmoOneTimePaymentSession({
   const isPending = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleDestroy = useCallback(() => {
-    sessionRef.current?.destroy();
+    const session = sessionRef.current;
     sessionRef.current = null;
+    session?.destroy();
   }, []);
 
   // Handle SDK availability
@@ -116,7 +117,10 @@ export function useVenmoOneTimePaymentSession({
     sessionRef.current = newSession;
 
     return () => {
-      newSession.destroy();
+      if (sessionRef.current === newSession) {
+        sessionRef.current = null;
+        newSession.destroy();
+      }
     };
   }, [sdkInstance, orderId, proxyCallbacks, setError]);
 


### PR DESCRIPTION
## Fixes

Clear the owned session before destroying it, and let effect cleanup destroy only the session it still owns. Apply the same correction to PayPal one-time/save/subscription/guest, PayPal Credit one-time/save, Venmo and Pay Later hooks.

Previously, calling handleDestroy followed by unmount called destroy twice. SDK replacement/removal also left the ref pointing to an already-destroyed session, allowing a later handleClick to start it.

## Compatibility

No public API/type changes. Destroy is now idempotent for the owned session; calls after disposal follow the existing unavailable-session error path instead of invoking a destroyed SDK object.

## Verification

React 19/JSDOM mocked-SDK reproductions for all eight hooks: manual destroy plus unmount changes from two destroy calls to one; SDK removal followed by click changes from one stale start to zero. Combined reviewed patch set: existing React suite has 914 passes, 2 pre-existing HostedFieldsProvider failures and 17 passing snapshots, identical to unmodified main. Lint/typecheck, Rollup builds, declarations and diff/format checks pass (five existing JSDoc warnings). No live transactions. No test files changed.

