### PR TITLE
feat(storybook): add v6 BLIK and iDEAL examples

### DIFF
--- a/packages/react-paypal-js-storybook/v6/src/decorators/PayPalProviderDecorator.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/decorators/PayPalProviderDecorator.tsx
@@ -7,7 +7,18 @@ import {
   usePayPal,
   INSTANCE_LOADING_STATE,
 } from "@paypal/react-paypal-js/sdk-v6";
+import type { Components } from "@paypal/react-paypal-js/sdk-v6";
 import { PAYPAL_CLIENT_ID } from "../shared/utils";
+
+const DEFAULT_COMPONENTS: Components[] = [
+  "paypal-payments",
+  "venmo-payments",
+  "paypal-guest-payments",
+  "paypal-subscriptions",
+  "card-fields",
+  "applepay-payments",
+  "googlepay-payments",
+];
 
 // Logs SDK and button events to the Actions panel.
 function SdkStatusMonitor({ children }: { children: React.ReactNode }) {
@@ -29,7 +40,15 @@ function SdkStatusMonitor({ children }: { children: React.ReactNode }) {
   return <div onClick={handleClick}>{children}</div>;
 }
 
-function ProviderWrapper({ children }: { children: React.ReactNode }) {
+function ProviderWrapper({
+  children,
+  components,
+  testBuyerCountry,
+}: {
+  children: React.ReactNode;
+  components: Components[];
+  testBuyerCountry?: string;
+}) {
   if (!PAYPAL_CLIENT_ID) {
     return (
       <div
@@ -63,16 +82,9 @@ function ProviderWrapper({ children }: { children: React.ReactNode }) {
     <PayPalProvider
       clientId={PAYPAL_CLIENT_ID}
       environment="sandbox"
-      components={[
-        "paypal-payments",
-        "venmo-payments",
-        "paypal-guest-payments",
-        "paypal-subscriptions",
-        "card-fields",
-        "applepay-payments",
-        "googlepay-payments",
-      ]}
+      components={components}
       pageType="checkout"
+      testBuyerCountry={testBuyerCountry}
     >
       <SdkStatusMonitor>{children}</SdkStatusMonitor>
     </PayPalProvider>
@@ -87,8 +99,17 @@ export const withPayPalProvider: Decorator = (Story, context) => {
     return <Story />;
   }
 
+  const components =
+    (context.parameters?.sdkComponents as Components[] | undefined) ??
+    DEFAULT_COMPONENTS;
+  const testBuyerCountry = context.parameters?.testBuyerCountry as
+    string | undefined;
+
   return (
-    <ProviderWrapper>
+    <ProviderWrapper
+      components={components}
+      testBuyerCountry={testBuyerCountry}
+    >
       <Story />
     </ProviderWrapper>
   );

--- a/packages/react-paypal-js-storybook/v6/src/shared/utils.ts
+++ b/packages/react-paypal-js-storybook/v6/src/shared/utils.ts
@@ -30,12 +30,15 @@ export const PAYPAL_CLIENT_ID =
 
 // One-Time Payment APIs
 
-export async function createOrder(): Promise<{ orderId: string }> {
+export async function createOrder(
+  currencyCode = "USD",
+): Promise<{ orderId: string }> {
   const response = await fetch(
     `${SAMPLE_INTEGRATION_API}/paypal-api/checkout/orders/create-order-for-one-time-payment`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ currencyCode }),
     },
   );
   const data = await response.json();

--- a/packages/react-paypal-js-storybook/v6/src/stories/lpm/BlikOneTimePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/lpm/BlikOneTimePaymentButton.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { Decorator } from "@storybook/react";
+
+import {
+  BlikOneTimePaymentButton,
+  useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
+import {
+  createOrder,
+  oneTimePaymentCallbacks,
+  buttonTypeArgType,
+  presentationModeArgType,
+  disabledArgType,
+} from "../../shared/utils";
+
+/**
+ * Wrapper that calls useEligibleMethods in PLN (BLIK only supports PLN and
+ * Poland buyers). Only renders the button if BLIK is eligible, mirroring the
+ * client-side eligibility pattern the sample integration uses for LPMs (which
+ * pass currencyCode only — no paymentFlow).
+ */
+function BlikEligibilityWrapper({ children }: { children: React.ReactNode }) {
+  const {
+    eligiblePaymentMethods,
+    isLoading: isEligibilityLoading,
+    error: eligibilityError,
+  } = useEligibleMethods({
+    payload: {
+      currencyCode: "PLN",
+    },
+  });
+
+  const isBlikEligible =
+    !isEligibilityLoading && eligiblePaymentMethods?.isEligible("blik");
+
+  if (isEligibilityLoading) return <div>Checking eligibility...</div>;
+  if (eligibilityError)
+    return <div>Failed to check eligibility: {eligibilityError.message}</div>;
+  if (!isBlikEligible)
+    return <div>BLIK is not eligible for this configuration.</div>;
+
+  return <>{children}</>;
+}
+
+const withBlikEligibility: Decorator = (Story) => (
+  <BlikEligibilityWrapper>
+    <Story />
+  </BlikEligibilityWrapper>
+);
+
+const meta: Meta<typeof BlikOneTimePaymentButton> = {
+  title: "V6/Local Payment Methods/BLIK",
+  component: BlikOneTimePaymentButton,
+  decorators: [withBlikEligibility],
+  parameters: {
+    sdkComponents: ["blik-payments"],
+    testBuyerCountry: "PL",
+  },
+  argTypes: {
+    type: buttonTypeArgType,
+    presentationMode: presentationModeArgType,
+    disabled: disabledArgType,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BlikOneTimePaymentButton>;
+
+export const Default: Story = {
+  args: {
+    createOrder: () => createOrder("PLN"),
+    presentationMode: "popup",
+    fieldValues: {
+      name: "Test Buyer",
+      email: "test-buyer@example.com",
+    },
+    ...oneTimePaymentCallbacks,
+  },
+};

--- a/packages/react-paypal-js-storybook/v6/src/stories/lpm/IdealOneTimePaymentButton.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/lpm/IdealOneTimePaymentButton.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { Decorator } from "@storybook/react";
+
+import {
+  IdealOneTimePaymentButton,
+  useEligibleMethods,
+} from "@paypal/react-paypal-js/sdk-v6";
+import {
+  createOrder,
+  oneTimePaymentCallbacks,
+  buttonTypeArgType,
+  presentationModeArgType,
+  disabledArgType,
+} from "../../shared/utils";
+
+/**
+ * Wrapper that calls useEligibleMethods in EUR (iDEAL only supports EUR and
+ * Netherlands buyers). Only renders the button if iDEAL is eligible, mirroring
+ * the client-side eligibility pattern the sample integration uses for LPMs
+ * (which pass currencyCode only — no paymentFlow).
+ */
+function IdealEligibilityWrapper({ children }: { children: React.ReactNode }) {
+  const {
+    eligiblePaymentMethods,
+    isLoading: isEligibilityLoading,
+    error: eligibilityError,
+  } = useEligibleMethods({
+    payload: {
+      currencyCode: "EUR",
+    },
+  });
+
+  const isIdealEligible =
+    !isEligibilityLoading && eligiblePaymentMethods?.isEligible("ideal");
+
+  if (isEligibilityLoading) return <div>Checking eligibility...</div>;
+  if (eligibilityError)
+    return <div>Failed to check eligibility: {eligibilityError.message}</div>;
+  if (!isIdealEligible)
+    return <div>iDEAL is not eligible for this configuration.</div>;
+
+  return <>{children}</>;
+}
+
+const withIdealEligibility: Decorator = (Story) => (
+  <IdealEligibilityWrapper>
+    <Story />
+  </IdealEligibilityWrapper>
+);
+
+const meta: Meta<typeof IdealOneTimePaymentButton> = {
+  title: "V6/Local Payment Methods/iDEAL",
+  component: IdealOneTimePaymentButton,
+  decorators: [withIdealEligibility],
+  parameters: {
+    sdkComponents: ["ideal-payments"],
+    testBuyerCountry: "NL",
+  },
+  argTypes: {
+    type: buttonTypeArgType,
+    presentationMode: presentationModeArgType,
+    disabled: disabledArgType,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof IdealOneTimePaymentButton>;
+
+export const Default: Story = {
+  args: {
+    createOrder: () => createOrder("EUR"),
+    presentationMode: "popup",
+    fieldValues: { name: "Test Buyer" },
+    ...oneTimePaymentCallbacks,
+  },
+};


### PR DESCRIPTION
## Summary

- allow v6 Storybook stories to configure SDK components and a sandbox test buyer country
- allow one-time-payment stories to create orders in the payment method currency
- add BLIK and iDEAL stories with eligibility checks and the required PLN/PL and EUR/NL configurations

## Related

- follows the LPM eligibility type support merged in #1062

## Testing

- `npm run build-storybook:v6`
- completed sandbox BLIK and iDEAL payment-flow verification