### PR TITLE
fix(react-paypal-js): remove stale proxy props

### DIFF
--- a/.changeset/remove-stale-proxy-props.md
+++ b/.changeset/remove-stale-proxy-props.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Remove properties from `useProxyProps` when a later render omits them, preventing removed callbacks and options from remaining visible to SDK integrations.

--- a/packages/react-paypal-js/src/hooks/useProxyProps.test.ts
+++ b/packages/react-paypal-js/src/hooks/useProxyProps.test.ts
@@ -52,4 +52,19 @@ describe("useProxyProps", () => {
     expect(current.fundingSource).toBe(props.fundingSource);
     expect(props.fundingSource).toBe(fundingSource);
   });
+
+  test("should remove props that are omitted from a later render", () => {
+    let props: Record<string, unknown> = {
+      createOrder: jest.fn(),
+      onClick: jest.fn(),
+    };
+    const { result, rerender } = renderHook(() => useProxyProps(props));
+
+    expect(result.current).toHaveProperty("onClick");
+
+    props = { createOrder: props.createOrder };
+    rerender();
+
+    expect(result.current).not.toHaveProperty("onClick");
+  });
 });

--- a/packages/react-paypal-js/src/hooks/useProxyProps.ts
+++ b/packages/react-paypal-js/src/hooks/useProxyProps.ts
@@ -30,6 +30,11 @@ export function useProxyProps<T extends Record<PropertyKey, unknown>>(
     }),
   );
 
+  for (const prop of Reflect.ownKeys(proxyRef.current)) {
+    if (!Object.prototype.hasOwnProperty.call(props, prop)) {
+      Reflect.deleteProperty(proxyRef.current, prop);
+    }
+  }
   proxyRef.current = Object.assign(proxyRef.current, props);
 
   return proxyRef.current;


### PR DESCRIPTION
## Problem

`useProxyProps` only assigns current props onto its stable Proxy target. When a caller removes a callback or option on a later render, the old own property remains on that target indefinitely. SDK integrations therefore keep seeing and invoking a callback that the React caller has removed.

## Fix

- Delete own Proxy-target properties that are absent from the latest props object before assigning current values.
- Use `Reflect.ownKeys` so string and symbol properties follow the same lifecycle.
- Add a regression that rerenders without `onClick` and verifies that the stable proxy no longer exposes it.
- Add a patch changeset.

The Proxy identity and current-callback forwarding behavior remain unchanged. No public API or dependency changes are introduced.

## Verification

- 72 suites, 917 tests and 17 snapshots pass.
- Package ESLint and TypeScript pass with the five pre-existing JSDoc warnings.
- All four package bundles build.
- Focused Prettier and `git diff --check` pass.