### PR TITLE
fix(react-paypal-js): ignore obsolete resume errors

### DIFF
--- a/.changeset/ignore-obsolete-resume-errors.md
+++ b/.changeset/ignore-obsolete-resume-errors.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": patch
+---
+
+Ignore redirect resume errors from payment sessions that have already been replaced or destroyed.

--- a/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayLaterOneTimePaymentSession.ts
@@ -155,7 +155,9 @@ export function usePayLaterOneTimePaymentSession({
             await newSession.resume?.();
           }
         } catch (err) {
-          setError(err as Error);
+          if (sessionRef.current === newSession) {
+            setError(err as Error);
+          }
         }
       };
 

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditOneTimePaymentSession.ts
@@ -150,7 +150,9 @@ export function usePayPalCreditOneTimePaymentSession({
             await newSession.resume?.();
           }
         } catch (err) {
-          setError(err as Error);
+          if (sessionRef.current === newSession) {
+            setError(err as Error);
+          }
         }
       };
 

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.test.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.test.ts
@@ -482,6 +482,44 @@ describe("usePayPalCreditSavePaymentSession", () => {
 
       expect(mockSession.resume).toHaveBeenCalled();
     });
+
+    test("should ignore a resume error from a replaced session", async () => {
+      const firstSession = createMockPayPalCreditSavePaymentSession();
+      const secondSession = createMockPayPalCreditSavePaymentSession();
+      const resumeError = new Error("obsolete resume failed");
+      let rejectResume!: (error: Error) => void;
+      (firstSession.hasReturned as jest.Mock).mockReturnValue(true);
+      (firstSession.resume as jest.Mock).mockReturnValue(
+        new Promise<void>((_, reject) => {
+          rejectResume = reject;
+        }),
+      );
+      const mockSdk = createMockSdkInstance(firstSession);
+      mockSdk.createPayPalSavePaymentSession.mockReturnValueOnce(firstSession);
+      mockSdk.createPayPalSavePaymentSession.mockReturnValue(secondSession);
+      mockPayPalContext({ sdkInstance: mockSdk });
+
+      const { result, rerender } = renderHook(
+        ({ vaultSetupToken }) =>
+          usePayPalCreditSavePaymentSession({
+            presentationMode: "redirect",
+            vaultSetupToken,
+            onApprove: jest.fn(),
+          }),
+        { initialProps: { vaultSetupToken: "first-token" } },
+      );
+
+      expect(firstSession.resume).toHaveBeenCalled();
+
+      rerender({ vaultSetupToken: "second-token" });
+
+      await act(async () => {
+        rejectResume(resumeError);
+        await Promise.resolve();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
   });
 
   describe("handleClick", () => {

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalCreditSavePaymentSession.ts
@@ -137,7 +137,9 @@ export function usePayPalCreditSavePaymentSession({
             await newSession.resume?.();
           }
         } catch (err) {
-          setError(err as Error);
+          if (sessionRef.current === newSession) {
+            setError(err as Error);
+          }
         }
       };
 

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalOneTimePaymentSession.ts
@@ -138,7 +138,9 @@ export function usePayPalOneTimePaymentSession({
             await newSession.resume?.();
           }
         } catch (err) {
-          setError(err as Error);
+          if (sessionRef.current === newSession) {
+            setError(err as Error);
+          }
         }
       };
 

--- a/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
+++ b/packages/react-paypal-js/src/v6/hooks/usePayPalSavePaymentSession.ts
@@ -132,7 +132,9 @@ export function usePayPalSavePaymentSession({
             await newSession.resume?.();
           }
         } catch (err) {
-          setError(err as Error);
+          if (sessionRef.current === newSession) {
+            setError(err as Error);
+          }
         }
       };
 


### PR DESCRIPTION
## Problem

The five payment hooks that resume redirect/direct-app-switch sessions start `resume()` asynchronously. If props or the SDK instance replace that session before the promise rejects, its catch handler still writes the obsolete error into the live hook state. The replacement session can consequently appear failed even though it did not produce the error.

## Fix

- Before surfacing a resume error, verify that the originating session is still the hook’s current session.
- Apply the same guard to PayPal one-time, PayPal save, PayPal Credit one-time, PayPal Credit save, and Pay Later one-time sessions.
- Add a regression that replaces a session before its pending resume rejects.
- Add a patch changeset.

## Verification

- All five affected hook suites: 5 suites and 129 tests passed.
- Full React suite: 71 suites and 915 tests passed; the two existing timer-sensitive Hosted Fields tests failed unchanged.
- React ESLint and TypeScript checks passed; ESLint reports the same five pre-existing JSDoc warnings.
- All four React bundles built successfully.
- Changed files pass Prettier and `git diff --check`.