### PR TITLE
fix(react-paypal-js): recover Hosted Fields eligibility

### DIFF
--- a/.changeset/recover-hosted-fields-eligibility.md
+++ b/.changeset/recover-hosted-fields-eligibility.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Render Hosted Fields again when a style update becomes eligible after the previous SDK eligibility check failed.

--- a/packages/react-paypal-js/src/components/hostedFields/PayPalHostedFieldsProvider.test.tsx
+++ b/packages/react-paypal-js/src/components/hostedFields/PayPalHostedFieldsProvider.test.tsx
@@ -221,6 +221,59 @@ describe("PayPalHostedFieldsProvider", () => {
     expect(container.querySelector(".cvv")).toEqual(null);
   });
 
+  test("should render hosted fields after becoming eligible", async () => {
+    let eligible = false;
+    isEligible.mockImplementation(() => eligible);
+
+    const renderProvider = (styles?: Record<string, unknown>) => (
+      <PayPalScriptProvider
+        options={{
+          clientId: "test-client",
+          currency: "USD",
+          intent: "authorize",
+          components: "hosted-fields",
+          dataClientToken: "test-data-client-token",
+        }}
+      >
+        <PayPalHostedFieldsProvider
+          createOrder={mockCreateOrder}
+          styles={styles}
+        >
+          <PayPalHostedField
+            className="number"
+            hostedFieldType={PAYPAL_HOSTED_FIELDS_TYPES.NUMBER}
+            options={{ selector: ".number" }}
+          />
+          <PayPalHostedField
+            className="expiration"
+            hostedFieldType={PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_DATE}
+            options={{ selector: ".expiration" }}
+          />
+          <PayPalHostedField
+            className="cvv"
+            hostedFieldType={PAYPAL_HOSTED_FIELDS_TYPES.CVV}
+            options={{ selector: ".cvv" }}
+          />
+        </PayPalHostedFieldsProvider>
+      </PayPalScriptProvider>
+    );
+
+    const { container, rerender } = render(renderProvider());
+
+    await waitFor(() =>
+      expect(container.querySelector(".number")).not.toBeInTheDocument(),
+    );
+    expect(window.paypal?.HostedFields?.render).not.toHaveBeenCalled();
+
+    eligible = true;
+    rerender(renderProvider({ input: { color: "black" } }));
+
+    await waitFor(() =>
+      expect(window.paypal?.HostedFields?.render).toHaveBeenCalledTimes(1),
+    );
+    expect(container.querySelector(".number")).toBeInTheDocument();
+  });
+
   test("should throw an Error on hosted fields render process exception", async () => {
     const spyConsoleError = jest.spyOn(console, "error").mockImplementation();
     (

--- a/packages/react-paypal-js/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
+++ b/packages/react-paypal-js/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
@@ -65,6 +65,10 @@ export const PayPalHostedFieldsProvider: FC<
     if (!hostedFields.current.isEligible()) {
       return setIsEligible(false);
     }
+    if (!isEligible) {
+      setIsEligible(true);
+      return;
+    }
     // Clean all the fields before the rerender
     if (cardFields) {
       cardFields.teardown();
@@ -90,7 +94,7 @@ export const PayPalHostedFieldsProvider: FC<
           );
         });
       });
-  }, [loadingStatus, styles]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [loadingStatus, styles, isEligible]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div ref={hostedFieldsContainerRef}>


### PR DESCRIPTION
## Problem

`PayPalHostedFieldsProvider` permanently replaces its fields with the ineligible fallback after one `HostedFields.isEligible()` check returns false. If a later style update triggers another check that is eligible, the provider does not restore its children. Calling `render` immediately would also target field nodes that have not remounted yet.

## Fix

- Restore the eligible state when a later check succeeds.
- Treat that restoration as a separate render phase: remount the field children first, then rerun the existing effect and initialize Hosted Fields against the current registered nodes.
- Add a regression covering an ineligible-to-eligible style transition.
- Add a patch changeset.

The normal eligible path and ineligible fallback remain unchanged. No public API or dependency changes are introduced.

## Verification

- Focused HostedFieldsProvider suite: 11 tests pass.
- Full React package run: 915 tests pass; the same two existing HostedFieldsProvider tests intermittently fail because their shared render mock is not called. Both pass in the focused suite, including the new regression.
- Package ESLint and TypeScript pass with five pre-existing JSDoc warnings.
- Core and React package bundles build.
- Focused Prettier and `git diff --check` pass.