### PR TITLE
fix(react-paypal-js): preserve Braintree options and clean up checkout instances

### DIFF
--- a/.changeset/braintree-lifecycle-and-options.md
+++ b/.changeset/braintree-lifecycle-and-options.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Preserve Braintree button options and clean up obsolete checkout instances safely.

--- a/packages/react-paypal-js/src/components/braintree/utils.ts
+++ b/packages/react-paypal-js/src/components/braintree/utils.ts
@@ -18,7 +18,7 @@ import type { BraintreePayPalButtonsComponentProps } from "../../types";
  */
 const isValidBraintreeNamespace = (braintreeSource?: BraintreeNamespace) => {
   if (
-    typeof braintreeSource?.client?.create !== "function" &&
+    typeof braintreeSource?.client?.create !== "function" ||
     typeof braintreeSource?.paypalCheckout?.create !== "function"
   ) {
     throw new Error(

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalCheckoutWithVaultButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalCheckoutWithVaultButton.tsx
@@ -34,49 +34,10 @@ export type BraintreePayPalCheckoutWithVaultButtonProps =
 export const BraintreePayPalCheckoutWithVaultButton = ({
   type = "pay",
   disabled = false,
-  // Callbacks
-  onApprove,
-  onCancel,
-  onError,
-  onShippingAddressChange,
-  onShippingOptionsChange,
-  // Primitive data options
-  amount,
-  currency,
-  intent,
-  commit,
-  userAuthenticationEmail,
-  returnUrl,
-  cancelUrl,
-  displayName,
-  presentationMode,
-  // Object/array data options
-  billingAgreementDetails,
-  lineItems,
-  shippingOptions,
-  amountBreakdown,
+  ...hookProps
 }: BraintreePayPalCheckoutWithVaultButtonProps): JSX.Element | null => {
   const { error, isPending, handleClick } =
-    useBraintreePayPalCheckoutWithVaultSession({
-      onApprove,
-      onCancel,
-      onError,
-      onShippingAddressChange,
-      onShippingOptionsChange,
-      amount,
-      currency,
-      intent,
-      commit,
-      userAuthenticationEmail,
-      returnUrl,
-      cancelUrl,
-      displayName,
-      presentationMode,
-      billingAgreementDetails,
-      lineItems,
-      shippingOptions,
-      amountBreakdown,
-    });
+    useBraintreePayPalCheckoutWithVaultSession(hookProps);
   const { isHydrated } = useBraintreePayPal();
 
   useEffect(() => {

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalOneTimePaymentButton.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalOneTimePaymentButton.tsx
@@ -43,49 +43,10 @@ type BraintreePayPalButtonProps = UseBraintreePayPalOneTimePaymentSessionProps &
 export const BraintreePayPalOneTimePaymentButton = ({
   type = "pay",
   disabled = false,
-  // Callbacks
-  onApprove,
-  onCancel,
-  onError,
-  onShippingAddressChange,
-  onShippingOptionsChange,
-  // Primitive data options
-  amount,
-  currency,
-  intent,
-  commit,
-  offerCredit,
-  userAuthenticationEmail,
-  returnUrl,
-  cancelUrl,
-  displayName,
-  presentationMode,
-  // Object/array data options
-  lineItems,
-  shippingOptions,
-  amountBreakdown,
+  ...hookProps
 }: BraintreePayPalButtonProps): JSX.Element | null => {
   const { error, isPending, handleClick } =
-    useBraintreePayPalOneTimePaymentSession({
-      onApprove,
-      onCancel,
-      onError,
-      onShippingAddressChange,
-      onShippingOptionsChange,
-      amount,
-      currency,
-      intent,
-      commit,
-      offerCredit,
-      userAuthenticationEmail,
-      returnUrl,
-      cancelUrl,
-      displayName,
-      presentationMode,
-      lineItems,
-      shippingOptions,
-      amountBreakdown,
-    });
+    useBraintreePayPalOneTimePaymentSession(hookProps);
   const { isHydrated } = useBraintreePayPal();
 
   useEffect(() => {

--- a/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.tsx
+++ b/packages/react-paypal-js/src/v6/components/Braintree/BraintreePayPalProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useReducer, useRef, useState } from "react";
+import React, { useEffect, useMemo, useReducer, useState } from "react";
 
 import {
   BraintreePayPalContext,
@@ -93,8 +93,6 @@ export const BraintreePayPalProvider: React.FC<
   const [state, dispatch] = useReducer(braintreeReducer, braintreeInitialState);
   const [isHydrated, setIsHydrated] = useState(false);
   const [, setError] = useError();
-  const braintreePayPalCheckoutRef =
-    useRef<BraintreePayPalCheckoutInstance | null>(null);
 
   // Set hydrated state after initial client render to prevent hydration mismatch
   useIsomorphicLayoutEffect(() => {
@@ -117,6 +115,18 @@ export const BraintreePayPalProvider: React.FC<
     }
 
     let isSubscribed = true;
+    let isInitializing = true;
+    let checkoutInstance: BraintreePayPalCheckoutInstance | undefined;
+
+    const teardown = async () => {
+      const instance = checkoutInstance;
+      checkoutInstance = undefined;
+      try {
+        await instance?.teardown();
+      } catch {
+        // Closing an obsolete instance must not create an unhandled rejection.
+      }
+    };
 
     dispatch({
       type: BRAINTREE_DISPATCH_ACTION.SET_LOADING_STATUS,
@@ -150,6 +160,7 @@ export const BraintreePayPalProvider: React.FC<
         const paypalCheckoutInstance = await namespace.paypalCheckoutV6.create({
           client: clientInstance,
         });
+        checkoutInstance = paypalCheckoutInstance;
 
         if (!isSubscribed) {
           return;
@@ -161,18 +172,23 @@ export const BraintreePayPalProvider: React.FC<
           return;
         }
 
-        braintreePayPalCheckoutRef.current = paypalCheckoutInstance;
         dispatch({
           type: BRAINTREE_DISPATCH_ACTION.SET_INSTANCE,
           value: paypalCheckoutInstance,
         });
       } catch (error) {
+        void teardown();
         if (isSubscribed) {
           setError(error);
           dispatch({
             type: BRAINTREE_DISPATCH_ACTION.SET_ERROR,
             value: toError(error),
           });
+        }
+      } finally {
+        isInitializing = false;
+        if (!isSubscribed) {
+          void teardown();
         }
       }
     };
@@ -181,8 +197,9 @@ export const BraintreePayPalProvider: React.FC<
 
     return () => {
       isSubscribed = false;
-      braintreePayPalCheckoutRef.current?.teardown();
-      braintreePayPalCheckoutRef.current = null;
+      if (!isInitializing) {
+        void teardown();
+      }
     };
   }, [namespace, braintreeClientToken, setError]);
 


### PR DESCRIPTION
## Fixes

- Forward all supported hook props from the one-time and checkout-with-vault buttons. This restores shippingCallbackUrl on both and shippingAddressOverride on the one-time button; removes two duplicated prop lists that omitted options added by #936.
- Own each v6 checkout instance within its initialization effect. Close late-created instances and instances whose SDK loading fails or finishes after unmount. Wait for initialization to settle before teardown, close once, and contain teardown rejections.
- Reject a legacy Braintree namespace if either required factory is missing, rather than only when both are missing.

## Compatibility

No public API/type changes. Shipping options already accepted by the button types now reach the SDK. Incomplete legacy namespaces fail early with the existing descriptive error. No new payment/capture behavior or client-instance ownership changes.

## Verification

React 19/JSDOM mocked-SDK reproductions cover unmount during checkout creation, unmount during SDK load, normal unmount and SDK-load failure: each instance closes once (previously three of these leaked). Button-to-session option capture confirms restored shipping props, with billing-agreement behavior unchanged. Both partially populated legacy namespaces are rejected.

Combined reviewed patch set: existing React suite has 914 passes, 2 pre-existing HostedFieldsProvider failures and 17 passing snapshots, identical to unmodified main. Lint/typecheck, Rollup builds, declarations and diff/format checks pass (five existing JSDoc warnings). No live Braintree/PayPal transactions. No test files changed.

