### PR TITLE
fix(paypal-js): dedupe concurrent SDK loads

### DIFF
--- a/.changeset/load-script-dedupe-inflight.md
+++ b/.changeset/load-script-dedupe-inflight.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Reuse an in-flight SDK script load when the same options are requested concurrently.

--- a/packages/paypal-js/src/load-script.test.ts
+++ b/packages/paypal-js/src/load-script.test.ts
@@ -98,6 +98,17 @@ describe("loadScript()", () => {
     expect(response).toEqual([windowObject.paypal1, windowObject.paypal2]);
   });
 
+  test("should reuse an in-flight request with the same options", async () => {
+    const [response1, response2] = await Promise.all([
+      loadScript({ clientId: "test" }),
+      loadScript({ clientId: "test" }),
+    ]);
+
+    expect(mockedInsertScriptElement).toHaveBeenCalledTimes(1);
+    expect(response1).toBe(window.paypal);
+    expect(response2).toBe(window.paypal);
+  });
+
   test("should reject the promise when window.paypal is undefined after loading the <script>", async () => {
     expect.assertions(3);
 

--- a/packages/paypal-js/src/load-script.ts
+++ b/packages/paypal-js/src/load-script.ts
@@ -2,6 +2,11 @@ import { findScript, insertScriptElement, processOptions } from "./utils";
 import type { PayPalScriptOptions } from "../types/script-options";
 import type { PayPalNamespace } from "../types/index";
 
+const loadingScripts: Record<
+  string,
+  Promise<PayPalNamespace | null>
+> = Object.create(null);
+
 /**
  * Load the Paypal JS SDK script asynchronously.
  *
@@ -26,12 +31,24 @@ export function loadScript(
     attributes["data-js-sdk-library"] = "paypal-js";
   }
 
+  const scriptKey = JSON.stringify([
+    url,
+    Object.keys(attributes)
+      .sort()
+      .map((key) => [key, attributes[key]]),
+  ]);
+  const loadingScript = loadingScripts[scriptKey];
+
+  if (loadingScript) {
+    return loadingScript;
+  }
+
   // resolve with the existing global paypal namespace when a script with the same params already exists
   if (findScript(url, attributes) && existingWindowNamespace) {
     return PromisePonyfill.resolve(existingWindowNamespace);
   }
 
-  return loadCustomScript(
+  const loadPromise = loadCustomScript(
     {
       url,
       attributes: attributes,
@@ -48,6 +65,19 @@ export function loadScript(
       `The window.${namespace} global variable is not available.`,
     );
   });
+
+  loadingScripts[scriptKey] = loadPromise.then(
+    (paypalNamespace) => {
+      delete loadingScripts[scriptKey];
+      return paypalNamespace;
+    },
+    (error: unknown) => {
+      delete loadingScripts[scriptKey];
+      throw error;
+    },
+  );
+
+  return loadingScripts[scriptKey];
 }
 
 /**


### PR DESCRIPTION
## Problem

Two concurrent `loadScript()` calls with identical options can each insert an SDK script. The existing DOM/global shortcut only works after the first script has exposed its namespace, so it does not cover the in-flight interval. Duplicate SDK scripts can perform duplicate network and initialization work.

## Fix

- Key in-flight loads by the exact processed URL and sorted script attributes.
- Return the existing promise only for an identical configuration.
- Remove the entry after either success or failure so sequential calls and retries retain their existing behavior.
- Add a parallel-call regression test.
- Add a patch changeset.

## Verification

- Core source suite: 5 files and 55 tests passed.
- ESLint and TypeScript checks passed.
- ESM, CJS, IIFE, legacy, and v6 bundles built successfully.
- Changed files pass Prettier and `git diff --check`.