### PR TITLE
fix(react-paypal-js): recover mark eligibility

### DIFF
--- a/.changeset/recover-paypal-marks-eligibility.md
+++ b/.changeset/recover-paypal-marks-eligibility.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Render `PayPalMarks` again when a funding-source update becomes eligible after the previous SDK component was ineligible.

--- a/packages/react-paypal-js/src/components/PayPalMarks.test.tsx
+++ b/packages/react-paypal-js/src/components/PayPalMarks.test.tsx
@@ -208,7 +208,9 @@ describe("<PayPalMarks />", () => {
         container.querySelector(".ineligible") instanceof HTMLDivElement,
       ).toBeTruthy(),
     );
-    expect(container.querySelector(".mark-container")).toBeNull();
+    expect(container.querySelector(".mark-container")).toHaveAttribute(
+      "hidden",
+    );
     expect(mockIsEligible).toBeCalledTimes(1);
     expect(mockRender).not.toBeCalled();
   });
@@ -246,5 +248,48 @@ describe("<PayPalMarks />", () => {
     );
 
     await waitFor(() => expect(mockRender).toBeCalledTimes(2));
+  });
+
+  test("should render after becoming eligible", async () => {
+    const mockRender = jest.fn().mockResolvedValue(undefined);
+    const mockIsEligible = jest
+      .fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    window.paypal = {
+      Marks() {
+        return {
+          isEligible: mockIsEligible,
+          render: mockRender,
+        };
+      },
+      version: "",
+    };
+
+    const { container, rerender } = render(
+      <PayPalScriptProvider options={{ clientId: "test" }}>
+        <PayPalMarks className="mark-container" fundingSource="paypal">
+          <div className="ineligible" />
+        </PayPalMarks>
+      </PayPalScriptProvider>,
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector(".ineligible")).toBeInTheDocument(),
+    );
+
+    rerender(
+      <PayPalScriptProvider options={{ clientId: "test" }}>
+        <PayPalMarks className="mark-container" fundingSource="card">
+          <div className="ineligible" />
+        </PayPalMarks>
+      </PayPalScriptProvider>,
+    );
+
+    await waitFor(() => expect(mockRender).toHaveBeenCalledTimes(1));
+    expect(container.querySelector(".ineligible")).not.toBeInTheDocument();
+    expect(container.querySelector(".mark-container")).not.toHaveAttribute(
+      "hidden",
+    );
   });
 });

--- a/packages/react-paypal-js/src/components/PayPalMarks.tsx
+++ b/packages/react-paypal-js/src/components/PayPalMarks.tsx
@@ -46,6 +46,7 @@ export const PayPalMarks: FC<PayPalMarksComponentProps> = ({
     if (!current || !mark.isEligible()) {
       return setIsEligible(false);
     }
+    setIsEligible(true);
     // Remove any children before render it again
     if (current.firstChild) {
       current.removeChild(current.firstChild);
@@ -97,11 +98,8 @@ export const PayPalMarks: FC<PayPalMarksComponentProps> = ({
 
   return (
     <>
-      {isEligible ? (
-        <div ref={markContainerRef} className={className} />
-      ) : (
-        children
-      )}
+      <div ref={markContainerRef} className={className} hidden={!isEligible} />
+      {isEligible ? null : children}
     </>
   );
 };


### PR DESCRIPTION
## Problem

`PayPalMarks` permanently switches to its ineligible fallback after one SDK component returns `isEligible() === false`. When `fundingSource` changes and the next Marks component is eligible, React never resets the eligibility state. Its render container is also absent while the fallback is shown, so the eligible SDK component has nowhere to render.

## Fix

- Reset eligibility when a newly created Marks component is eligible.
- Keep the SDK render container mounted but hidden while fallback content is active.
- Add a regression covering an ineligible-to-eligible funding-source transition.
- Update the existing ineligible assertion for the hidden container and add a patch changeset.

Fallback content remains visible only while ineligible. No public API or dependency changes are introduced.

## Verification

- Focused PayPalMarks suite: 10 tests and 4 snapshots pass.
- Full React package run: 915 tests pass; the same two existing HostedFieldsProvider tests fail because their shared render mock is not called.
- Package ESLint and TypeScript pass with five pre-existing JSDoc warnings.
- Core and React package bundles build.
- Focused Prettier and `git diff --check` pass.