### PR TITLE
fix(react-paypal-js): recover button eligibility

### DIFF
--- a/.changeset/recover-paypal-buttons-eligibility.md
+++ b/.changeset/recover-paypal-buttons-eligibility.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Render `PayPalButtons` again when a forced rerender creates an eligible SDK component after a previous component was ineligible.

--- a/packages/react-paypal-js/src/components/PayPalButtons.test.tsx
+++ b/packages/react-paypal-js/src/components/PayPalButtons.test.tsx
@@ -274,6 +274,35 @@ describe("<PayPalButtons />", () => {
     ).toBeFalsy();
   });
 
+  test("should render Buttons after becoming eligible", async () => {
+    mockPaypalButtonsComponent.isEligible
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+
+    const { rerender } = render(
+      <PayPalScriptProvider options={{ clientId: "test" }}>
+        <PayPalButtons forceReRender={[0]}>
+          <div data-testid="ineligible">Unavailable</div>
+        </PayPalButtons>
+      </PayPalScriptProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("ineligible")).toBeVisible());
+
+    rerender(
+      <PayPalScriptProvider options={{ clientId: "test" }}>
+        <PayPalButtons forceReRender={[1]}>
+          <div data-testid="ineligible">Unavailable</div>
+        </PayPalButtons>
+      </PayPalScriptProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("ineligible")).not.toBeInTheDocument(),
+    );
+    expect(mockPaypalButtonsComponent.render).toHaveBeenCalledTimes(1);
+  });
+
   test("should catch the error when no components are passed to the PayPalScriptProvider", async () => {
     const spyConsoleError = jest.spyOn(console, "error").mockImplementation();
     const onErrorCallback = jest.fn();

--- a/packages/react-paypal-js/src/components/PayPalButtons.tsx
+++ b/packages/react-paypal-js/src/components/PayPalButtons.tsx
@@ -104,6 +104,7 @@ const PayPalButtonsInner: FunctionComponent<PayPalButtonsComponentProps> = ({
       setIsEligible(false);
       return closeButtonsComponent;
     }
+    setIsEligible(true);
 
     if (!buttonsContainerRef.current) {
       return closeButtonsComponent;
@@ -147,15 +148,13 @@ const PayPalButtonsInner: FunctionComponent<PayPalButtonsComponentProps> = ({
 
   return (
     <>
-      {isEligible ? (
-        <div
-          ref={buttonsContainerRef}
-          style={isDisabledStyle}
-          className={classNames}
-        />
-      ) : (
-        children
-      )}
+      <div
+        ref={buttonsContainerRef}
+        style={isDisabledStyle}
+        className={classNames}
+        hidden={!isEligible}
+      />
+      {isEligible ? null : children}
     </>
   );
 };


### PR DESCRIPTION
## Problem

`PayPalButtons` permanently switches to its ineligible fallback after one SDK component returns `isEligible() === false`. A later forced rerender can create an eligible Buttons component, but the component never resets its React eligibility state. Its container is also absent while the fallback is shown, so the newly eligible SDK component has nowhere to render.

## Fix

- Reset eligibility when a newly created SDK component is eligible.
- Keep the SDK render container mounted but hidden while the fallback is active, allowing a later eligible component to render before it becomes visible.
- Add a regression covering an ineligible-to-eligible `forceReRender` transition.
- Add a patch changeset.

The existing ineligible fallback and normal eligible rendering behavior remain unchanged. No public API or dependency changes are introduced.

## Verification

- Focused PayPalButtons suite: 17 tests and 3 snapshots pass.
- Full React package run: 915 tests pass; the same two existing HostedFieldsProvider tests fail because their shared render mock is not called.
- Package ESLint and TypeScript pass with five pre-existing JSDoc warnings.
- Core and React package bundles build.
- Focused Prettier and `git diff --check` pass.