### PR TITLE
Feature/Card fields Name Field component

### DIFF
--- a/.changeset/itchy-moons-type.md
+++ b/.changeset/itchy-moons-type.md
@@ -1,0 +1,5 @@
+---
+"@paypal/react-paypal-js": minor
+---
+
+Added new PayPalCardNameField component to use with Card Fields

--- a/.changeset/metal-masks-heal.md
+++ b/.changeset/metal-masks-heal.md
@@ -1,0 +1,5 @@
+---
+"@paypal/paypal-js": patch
+---
+
+Added name as a valid field to existing Card Fields types

--- a/packages/paypal-js/types/v6/components/card-fields.d.ts
+++ b/packages/paypal-js/types/v6/components/card-fields.d.ts
@@ -61,7 +61,7 @@ export type FieldState = {
   isPotentiallyValid: boolean;
 };
 
-export type CardFieldTypes = "cvv" | "expiry" | "number";
+export type CardFieldTypes = "cvv" | "expiry" | "number" | "name";
 
 export type MerchantMessagingEvents =
   | "blur"
@@ -88,6 +88,7 @@ export type EventState = {
   number: FieldState;
   cvv: FieldState;
   expiry: FieldState;
+  name?: FieldState;
 };
 
 export type EventPayload = {

--- a/packages/paypal-js/types/v6/tests/card-fields.test.ts
+++ b/packages/paypal-js/types/v6/tests/card-fields.test.ts
@@ -54,6 +54,10 @@ async function main() {
   const paypalCardFieldsOneTimePaymentSession =
     sdkInstance.createCardFieldsOneTimePaymentSession();
   paypalCardFieldsOneTimePaymentSession.createCardFieldsComponent({
+    type: "name",
+    placeholder: "Enter your name:",
+  });
+  paypalCardFieldsOneTimePaymentSession.createCardFieldsComponent({
     type: "number",
     placeholder: "Enter a number:",
   });

--- a/packages/react-paypal-js-storybook/v6/src/shared/code.ts
+++ b/packages/react-paypal-js-storybook/v6/src/shared/code.ts
@@ -663,6 +663,7 @@ export const getCardFieldsOneTimePaymentCode = (): string => `
 import {
     PayPalProvider,
     PayPalCardFieldsProvider,
+    PayPalCardNameField,
     PayPalCardNumberField,
     PayPalCardExpiryField,
     PayPalCardCvvField,
@@ -723,6 +724,10 @@ function CardFields() {
 
     return (
         <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+            <PayPalCardNameField
+                containerStyles={{ height: "3rem" }}
+                placeholder="Enter your name"
+            />
             <PayPalCardNumberField
                 containerStyles={{ height: "3rem" }}
                 placeholder="Enter card number"
@@ -790,6 +795,7 @@ export const getCardFieldsSavePaymentCode = (): string => `
 import {
     PayPalProvider,
     PayPalCardFieldsProvider,
+    PayPalCardNameField,
     PayPalCardNumberField,
     PayPalCardExpiryField,
     PayPalCardCvvField,
@@ -841,6 +847,10 @@ function CardFields() {
 
     return (
         <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+            <PayPalCardNameField
+                containerStyles={{ height: "3rem" }}
+                placeholder="Enter your name"
+            />
             <PayPalCardNumberField
                 containerStyles={{ height: "3rem" }}
                 placeholder="Enter card number"

--- a/packages/react-paypal-js-storybook/v6/src/stories/card-fields/CardFieldsOneTimePayment.stories.tsx
+++ b/packages/react-paypal-js-storybook/v6/src/stories/card-fields/CardFieldsOneTimePayment.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import {
   PayPalCardFieldsProvider,
+  PayPalCardNameField,
   PayPalCardNumberField,
   PayPalCardExpiryField,
   PayPalCardCvvField,
@@ -105,6 +106,10 @@ function CardFields() {
         maxWidth: "400px",
       }}
     >
+      <PayPalCardNameField
+        containerStyles={{ height: "3rem" }}
+        placeholder="Enter your name"
+      />
       <PayPalCardNumberField
         containerStyles={{ height: "3rem" }}
         placeholder="Enter card number"
@@ -165,7 +170,7 @@ const meta: Meta = {
       description: {
         component: `Card Fields for one-time payment flows.
 
-This example demonstrates the complete Card Fields integration using \`PayPalCardFieldsProvider\`, \`PayPalCardNumberField\`, \`PayPalCardExpiryField\`, and \`PayPalCardCvvField\` components.
+This example demonstrates the complete Card Fields integration using \`PayPalCardFieldsProvider\`, \`PayPalCardNumberField\`, \`PayPalCardExpiryField\`, \`PayPalCardCvvField\`, and \`PayPalCardNameField\` components.
 
 The Card Fields components render secure, PCI-compliant input fields for collecting card payment details. They must be wrapped in a \`<PayPalCardFieldsProvider>\` which manages the card fields session.
 

--- a/packages/react-paypal-js/README.md
+++ b/packages/react-paypal-js/README.md
@@ -57,6 +57,7 @@
   - [PayPalCardNumberField](#paypalcardnumberfield)
   - [PayPalCardExpiryField](#paypalcardexpiryfield)
   - [PayPalCardCvvField](#paypalcardcvvfield)
+  - [PayPalCardNameField](#paypalcardnamefield-optional-field)
   - [Field Component Props](#field-component-props)
 - [Payment Flow: Card Fields](#payment-flow-card-fields)
 - [Hooks API](#hooks-api)
@@ -1143,6 +1144,19 @@ import { PayPalCardCvvField } from "@paypal/react-paypal-js/sdk-v6";
 />;
 ```
 
+### PayPalCardNameField (Optional Field)
+
+Renders a Name input field. Must be used within a [PayPalCardFieldsProvider](#paypalcardfieldsprovider) component. This field is optional, and a transaction can complete without it being rendered or filled.
+
+```tsx
+import { PayPalCardNameField } from "@paypal/react-paypal-js/sdk-v6";
+
+<PayPalCardNameField
+  placeholder="Name"
+  containerStyles={{ height: "3rem", marginBottom: "1rem" }}
+/>;
+```
+
 ### Field Component Props
 
 All field components ([`PayPalCardNumberField`](#paypalcardnumberfield), [`PayPalCardExpiryField`](#paypalcardexpiryfield), [`PayPalCardCvvField`](#paypalcardcvvfield)) accept the same set of props. They combine container styling properties with CardField-specific configuration options.
@@ -1160,7 +1174,7 @@ All field components ([`PayPalCardNumberField`](#paypalcardnumberfield), [`PayPa
 
 ## Payment Flow: Card Fields
 
-1. User enters card number, expiry, and CVV in the card fields
+1. User enters card number, expiry, CVV, and an optional name in the card fields
 2. User clicks your submit button
 3. `createOrder` creates an order via your backend API
 4. `submit(orderId)` processes the card payment with the order ID
@@ -1688,6 +1702,7 @@ function CardPaymentForm() {
 
   return (
     <div>
+      <PayPalCardNameField />
       <PayPalCardNumberField />
       <PayPalCardExpiryField />
       <PayPalCardCvvField />
@@ -1748,6 +1763,7 @@ function CardPaymentForm() {
 
   return (
     <div>
+      <PayPalCardNameField />
       <PayPalCardNumberField />
       <PayPalCardExpiryField />
       <PayPalCardCvvField />

--- a/packages/react-paypal-js/src/v6/components/PayPalCardNameField.test.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalCardNameField.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import { PayPalCardNameField } from "./PayPalCardNameField";
+import { PayPalCardField } from "./PayPalCardField";
+
+jest.mock("./PayPalCardField", () => ({
+  PayPalCardField: jest.fn(() => <div data-testid="mock-card-field" />),
+}));
+
+const mockPayPalCardField = PayPalCardField as jest.MockedFunction<
+  typeof PayPalCardField
+>;
+
+const fieldType = "name";
+
+describe("PayPalCardNameField", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should pass type='name' to PayPalCardField", () => {
+    render(<PayPalCardNameField />);
+    expect(mockPayPalCardField.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ type: fieldType }),
+    );
+  });
+
+  it("should render PayPalCardField with the correct props", () => {
+    const testProps = {
+      placeholder: "Enter your name",
+      containerClassName: "test-container",
+      style: {
+        input: {
+          background: "lightgray",
+        },
+      },
+    };
+
+    render(<PayPalCardNameField {...testProps} />);
+
+    expect(mockPayPalCardField.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        type: fieldType,
+        ...testProps,
+      }),
+    );
+  });
+});

--- a/packages/react-paypal-js/src/v6/components/PayPalCardNameField.tsx
+++ b/packages/react-paypal-js/src/v6/components/PayPalCardNameField.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { PayPalCardField } from "./PayPalCardField";
+
+import type { CardFieldOptions } from "../types";
+import type { PayPalCardFieldsProvider } from "./PayPalCardFieldsProvider";
+
+type PayPalCardNameFieldProps = Omit<CardFieldOptions, "type"> & {
+  containerStyles?: React.CSSProperties;
+  containerClassName?: string;
+};
+
+/**
+ * `PayPalCardNameField` is a component that renders a name field using the PayPal Card Fields SDK. It must be used within a {@link PayPalCardFieldsProvider} component.
+ *
+ * @example
+ * // Basic usage creating a name field
+ * <PayPalCardNameField
+ *   placeholder="Enter your name"
+ *   containerStyles={{ height: "3rem", marginBottom: "1rem" }}
+ * />
+ */
+export const PayPalCardNameField = ({
+  containerStyles,
+  containerClassName,
+  placeholder,
+  label,
+  style,
+  ariaDescription,
+  ariaLabel,
+  ariaInvalidErrorMessage,
+}: PayPalCardNameFieldProps): JSX.Element | null => {
+  return (
+    <PayPalCardField
+      type="name"
+      containerStyles={containerStyles}
+      containerClassName={containerClassName}
+      placeholder={placeholder}
+      label={label}
+      style={style}
+      ariaDescription={ariaDescription}
+      ariaLabel={ariaLabel}
+      ariaInvalidErrorMessage={ariaInvalidErrorMessage}
+    />
+  );
+};

--- a/packages/react-paypal-js/src/v6/index.ts
+++ b/packages/react-paypal-js/src/v6/index.ts
@@ -66,6 +66,7 @@ export {
   GooglePayOneTimePaymentButton,
   type GooglePayOneTimePaymentButtonProps,
 } from "./components/GooglePayOneTimePaymentButton";
+export { PayPalCardNameField } from "./components/PayPalCardNameField";
 export { PayPalCardNumberField } from "./components/PayPalCardNumberField";
 export { PayPalCardExpiryField } from "./components/PayPalCardExpiryField";
 export { PayPalCardCvvField } from "./components/PayPalCardCvvField";


### PR DESCRIPTION
This PR adds:
- Types for the new Card Fields Name Field component
- A new React `PayPalCardNameField` compoent
- Updates storybook Card Fields stories to now include the new Card Field Name component.

Name field on card fields demo: https://github.com/paypal-examples/v6-web-sdk-sample-integration/pull/317