### PR TITLE
fix(react-paypal-js): keep latest Braintree message fetch state

### DIFF
--- a/.changeset/braintree-messages-latest-fetch.md
+++ b/.changeset/braintree-messages-latest-fetch.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Prevent an older Braintree Messages fetch from overwriting the state from a newer request.

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalMessages.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalMessages.test.ts
@@ -299,6 +299,43 @@ describe("useBraintreePayPalMessages", () => {
 
       expect(result.current.error).toBeNull();
     });
+
+    test("should ignore an older fetch error after a newer fetch succeeds", async () => {
+      const emptyContent = {
+        messageItems: { mainItems: [], actionItems: [] },
+        update: jest.fn(),
+      } as unknown as BraintreeMessageContent;
+      const populatedContent = {
+        messageItems: { mainItems: [{ type: "text" }], actionItems: [] },
+        update: jest.fn(),
+      } as unknown as BraintreeMessageContent;
+      let resolveFirst!: (content: BraintreeMessageContent) => void;
+      const first = new Promise<BraintreeMessageContent>((resolve) => {
+        resolveFirst = resolve;
+      });
+      (mockMessagesInstance.fetchContent as jest.Mock)
+        .mockReturnValueOnce(first)
+        .mockResolvedValueOnce(populatedContent);
+
+      const { result, waitFor } = renderHook(() =>
+        useBraintreePayPalMessages({ buyerCountry: "US", currencyCode: "USD" }),
+      );
+
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      let firstFetch!: Promise<unknown>;
+      await act(async () => {
+        firstFetch = result.current.handleFetchContent({ amount: "100" });
+        await result.current.handleFetchContent({ amount: "200" });
+      });
+
+      await act(async () => {
+        resolveFirst(emptyContent);
+        await firstFetch;
+      });
+
+      expect(result.current.error).toBeNull();
+    });
   });
 
   describe("context error", () => {

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalMessages.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalMessages.test.ts
@@ -324,16 +324,22 @@ describe("useBraintreePayPalMessages", () => {
       await waitFor(() => expect(result.current.isReady).toBe(true));
 
       let firstFetch!: Promise<unknown>;
+      let latestContent: unknown;
       await act(async () => {
         firstFetch = result.current.handleFetchContent({ amount: "100" });
-        await result.current.handleFetchContent({ amount: "200" });
+        latestContent = await result.current.handleFetchContent({
+          amount: "200",
+        });
       });
 
+      let staleContent: unknown;
       await act(async () => {
         resolveFirst(emptyContent);
-        await firstFetch;
+        staleContent = await firstFetch;
       });
 
+      expect(latestContent).toBe(populatedContent);
+      expect(staleContent).toBeUndefined();
       expect(result.current.error).toBeNull();
     });
   });

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalMessages.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalMessages.ts
@@ -79,6 +79,7 @@ export function useBraintreePayPalMessages({
   );
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useError();
+  const fetchRequestRef = useRef(0);
 
   // Prevents auto-retrying the exact (instance, buyerCountry, currencyCode) call
   // that just failed. Keyed on the options too so that changing them on the same
@@ -151,6 +152,7 @@ export function useBraintreePayPalMessages({
 
     return () => {
       isSubscribed = false;
+      fetchRequestRef.current += 1;
       setMessages(null);
     };
   }, [
@@ -167,6 +169,8 @@ export function useBraintreePayPalMessages({
         return;
       }
 
+      const request = ++fetchRequestRef.current;
+
       if (!messages) {
         setError(new Error("Braintree PayPal Messages instance not available"));
         return;
@@ -175,6 +179,10 @@ export function useBraintreePayPalMessages({
       setError(null);
 
       const result = await messages.fetchContent(options);
+
+      if (!isMountedRef.current || request !== fetchRequestRef.current) {
+        return result;
+      }
 
       // On an API error, fetchContent resolves to an empty sentinel MessageContent
       // (empty messageItems) instead of throwing, so the <paypal-message> element

--- a/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalMessages.ts
+++ b/packages/react-paypal-js/src/v6/hooks/Braintree/useBraintreePayPalMessages.ts
@@ -181,7 +181,7 @@ export function useBraintreePayPalMessages({
       const result = await messages.fetchContent(options);
 
       if (!isMountedRef.current || request !== fetchRequestRef.current) {
-        return result;
+        return;
       }
 
       // On an API error, fetchContent resolves to an empty sentinel MessageContent


### PR DESCRIPTION
## Problem

`useBraintreePayPalMessages` allows overlapping `fetchContent` calls. If an older call resolves with the empty error sentinel after a newer call succeeds, the older response replaces the current hook state with an error. A completion from a replaced Messages instance can do the same.

## Fix

- Track monotonically increasing fetch request IDs.
- Only let the latest request update hook state.
- Invalidate pending requests when the Messages instance is cleaned up.
- Continue returning each caller’s resolved content, including the empty sentinel.
- Add a reversed-completion regression test.
- Add a patch changeset.

## Verification

- Focused Braintree Messages suite: 13 tests passed.
- Full React suite: 71 suites and 915 tests passed; the two existing timer-sensitive Hosted Fields tests failed unchanged.
- React ESLint and TypeScript checks passed; ESLint reports the same five pre-existing JSDoc warnings.
- Core and all four React package bundles built successfully.
- Changed files pass Prettier and `git diff --check`.