### PR TITLE
fix(react-paypal-js): clean up Hosted Fields and validate expiration fields

### DIFF
--- a/.changeset/hosted-fields-lifecycle.md
+++ b/.changeset/hosted-fields-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Clean up obsolete Hosted Fields instances and validate combined or split expiration fields correctly.

--- a/packages/react-paypal-js/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
+++ b/packages/react-paypal-js/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
 import { useHostedFieldsRegister } from "./hooks";
@@ -16,10 +16,7 @@ import { getPayPalWindowNamespace } from "../../utils";
 
 import type { FC } from "react";
 import type { PayPalHostedFieldsComponentProps } from "../../types/payPalHostedFieldTypes";
-import type {
-  PayPalHostedFieldsComponent,
-  HostedFieldsHandler,
-} from "@paypal/paypal-js";
+import type { HostedFieldsHandler } from "@paypal/paypal-js";
 
 /**
 This `<PayPalHostedFieldsProvider />` provider component wraps the form field elements and accepts props like `createOrder()`.
@@ -37,8 +34,6 @@ export const PayPalHostedFieldsProvider: FC<
   const [isEligible, setIsEligible] = useState<boolean>(true);
   const [cardFields, setCardFields] = useState<HostedFieldsHandler>();
   const [, setErrorState] = useState(null);
-  const hostedFieldsContainerRef = useRef<HTMLDivElement>(null);
-  const hostedFields = useRef<PayPalHostedFieldsComponent>();
   const [registeredFields, registerHostedField] = useHostedFieldsRegister();
 
   useEffect(() => {
@@ -50,11 +45,11 @@ export const PayPalHostedFieldsProvider: FC<
       return;
     }
     // Get the hosted fields from the [window.paypal.HostedFields] SDK
-    hostedFields.current = getPayPalWindowNamespace(
+    const hostedFields = getPayPalWindowNamespace(
       options[SDK_SETTINGS.DATA_NAMESPACE],
-    ).HostedFields;
+    )?.HostedFields;
 
-    if (!hostedFields.current) {
+    if (!hostedFields) {
       throw new Error(
         generateMissingHostedFieldsError({
           components: options.components,
@@ -62,15 +57,21 @@ export const PayPalHostedFieldsProvider: FC<
         }),
       );
     }
-    if (!hostedFields.current.isEligible()) {
+    if (!hostedFields.isEligible()) {
       return setIsEligible(false);
     }
-    // Clean all the fields before the rerender
-    if (cardFields) {
-      cardFields.teardown();
-    }
+    let isSubscribed = true;
+    let cardFieldsInstance: HostedFieldsHandler | undefined;
 
-    hostedFields.current
+    const teardown = async () => {
+      try {
+        await cardFieldsInstance?.teardown();
+      } catch {
+        // Ignore errors when closing an obsolete or unmounted instance.
+      }
+    };
+
+    hostedFields
       .render({
         // Call your server to set up the transaction
         createOrder: createOrder,
@@ -78,22 +79,34 @@ export const PayPalHostedFieldsProvider: FC<
         installments,
         styles,
       })
-      .then((cardFieldsInstance) => {
-        if (hostedFieldsContainerRef.current) {
-          setCardFields(cardFieldsInstance);
+      .then((instance) => {
+        cardFieldsInstance = instance;
+        if (isSubscribed) {
+          setCardFields(instance);
+        } else {
+          return teardown();
         }
       })
       .catch((err) => {
+        if (!isSubscribed) {
+          return;
+        }
         setErrorState(() => {
           throw new Error(
             `Failed to render <PayPalHostedFieldsProvider /> component. ${err}`,
           );
         });
       });
+
+    return () => {
+      isSubscribed = false;
+      teardown();
+      setCardFields(undefined);
+    };
   }, [loadingStatus, styles]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <div ref={hostedFieldsContainerRef}>
+    <div>
       {isEligible ? (
         <PayPalHostedFieldsContext.Provider
           value={{

--- a/packages/react-paypal-js/src/components/hostedFields/utils.ts
+++ b/packages/react-paypal-js/src/components/hostedFields/utils.ts
@@ -42,14 +42,20 @@ export const generateMissingHostedFieldsError = ({
  * @param registerTypes
  * @returns @type {true} when the children are valid
  */
-const validateExpirationDate = (
+const hasInvalidExpirationDate = (
   registerTypes: PAYPAL_HOSTED_FIELDS_TYPES[],
 ) => {
-  return (
-    !registerTypes.includes(PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_DATE) &&
-    !registerTypes.includes(PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_MONTH) &&
-    !registerTypes.includes(PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_YEAR)
+  const hasDate = registerTypes.includes(
+    PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_DATE,
   );
+  const hasMonth = registerTypes.includes(
+    PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_MONTH,
+  );
+  const hasYear = registerTypes.includes(
+    PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_YEAR,
+  );
+
+  return hasDate ? hasMonth || hasYear : !hasMonth || !hasYear;
 };
 
 /**
@@ -63,7 +69,7 @@ const hasDefaultChildren = (registerTypes: PAYPAL_HOSTED_FIELDS_TYPES[]) => {
   if (
     !registerTypes.includes(PAYPAL_HOSTED_FIELDS_TYPES.NUMBER) ||
     !registerTypes.includes(PAYPAL_HOSTED_FIELDS_TYPES.CVV) ||
-    validateExpirationDate(registerTypes)
+    hasInvalidExpirationDate(registerTypes)
   ) {
     throw new Error(HOSTED_FIELDS_CHILDREN_ERROR);
   }


### PR DESCRIPTION
## Fixes

- Tear down each Hosted Fields instance when its effect is replaced or unmounted, including instances whose asynchronous render finishes after cleanup. Do not let an obsolete render replace the current context instance.
- Clear the disposed context instance and ignore stale render/teardown errors.
- Validate expiration fields as either one combined expirationDate field or the complete expirationMonth/expirationYear pair; reject partial and mixed configurations.
- Preserve the descriptive missing-SDK error when the namespace itself is absent.

## Compatibility

No public API/type changes. Invalid expiration configurations that previously slipped through now fail early with the existing validation error. Obsolete instances are now actually torn down; consumers must not continue using them after unmount/replacement.

## Verification

React 19/JSDOM inline reproductions: resolved and pending unmounts both close once; an out-of-order old render cannot replace the newest instance; old/new instances each close once. Checked all eight expiration-field combinations: only the two valid configurations pass.

Existing full React suite on unmodified main and the combined reviewed fixes: 914 passed, 2 failed, 17 snapshots passed in both runs. The two existing HostedFieldsProvider failures are “should not set context state if component is unmounted” and “should call render function with installments option”; their render mocks are not called in this environment. They are not suppressed or represented as passing. Lint/typecheck, Rollup builds, declarations and diff/format checks pass (five existing JSDoc warnings). No live payment testing. No test files changed.

