### PR TITLE
feat(paypal-js): support LPM eligibility funding sources

### DIFF
--- a/.changeset/lpm-eligibility-funding-sources.md
+++ b/.changeset/lpm-eligibility-funding-sources.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Expand the v6 eligibility `FundingSource` type to include supported local payment methods.

--- a/packages/paypal-js/types/v6/components/find-eligible-methods.d.ts
+++ b/packages/paypal-js/types/v6/components/find-eligible-methods.d.ts
@@ -28,15 +28,71 @@ export type FindEligibleMethodsOptions = {
   paymentFlow?: PaymentFlow;
 };
 
+/**
+ * Funding sources accepted by `EligiblePaymentMethodsOutput.isEligible` /
+ * `getDetails`. This includes the funding sources used by the v6 Local Payment
+ * Method wrappers (e.g. `ideal`, `blik`) in addition to the core wallet and
+ * card methods.
+ */
 export type FundingSource =
+  | "advanced_cards"
+  | "afterpay"
+  | "alfamart"
+  | "alipay"
+  | "applepay"
+  | "bancomatpay"
+  | "bancontact"
+  | "bizum"
+  | "blik"
+  | "blik_pay_later"
+  | "boletobancario"
+  | "card"
   | "credit"
+  | "crypto"
+  | "doku"
+  | "dragonpay"
+  | "eps"
+  | "estonia_banks"
+  | "fiuu_cash"
+  | "floa_pay"
+  | "fpx"
+  | "googlepay"
+  | "gopay"
+  | "grabpay"
+  | "ideal"
+  | "indomaret"
+  | "indonesia_banks"
+  | "jenius_pay"
+  | "klarna"
+  | "kredivo"
+  | "latvia_banks"
+  | "linkaja"
+  | "lithuania_banks"
+  | "mbway"
+  | "multibanco"
+  | "mybank"
+  | "ovo"
+  | "oxxo_pay"
+  | "p24"
   | "paylater"
   | "paypal"
+  | "paysafecard"
+  | "paysera"
+  | "payu"
+  | "pix_international"
+  | "satispay"
+  | "scalapay"
+  | "sepa"
+  | "skrill"
+  | "swish"
+  | "thailand_banks"
+  | "trustly"
+  | "twint"
   | "venmo"
-  | "card"
-  | "advanced_cards"
-  | "applepay"
-  | "googlepay";
+  | "verkkopankki"
+  | "wechatpay"
+  | "wero"
+  | "zip";
 
 type BaseEligiblePaymentMethodDetails = {
   canBeVaulted: boolean;


### PR DESCRIPTION
## Summary

- expand the v6 eligibility `FundingSource` type to cover the supported local payment methods
- allow consumers to call `isEligible` and `getDetails` with LPM funding sources such as `ideal` and `blik`
- add a patch changeset for `@paypal/paypal-js`

## Testing

- `npm run typecheck --workspace=@paypal/paypal-js`
- `git diff --check`