### PR TITLE
fix(react-paypal-js): compare own keys when memoizing eligibility payloads

### DIFF
--- a/.changeset/eligibility-own-key-equality.md
+++ b/.changeset/eligibility-own-key-equality.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Compare own keys when memoizing v6 eligibility payloads.

--- a/packages/react-paypal-js/src/v6/utils.test.ts
+++ b/packages/react-paypal-js/src/v6/utils.test.ts
@@ -260,6 +260,12 @@ describe("deepEqual", () => {
       expect(deepEqual({ a: 1 }, { b: 1 })).toBe(false);
     });
 
+    test("returns false when a matching value is inherited", () => {
+      const inherited = Object.assign(Object.create({ a: 1 }), { b: 1 });
+
+      expect(deepEqual({ a: 1 }, inherited)).toBe(false);
+    });
+
     test("returns false for objects with different key counts", () => {
       expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
     });

--- a/packages/react-paypal-js/src/v6/utils.ts
+++ b/packages/react-paypal-js/src/v6/utils.ts
@@ -244,7 +244,10 @@ export function deepEqual(
   }
 
   for (const key of keys1) {
-    if (!deepEqual(record1[key], record2[key], maxDepth, currentDepth + 1)) {
+    if (
+      !Object.prototype.hasOwnProperty.call(record2, key) ||
+      !deepEqual(record1[key], record2[key], maxDepth, currentDepth + 1)
+    ) {
       return false;
     }
   }


### PR DESCRIPTION
## Fix

Require each compared object key to be an own property of the other object before recursively comparing its value. Equal key counts and equal property lookups alone do not establish equality: {a: undefined} and {b: undefined} previously compared equal, as could an inherited property standing in for a missing own key.

This prevents deep-comparison memoization from reusing a different eligibility payload. Existing reference, array, depth-limit and value comparison behavior is preserved; no new dependency or public API.

## Verification

Inline reproductions confirm both distinct-undefined-key and inherited-key false positives change from true to false. Combined reviewed patch set: existing React suite has 914 passes, 2 pre-existing HostedFieldsProvider failures and 17 passing snapshots, identical to unmodified main. Lint/typecheck, Rollup builds, declarations and diff/format checks pass (five existing JSDoc warnings). No test files changed.

