### PR TITLE
Fix: Signal ESM for V6 bundle files

### DIFF
--- a/.changeset/paypal-js-v6-esm-module-marker.md
+++ b/.changeset/paypal-js-v6-esm-module-marker.md
@@ -1,0 +1,7 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Emit a nested `dist/v6/esm/package.json` with `{"type":"module"}` so the v6 ESM bundle is correctly signaled as an ES module.
+
+The v6 build outputs ESM syntax into `.js` files, but the package has no root `"type":"module"` (it can't — that would relabel the v5 CJS bundles). Under Node's resolution rules those `.js` files therefore default to CommonJS, so a native ESM import of `@paypal/paypal-js/sdk-v6` triggers a `MODULE_TYPELESS_PACKAGE_JSON` warning plus a reparse penalty on modern Node, and fails to load outright on older Node or loaders without ESM syntax detection. The nested marker scopes the ESM declaration to the v6 directory only, leaving the v5 CJS artifacts untouched.

--- a/.changeset/react-paypal-js-v6-esm-module-marker.md
+++ b/.changeset/react-paypal-js-v6-esm-module-marker.md
@@ -1,0 +1,7 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Emit a nested `dist/v6/esm/package.json` with `{"type":"module"}` so the v6 ESM bundles (main and server) are correctly signaled as ES modules.
+
+The v6 build outputs ESM syntax into `.js` files, but the package has no root `"type":"module"` (it can't — that would relabel the v5 CJS bundles). Under Node's resolution rules those `.js` files therefore default to CommonJS, so a native ESM import of `@paypal/react-paypal-js/sdk-v6` (or `/sdk-v6/server`) triggers a `MODULE_TYPELESS_PACKAGE_JSON` warning plus a reparse penalty on modern Node, and fails to load outright on older Node or loaders without ESM syntax detection. The nested marker scopes the ESM declaration to the v6 directory only, leaving the v5 CJS artifacts untouched.

--- a/packages/paypal-js/rollup.config.js
+++ b/packages/paypal-js/rollup.config.js
@@ -125,6 +125,10 @@ export default [
 // package has no root `"type":"module"`, which would break the v5 CJS bundles),
 // triggering a MODULE_TYPELESS_PACKAGE_JSON warning + reparse on modern Node and
 // a hard load failure on older/stricter loaders.
+const v6EsmPackageMetadata = {
+  type: "module",
+};
+
 function emitEsmModuleMarker() {
   return {
     name: "emit-esm-module-marker",
@@ -132,7 +136,7 @@ function emitEsmModuleMarker() {
       const outDir = dirname(options.file);
       writeFileSync(
         `${outDir}/package.json`,
-        `${JSON.stringify({ type: "module" }, null, 2)}\n`,
+        `${JSON.stringify(v6EsmPackageMetadata, null, 2)}\n`,
       );
     },
   };

--- a/packages/paypal-js/rollup.config.js
+++ b/packages/paypal-js/rollup.config.js
@@ -1,3 +1,6 @@
+import { writeFileSync } from "fs";
+import { dirname } from "path";
+
 import replace from "@rollup/plugin-replace";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
@@ -99,6 +102,7 @@ export default [
         __VERSION__: pkg.version,
         preventAssignment: true,
       }),
+      emitEsmModuleMarker(),
     ],
     output: [
       {
@@ -115,6 +119,24 @@ export default [
     ],
   },
 ];
+
+// Writes a nested `package.json` containing `{"type":"module"}` next to the v6
+// ESM outputs. Without it, Node interprets these `.js` files as CommonJS (the
+// package has no root `"type":"module"`, which would break the v5 CJS bundles),
+// triggering a MODULE_TYPELESS_PACKAGE_JSON warning + reparse on modern Node and
+// a hard load failure on older/stricter loaders.
+function emitEsmModuleMarker() {
+  return {
+    name: "emit-esm-module-marker",
+    writeBundle(options) {
+      const outDir = dirname(options.file);
+      writeFileSync(
+        `${outDir}/package.json`,
+        `${JSON.stringify({ type: "module" }, null, 2)}\n`,
+      );
+    },
+  };
+}
 
 function getBannerText() {
   return `

--- a/packages/react-paypal-js/rollup.config.js
+++ b/packages/react-paypal-js/rollup.config.js
@@ -165,6 +165,11 @@ export default [
 // package has no root `"type":"module"`, which would break the v5 CJS bundles),
 // triggering a MODULE_TYPELESS_PACKAGE_JSON warning + reparse on modern Node and
 // a hard load failure on older/stricter loaders.
+const v6EsmPackageMetadata = {
+  type: "module",
+  sideEffects: ["./server.js", "./server.min.js"],
+};
+
 function emitEsmModuleMarker() {
   return {
     name: "emit-esm-module-marker",
@@ -172,7 +177,7 @@ function emitEsmModuleMarker() {
       const outDir = dirname(options.file);
       writeFileSync(
         `${outDir}/package.json`,
-        `${JSON.stringify({ type: "module" }, null, 2)}\n`,
+        `${JSON.stringify(v6EsmPackageMetadata, null, 2)}\n`,
       );
     },
   };

--- a/packages/react-paypal-js/rollup.config.js
+++ b/packages/react-paypal-js/rollup.config.js
@@ -4,6 +4,9 @@ import typescript from "@rollup/plugin-typescript";
 import terser from "@rollup/plugin-terser";
 import cleanup from "rollup-plugin-cleanup";
 
+import { dirname } from "path";
+import { writeFileSync } from "fs";
+
 import pkg from "./package.json";
 
 const pkgName = pkg.name.split("@paypal/")[1];
@@ -107,6 +110,7 @@ export default [
       cleanup({
         comments: "none",
       }),
+      emitEsmModuleMarker(),
     ],
     external: ["react", /^@paypal\/paypal-js/, "server-only"],
     output: [
@@ -136,6 +140,7 @@ export default [
       cleanup({
         comments: "none",
       }),
+      emitEsmModuleMarker(),
     ],
     external: ["react", "server-only"],
     output: [
@@ -154,6 +159,24 @@ export default [
     ],
   },
 ];
+
+// Writes a nested `package.json` containing `{"type":"module"}` next to the v6
+// ESM outputs. Without it, Node interprets these `.js` files as CommonJS (the
+// package has no root `"type":"module"`, which would break the v5 CJS bundles),
+// triggering a MODULE_TYPELESS_PACKAGE_JSON warning + reparse on modern Node and
+// a hard load failure on older/stricter loaders.
+function emitEsmModuleMarker() {
+  return {
+    name: "emit-esm-module-marker",
+    writeBundle(options) {
+      const outDir = dirname(options.file);
+      writeFileSync(
+        `${outDir}/package.json`,
+        `${JSON.stringify({ type: "module" }, null, 2)}\n`,
+      );
+    },
+  };
+}
 
 function getBannerText() {
   return `


### PR DESCRIPTION
This PR fixes a silent error/warning due to v6 ESM bundles not specifically marking themselves as ESM. Modern bundlers detect ESM syntax by content, not by file extension, so this issue has been unnoticed. However a native Node ESM consuming either package would throw a syntax error (pre-v20 Node) or warning. These updates fix that issue.

Steps to test:

# 0. Pull these changes locally

# 1. Build both packages
```
cd packages/paypal-js && npm run build
cd ../react-paypal-js && npm run build
```

# 2. Confirm the marker exists and ships in the tarball (both packages)
```
cat packages/paypal-js/dist/v6/esm/package.json          # -> {"type":"module"}
cat packages/react-paypal-js/dist/v6/esm/package.json     # -> {"type":"module"}
cd packages/paypal-js && npm pack --dry-run 2>&1 | grep v6/esm/package.json
cd ../react-paypal-js && npm pack --dry-run 2>&1 | grep v6/esm/package.json
```

# 3. Native ESM import must succeed with NO MODULE_TYPELESS_PACKAGE_JSON warning
```
node --input-type=module -e 'import("./packages/paypal-js/dist/v6/esm/paypal-js.js").then(m=>console.log("ok",Object.keys(m)))'
```

# 4. Must also succeed with Node's ESM syntax-detection DISABLED
#    (simulates older Node <20.19/<22.7; this failed before the fix)
```
node --no-experimental-detect-module --input-type=module \
  -e 'import("./packages/paypal-js/dist/v6/esm/paypal-js.js").then(m=>console.log("ok",Object.keys(m)))'
```

Pass criteria:
- Marker file present in both dist/v6/esm/ dirs and in both `npm pack --dry-run` file lists.
- Step 3 prints `ok [...]` with NO MODULE_TYPELESS_PACKAGE_JSON warning (before the fix it emitted the warning + a reparse penalty).
- Step 4 prints `ok [...]` (before the fix it hard-failed with ERR_REQUIRE_CYCLE_MODULE).
- Run each package's existing suite (npm test, plus paypal-js `npm run test:bundle`) — must stay green.

Notes:
- Use absolute paths, or run the `node -e` snippets from the repo root — relative import() resolves from CWD, not the target file.
- The dist/ marker is generated on every build (survives the `rm -rf dist` clean), so don't commit it by hand.
