### PR TITLE
fix(paypal-js): match pending v6 script options

### DIFF
--- a/.changeset/v6-match-pending-script-options.md
+++ b/.changeset/v6-match-pending-script-options.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Only reuse an in-flight v6 SDK script when its environment, debug mode, namespace, and integration source match.

--- a/packages/paypal-js/src/v6/index.test.ts
+++ b/packages/paypal-js/src/v6/index.test.ts
@@ -121,6 +121,46 @@ describe("loadCoreSdkScript()", () => {
     expect(window.paypal).toBeDefined();
   });
 
+  test.each([
+    {
+      name: "environment",
+      existing:
+        '<script src="https://www.paypal.com/web-sdk/v6/core" data-loading-state="pending"></script>',
+      options: { environment: "sandbox" } as const,
+    },
+    {
+      name: "debug mode",
+      existing:
+        '<script src="https://www.sandbox.paypal.com/web-sdk/v6/core" data-loading-state="pending"></script>',
+      options: { environment: "sandbox", debug: true } as const,
+    },
+    {
+      name: "namespace",
+      existing:
+        '<script src="https://www.sandbox.paypal.com/web-sdk/v6/core" data-loading-state="pending" data-namespace="first"></script>',
+      options: { environment: "sandbox", dataNamespace: "second" } as const,
+    },
+    {
+      name: "integration source",
+      existing:
+        '<script src="https://www.sandbox.paypal.com/web-sdk/v6/core" data-loading-state="pending" data-sdk-integration-source="first"></script>',
+      options: {
+        environment: "sandbox",
+        dataSdkIntegrationSource: "second",
+      } as const,
+    },
+  ])(
+    "should not reuse a pending script with a different $name",
+    async (testCase) => {
+      document.head.innerHTML = testCase.existing;
+
+      const result = await loadCoreSdkScript(testCase.options);
+
+      expect(scriptAppendChildSpy).toHaveBeenCalledTimes(1);
+      expect(result).toBeDefined();
+    },
+  );
+
   test("should reject when the script fails to load", async () => {
     vi.spyOn(document.head, "appendChild").mockImplementationOnce((node) => {
       process.nextTick(() => node.dispatchEvent(new Event("error")));

--- a/packages/paypal-js/src/v6/index.ts
+++ b/packages/paypal-js/src/v6/index.ts
@@ -40,9 +40,11 @@ function loadCoreSdkScript(options: LoadCoreSdkScriptOptions) {
   }
 
   const scriptElement =
-    document.querySelector<HTMLScriptElement>(
-      `script[src*="${url.pathname}"][${DATA_ATTRIBUTE_LOADING_STATE}="${SCRIPT_LOADING_STATE.PENDING}"]`,
-    ) ??
+    findPendingScript({
+      url: url.toString(),
+      namespace,
+      dataSdkIntegrationSource,
+    }) ??
     createScriptElement({
       url: url.toString(),
       attributes: {
@@ -94,6 +96,30 @@ function loadCoreSdkScript(options: LoadCoreSdkScriptOptions) {
     );
   });
 }
+
+function findPendingScript({
+  url,
+  namespace,
+  dataSdkIntegrationSource,
+}: {
+  url: string;
+  namespace: string;
+  dataSdkIntegrationSource?: string;
+}): HTMLScriptElement | undefined {
+  return Array.from(
+    document.querySelectorAll<HTMLScriptElement>(
+      `script[${DATA_ATTRIBUTE_LOADING_STATE}="${SCRIPT_LOADING_STATE.PENDING}"]`,
+    ),
+  ).find(
+    (scriptElement) =>
+      scriptElement.src === url &&
+      (scriptElement.getAttribute("data-namespace") ?? "paypal") ===
+        namespace &&
+      scriptElement.getAttribute("data-sdk-integration-source") ===
+        (dataSdkIntegrationSource ?? null),
+  );
+}
+
 function validateArguments(options: unknown) {
   if (typeof options !== "object" || options === null) {
     throw new Error("Expected an options object");


### PR DESCRIPTION
## Problem

`loadCoreSdkScript()` currently reuses any pending script whose URL contains `/web-sdk/v6/core`. That selector ignores the environment host, `debug` query, namespace, and integration-source attribute. A request can therefore wait on an incompatible script, resolve the wrong configuration, or reject because its expected namespace was never created.

## Fix

- Match pending scripts by the complete resolved URL.
- Also require the effective namespace and integration source to match.
- Preserve the default `paypal` namespace equivalence when the attribute is omitted.
- Add regressions for environment, debug mode, namespace, and integration-source mismatches.
- Add a patch changeset.

## Verification

- Core source suite: 5 files and 58 tests passed.
- ESLint and TypeScript checks passed.
- ESM, CJS, IIFE, legacy, and v6 bundles built successfully.
- Changed files pass Prettier and `git diff --check`.